### PR TITLE
Fix README license wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ On unsupported non-POWER8 hosts, the harness still produces reproducible metadat
 
 ## License
 
-MIT License - Free to use, modify, and distribute with attribution.
+Apache License 2.0 - see [LICENSE](LICENSE) for the full terms.
 
 ## Citation
 


### PR DESCRIPTION
## Summary
- update the README License section to match the repository's Apache 2.0 LICENSE file
- keep the change scoped to documentation only

## Validation
- git diff --check
- rg -n 'MIT License|Apache License 2\.0|LICENSE' README.md LICENSE

Bounty: Scottcjn/rustchain-bounties#2178