### PR TITLE
[codex] Fix ram-coffers documentation links

### DIFF
--- a/PRIORITY_CLAIM.md
+++ b/PRIORITY_CLAIM.md
@@ -29,7 +29,7 @@ This document establishes priority for the following innovations, all of which *
 | **Dec 17, 2025** | **VIDEO: NUMA-aware loading DeepSeek 671B** | **https://youtu.be/T_o39s7r0iE** ⭐ |
 | **Dec 16, 2025** | DCBT resident prefetch (147 t/s) | POWER8 benchmark logs |
 | **Jan 12, 2026** | DeepSeek "Engram" paper published | arXiv:2601.07372 |
-| **Jan 19, 2026** | GitHub publication | github.com/Scottcjn/ram-coffers |
+| **Jan 19, 2026** | GitHub publication | [github.com/Scottcjn/ram-coffers](https://github.com/Scottcjn/ram-coffers) |
 | **Jan 20, 2026** | Neuromorphic coffers | This implementation |
 
 ### Video Evidence (CRITICAL)

--- a/grail-v-paper/paper/GRAIL_V_PAPER_FINAL.md
+++ b/grail-v-paper/paper/GRAIL_V_PAPER_FINAL.md
@@ -385,7 +385,7 @@ The NPT includes:
 - **Grammar validator**: Ensures single emotional focus per subject
 - **Arc templates**: Pre-built emotional trajectories for common scenarios
 
-Code available at: `github.com/Scottcjn/ram-coffers`
+Code available at: [github.com/Scottcjn/ram-coffers](https://github.com/Scottcjn/ram-coffers)
 
 ---
 
@@ -801,6 +801,6 @@ the air thick with intellectual rivalry
 
 ---
 
-*This work was conducted at Elyan Labs. Code, data, and video outputs available at: github.com/Scottcjn/ram-coffers*
+*This work was conducted at Elyan Labs. Code, data, and video outputs available at: [github.com/Scottcjn/ram-coffers](https://github.com/Scottcjn/ram-coffers)*
 
 *Priority claim: This work predates DeepSeek Engram (arXiv:2601.07372, Jan 12, 2026) by 27+ days. See PRIORITY_CLAIM.md for documentation.*


### PR DESCRIPTION
## Summary

- Convert naked `github.com/Scottcjn/ram-coffers` references into explicit Markdown links in `PRIORITY_CLAIM.md` and `grail-v-paper/paper/GRAIL_V_PAPER_FINAL.md`.
- Keep the fix scoped to documentation formatting so the repository references render as clickable links.

## Bounty context

This addresses Scottcjn/rustchain-bounties#444 as a typo/broken-link/formatting cleanup. Duplicate checks found no existing #444 dashboard or issue claim for `PRIORITY_CLAIM.md` or `grail-v-paper/paper/GRAIL_V_PAPER_FINAL.md`; the only similar open PR, #655, touches `apple-silicon/EQUATION.md`, which this PR does not edit.

## Validation

- `git diff --check HEAD~1..HEAD`
- `rg -n '(^|[[:space:]:])github\.com/Scottcjn/ram-coffers([[:space:]]|$)' PRIORITY_CLAIM.md grail-v-paper/paper/GRAIL_V_PAPER_FINAL.md || true`
- `curl -L -I --max-time 10 --connect-timeout 5 -o /dev/null -s -w '%{http_code} %{url_effective}\n' https://github.com/Scottcjn/ram-coffers` -> `200 https://github.com/Scottcjn/ram-coffers`
