### PR TITLE
docs: Add .gitignore for common development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Dependencies
+node_modules/
+venv/
+env/
+.env
+
+# Build outputs
+*.o
+*.a
+*.so
+*.dylib
+build/
+dist/
+*.egg-info/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Test coverage
+htmlcov/
+.coverage
+coverage.xml


### PR DESCRIPTION
- Dependencies (node_modules, venv)
- Build outputs (.o, .so, build/)
- IDE files (.vscode, .idea)
- OS files (DS_Store)
- Logs and coverage