### PR TITLE
Fix dead elyan-prime README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See **[/grail-v-paper](./grail-v-paper/)** for the full CVPR 2026 submission:
 
 The elyan-prime MCP server that powers the persistent memory system used during development of RAM Coffers is itself the subject of research. The paper **"Memory Scaffolding Shapes LLM Inference"** ([DOI 10.5281/zenodo.18817988](https://doi.org/10.5281/zenodo.18817988)) demonstrates that persistent context (600+ memories) fundamentally changes how an LLM architects solutions — the iterative compounding that produced RAM Coffers is a direct example of this effect.
 
-- Repository: [Scottcjn/elyan-prime](https://github.com/Scottcjn/elyan-prime)
+- Project: elyan-prime MCP server
 - Article: [Dev.to — Memory Scaffolding Shapes LLM Inference](https://dev.to/scottcjn/memory-scaffolding-shapes-llm-inference-how-persistent-context-changes-what-ai-builds-plj)
 
 ---


### PR DESCRIPTION
## Summary

- removes a dead GitHub link to `Scottcjn/elyan-prime` from the README
- keeps the `elyan-prime` project reference as plain text
- leaves the valid DOI and Dev.to article links in place

## Verification

- `curl -L -I https://github.com/Scottcjn/elyan-prime` returns `404`
- `git diff --check`
- local Markdown relative-link scan found no broken relative links

Related bounty: Scottcjn/rustchain-bounties#444
