### PR TITLE
test: cover NUMA topology parsing

### DIFF
--- a/ram_coffers_topology.py
+++ b/ram_coffers_topology.py
@@ -37,36 +37,38 @@ def detect_numa_linux() -> Optional[Dict]:
 def _parse_numactl_output(output: str) -> Dict:
     """Parse numactl --hardware output."""
     nodes = {}
-    current_node = None
-    
+
     for line in output.split('\n'):
         line = line.strip()
-        if line.startswith('node'):
-            parts = line.split()
-            node_id = int(parts[0].split(' ')[-1].rstrip(':'))
-            current_node = node_id
-            nodes[node_id] = {
+        parts = line.split()
+        if len(parts) < 3 or parts[0] != 'node' or not parts[1].isdigit():
+            continue
+
+        node_id = int(parts[1])
+        field = parts[2].rstrip(':')
+        nodes.setdefault(
+            node_id,
+            {
                 'cpus': [],
                 'size_mb': 0,
                 'free_mb': 0,
-            }
-        elif line.startswith('cpus:') and current_node is not None:
+            },
+        )
+
+        if field == 'cpus':
             # Parse CPU list: "0 1 2 3 4 5 6 7" or "0-7"
-            cpu_str = line.split(':', 1)[1].strip()
             cpus = []
-            for part in cpu_str.split():
+            for part in parts[3:]:
                 if '-' in part:
                     start, end = part.split('-')
                     cpus.extend(range(int(start), int(end) + 1))
                 else:
                     cpus.append(int(part))
-            nodes[current_node]['cpus'] = cpus
-        elif line.startswith('size:') and current_node is not None:
-            parts = line.split()
-            nodes[current_node]['size_mb'] = int(parts[1])
-        elif line.startswith('free:') and current_node is not None:
-            parts = line.split()
-            nodes[current_node]['free_mb'] = int(parts[1])
+            nodes[node_id]['cpus'] = cpus
+        elif field == 'size' and len(parts) >= 4:
+            nodes[node_id]['size_mb'] = int(parts[3])
+        elif field == 'free' and len(parts) >= 4:
+            nodes[node_id]['free_mb'] = int(parts[3])
     
     return {
         'system': 'linux',

--- a/tests/test_ram_coffers_topology.py
+++ b/tests/test_ram_coffers_topology.py
@@ -1,0 +1,59 @@
+import unittest
+
+from ram_coffers_topology import _parse_numactl_output, calculate_weights
+
+
+class TestRamCoffersTopology(unittest.TestCase):
+  def test_parse_numactl_output_expands_cpu_ranges_and_memory_fields(self):
+    output = """
+available: 2 nodes (0-1)
+node 0 cpus: 0-3 8 9
+node 0 size: 32768 MB
+node 0 free: 12000 MB
+node 1 cpus: 4 5 6 7
+node 1 size: 65536 MB
+node 1 free: 50000 MB
+node distances:
+"""
+
+    topology = _parse_numactl_output(output)
+
+    self.assertEqual(topology["system"], "linux")
+    self.assertEqual(topology["num_nodes"], 2)
+    self.assertEqual(topology["nodes"][0]["cpus"], [0, 1, 2, 3, 8, 9])
+    self.assertEqual(topology["nodes"][0]["size_mb"], 32768)
+    self.assertEqual(topology["nodes"][0]["free_mb"], 12000)
+    self.assertEqual(topology["nodes"][1]["cpus"], [4, 5, 6, 7])
+    self.assertEqual(topology["nodes"][1]["size_mb"], 65536)
+    self.assertEqual(topology["nodes"][1]["free_mb"], 50000)
+
+  def test_calculate_weights_uses_memory_proportions(self):
+    topology = {
+      "nodes": {
+        0: {"size_mb": 32768},
+        1: {"size_mb": 65536},
+      }
+    }
+
+    weights = calculate_weights(topology)
+
+    self.assertAlmostEqual(weights[0], 33.3333333333)
+    self.assertAlmostEqual(weights[1], 66.6666666667)
+
+  def test_calculate_weights_splits_evenly_when_memory_is_unknown(self):
+    topology = {
+      "nodes": {
+        0: {"size_mb": 0},
+        1: {"size_mb": 0},
+        2: {"size_mb": 0},
+        3: {"size_mb": 0},
+      }
+    }
+
+    weights = calculate_weights(topology)
+
+    self.assertEqual(weights, {0: 25.0, 1: 25.0, 2: 25.0, 3: 25.0})
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary
- fix `numactl --hardware` parsing for actual `node 0 cpus:` style output
- add unittest coverage for CPU range expansion and NUMA memory fields
- cover proportional and equal-fallback topology weight calculation

## Bounty
Submission for Scottcjn/rustchain-bounties#1589: adds a focused test file with edge cases for the RAM Coffers topology helper. The parser fix is included because the new regression test exposed that current `numactl` output was not parsed correctly.

## Validation
- `python3 -m unittest discover -s tests -p 'test_ram_coffers_topology.py' -v` -> 3 passed
- `python3 -m compileall -q ram_coffers_topology.py tests/test_ram_coffers_topology.py` -> passed
- `git diff --check` -> passed

Payout/miner ID: pagefarms-codex-earner