### PR TITLE
test: skip optional Torch paper analysis when unavailable

### DIFF
--- a/grail-v-paper/code/emotional_attractor_test.py
+++ b/grail-v-paper/code/emotional_attractor_test.py
@@ -6,10 +6,35 @@ Tests the hypothesis that emotional vocabulary forms deeper attractor wells
 in Hopfield-like associative memory, explaining faster convergence.
 """
 
-import torch
-import torch.nn.functional as F
+from __future__ import annotations
+
 import numpy as np
 from typing import List, Tuple
+
+try:
+    import torch
+    import torch.nn.functional as F
+except ImportError as exc:
+    torch = None
+    F = None
+    _TORCH_IMPORT_ERROR = exc
+else:
+    _TORCH_IMPORT_ERROR = None
+
+
+def _require_torch() -> None:
+    if _TORCH_IMPORT_ERROR is not None:
+        raise RuntimeError(
+            "emotional_attractor_test.py requires the optional 'torch' "
+            "dependency. Install PyTorch to run this paper analysis."
+        ) from _TORCH_IMPORT_ERROR
+
+
+def test_optional_torch_dependency_available():
+    """Document that this paper analysis is skipped unless PyTorch is installed."""
+    import pytest
+
+    pytest.importorskip("torch")
 
 # Simulated embeddings based on CLIP/Gemma semantic space
 # Emotional words cluster more tightly (16% as shown in paper)
@@ -37,6 +62,7 @@ def generate_clustered_embeddings(vocab: List[str], dim: int = 128,
     Lower cluster_tightness = tighter clusters (emotional vocab)
     Higher cluster_tightness = looser clusters (literal vocab)
     """
+    _require_torch()
     n = len(vocab)
 
     # Generate base cluster centers (semantic categories)
@@ -66,6 +92,7 @@ def hopfield_energy(state: torch.Tensor, patterns: torch.Tensor, beta: float = 1
 
     Lower energy = deeper attractor well
     """
+    _require_torch()
     # Normalize
     state = F.normalize(state.unsqueeze(0), dim=1).squeeze()
     patterns = F.normalize(patterns, dim=1)
@@ -84,6 +111,7 @@ def measure_attractor_depth(embeddings: torch.Tensor, beta: float = 16.0) -> Tup
 
     Returns (avg_energy, avg_convergence_steps)
     """
+    _require_torch()
     n = len(embeddings)
     energies = []
     convergence_steps = []
@@ -133,6 +161,7 @@ def measure_attractor_depth(embeddings: torch.Tensor, beta: float = 16.0) -> Tup
 
 
 def main():
+    _require_torch()
     # Set seed for reproducibility
     torch.manual_seed(42)
     np.random.seed(42)
@@ -232,4 +261,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from None


### PR DESCRIPTION
## Summary

- handles missing optional `torch` in `grail-v-paper/code/emotional_attractor_test.py`
- lets pytest skip the optional paper analysis instead of failing collection
- keeps direct script execution explicit by exiting with a clear PyTorch-required message

## Bug / bounty

Fixes #657.

Bounty claim context: this is a reproducible RustChain ecosystem bug under the public bug bounty (`Scottcjn/Rustchain#305`). Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`.

## Validation

- Before fix from repo root without Torch: `python -m pytest -q` failed during collection with `ModuleNotFoundError: No module named 'torch'`
- After fix from repo root without Torch: `python -m pytest -q` -> 1 skipped
- `python -m py_compile grail-v-paper\code\emotional_attractor_test.py` -> passed
- `python -m ruff check grail-v-paper\code\emotional_attractor_test.py --select E9,F821,F811 --output-format=concise` -> passed
- `git diff --check` -> passed
- `python grail-v-paper\code\emotional_attractor_test.py` without Torch -> exits with a clear optional dependency message