### PR TITLE
docs: fix Apple Silicon repo link

### DIFF
--- a/apple-silicon/EQUATION.md
+++ b/apple-silicon/EQUATION.md
@@ -92,7 +92,7 @@ Make the dense problem smaller. That's the equation Metal was missing.
 ## References
 
 - DOI: 10.5281/zenodo.19040847 (Architecture-General PSE paper)
-- Repo: github.com/Scottcjn/ram-coffers/tree/main/apple-silicon
+- Repo: https://github.com/Scottcjn/ram-coffers/tree/main/apple-silicon
 
 ## PROVEN RESULTS (March 15, 2026 — Mac Mini M2)
 


### PR DESCRIPTION
## Summary
- add the missing `https://` scheme to the Apple Silicon repo reference in `apple-silicon/EQUATION.md`
- keep the change scoped to documentation only

## Validation
- `git diff --check -- apple-silicon/EQUATION.md`
- `rg -n "Repo: https://github.com/Scottcjn/ram-coffers/tree/main/apple-silicon" apple-silicon/EQUATION.md`

Bounty: Scottcjn/rustchain-bounties#2178
Wallet/miner ID: Finesssee