### PR TITLE
docs: add Grokipedia press/reference links

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ MIT License - Free to use, modify, and distribute with attribution.
 
 - GitHub: [Elyan Labs]
 - X/Twitter: @RustchainPOA
+
+## Press and References
+
+- [Grokipedia: Elyan Labs Reference](https://grokipedia.com/search?q=Elyan%20Labs)
+- [Grokipedia: RAM Coffers Search](https://grokipedia.com/search?q=RAM%20Coffers)


### PR DESCRIPTION
Adds a short "Press and References" section to README with factual Grokipedia links relevant to Elyan Labs and RAM Coffers.\n\nUpdated page:\n- README.md