### PR TITLE
feat: add reproducible benchmark harness

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,38 @@
+## Summary
+
+Adds a minimal reproducible benchmark harness and sample topology workflow for RAM Coffers contributors.
+
+## What this PR adds
+
+- `benchmark_harness.sh`
+  - captures machine topology (`lscpu`, `numactl --hardware` when available)
+  - captures environment/toolchain metadata
+  - attempts to build the POWER8 benchmark binary
+  - writes a standardized markdown report to `benchmarks/out/`
+  - falls back cleanly on unsupported non-POWER8 hosts instead of failing silently
+- `benchmarks/README_HARNESS.md`
+  - explains purpose, outputs, and usage
+- README update
+  - documents the one-command harness entrypoint in the contributor benchmark section
+
+## Why
+
+Issue #35 asks for a minimal benchmark harness plus sample topology output. This PR provides a practical contributor entrypoint that standardizes the workflow and reporting format, even for contributors validating structure on non-POWER8 hosts before running on target hardware.
+
+## Validation
+
+Run locally:
+
+```bash
+./benchmark_harness.sh
+```
+
+Verified on this host that the harness:
+- creates topology/environment/report artifacts
+- produces a fallback report when POWER8-specific compilation flags are unsupported
+
+## Files changed
+
+- `README.md`
+- `benchmark_harness.sh`
+- `benchmarks/README_HARNESS.md`

--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ When opening a PR, include:
 
 This keeps performance claims falsifiable and makes review much faster.
 
+### 4) Use the reproducible harness
+
+For contributors who want a one-command baseline scaffold, run:
+
+```bash
+./benchmark_harness.sh
+```
+
+This generates:
+- machine topology snapshot
+- environment/toolchain snapshot
+- markdown benchmark report in `benchmarks/out/`
+
+On unsupported non-POWER8 hosts, the harness still produces reproducible metadata and a fallback report instead of failing silently.
+
 ## License
 
 MIT License - Free to use, modify, and distribute with attribution.

--- a/benchmark_harness.sh
+++ b/benchmark_harness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${ROOT_DIR}/benchmarks/out"
+mkdir -p "$OUT_DIR"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+TOPOLOGY_FILE="$OUT_DIR/topology-${TS}.txt"
+REPORT_FILE="$OUT_DIR/benchmark-${TS}.md"
+ENV_FILE="$OUT_DIR/env-${TS}.txt"
+
+{
+  echo "# RAM Coffers Benchmark Run"
+  echo
+  echo "- Timestamp: $(date +%Y-%m-%dT%H:%M:%S%z)"
+  echo "- Host: $(hostname)"
+  echo "- Kernel: $(uname -srmo)"
+  echo
+  echo "## Tooling"
+  command -v gcc >/dev/null 2>&1 && echo "- gcc: $(gcc --version | head -1)" || echo "- gcc: not found"
+  command -v clang >/dev/null 2>&1 && echo "- clang: $(clang --version | head -1)" || echo "- clang: not found"
+  command -v numactl >/dev/null 2>&1 && echo "- numactl: available" || echo "- numactl: not found"
+  command -v lscpu >/dev/null 2>&1 && echo "- lscpu: available" || echo "- lscpu: not found"
+} > "$ENV_FILE"
+
+{
+  echo "# Machine Topology"
+  echo
+  if command -v lscpu >/dev/null 2>&1; then
+    echo '## lscpu'
+    echo '```text'
+    lscpu
+    echo '```'
+    echo
+  else
+    echo '- lscpu not available'
+    echo
+  fi
+
+  if command -v numactl >/dev/null 2>&1; then
+    echo '## numactl --hardware'
+    echo '```text'
+    numactl --hardware
+    echo '```'
+  else
+    echo '- numactl not available'
+  fi
+} > "$TOPOLOGY_FILE"
+
+BUILD_OK=false
+BIN="$OUT_DIR/bench_vcipher_collapse"
+BUILD_LOG="$OUT_DIR/build-${TS}.log"
+RUN_LOG="$OUT_DIR/run-${TS}.log"
+
+if command -v gcc >/dev/null 2>&1; then
+  if gcc -mcpu=power8 -mvsx -mcrypto -maltivec -O3 -fopenmp \
+      bench_vcipher_collapse.c -o "$BIN" -lm >"$BUILD_LOG" 2>&1; then
+    BUILD_OK=true
+  fi
+fi
+
+{
+  echo "# Benchmark Report"
+  echo
+  echo "- Timestamp: $(date +%Y-%m-%dT%H:%M:%S%z)"
+  echo "- Topology snapshot: $(basename "$TOPOLOGY_FILE")"
+  echo "- Environment snapshot: $(basename "$ENV_FILE")"
+  echo
+  if [ "$BUILD_OK" = true ]; then
+    echo "## Build"
+    echo "- Status: success"
+    echo "- Binary: $(basename "$BIN")"
+    echo
+    echo "## Run Output"
+    echo '```text'
+    "$BIN" | tee "$RUN_LOG"
+    echo '```'
+  else
+    echo "## Build"
+    echo "- Status: skipped or failed"
+    echo "- Reason: POWER8-specific benchmark could not be compiled on this host"
+    echo
+    echo "## Fallback"
+    echo "This harness still captured reproducible machine topology and environment details."
+    echo "Use the same script on POWER8 hardware to produce benchmark numbers with identical report structure."
+    echo
+    if [ -s "$BUILD_LOG" ]; then
+      echo "## Build Log"
+      echo '```text'
+      cat "$BUILD_LOG"
+      echo '```'
+    fi
+  fi
+} > "$REPORT_FILE"
+
+echo "Generated:"
+echo "- $TOPOLOGY_FILE"
+echo "- $ENV_FILE"
+echo "- $REPORT_FILE"
+[ "$BUILD_OK" = true ] && echo "- $RUN_LOG"

--- a/benchmarks/README_HARNESS.md
+++ b/benchmarks/README_HARNESS.md
@@ -1,0 +1,37 @@
+# Benchmark Harness
+
+This repository now includes a lightweight reproducible benchmark harness entrypoint:
+
+- `benchmark_harness.sh`
+
+## What it does
+
+1. Captures machine topology
+   - `lscpu` (when available)
+   - `numactl --hardware` (when available)
+2. Captures toolchain/environment metadata
+3. Attempts to build the POWER8 benchmark (`bench_vcipher_collapse.c`)
+4. Generates a markdown benchmark report in `benchmarks/out/`
+5. Falls back cleanly on unsupported hosts while still preserving reproducible environment data
+
+## Output files
+
+Each run creates timestamped artifacts in `benchmarks/out/`:
+
+- `topology-<timestamp>.txt`
+- `env-<timestamp>.txt`
+- `benchmark-<timestamp>.md`
+- `build-<timestamp>.log`
+- `run-<timestamp>.log` (only when benchmark execution succeeds)
+
+## Run
+
+```bash
+./benchmark_harness.sh
+```
+
+## Why this helps
+
+The issue asks for a minimal benchmark harness and sample topology output. This script creates a single repeatable entrypoint for that workflow and standardizes the reporting format for PR review.
+
+It is especially useful because this repository targets specialized POWER8 hardware, while many contributors will be validating structure and portability on non-POWER8 hosts first.


### PR DESCRIPTION
## Summary

Adds a minimal reproducible benchmark harness and sample topology workflow for RAM Coffers contributors.

## What this PR adds

- `benchmark_harness.sh`
  - captures machine topology (`lscpu`, `numactl --hardware` when available)
  - captures environment/toolchain metadata
  - attempts to build the POWER8 benchmark binary
  - writes a standardized markdown report to `benchmarks/out/`
  - falls back cleanly on unsupported non-POWER8 hosts instead of failing silently
- `benchmarks/README_HARNESS.md`
  - explains purpose, outputs, and usage
- README update
  - documents the one-command harness entrypoint in the contributor benchmark section

## Why

Issue #35 asks for a minimal benchmark harness plus sample topology output. This PR provides a practical contributor entrypoint that standardizes the workflow and reporting format, even for contributors validating structure on non-POWER8 hosts before running on target hardware.

## Validation

Run locally:

```bash
./benchmark_harness.sh
```

Verified on this host that the harness:
- creates topology/environment/report artifacts
- produces a fallback report when POWER8-specific compilation flags are unsupported

## Files changed

- `README.md`
- `benchmark_harness.sh`
- `benchmarks/README_HARNESS.md`
