### PR TITLE
Document POWER8 benchmark reproduction recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,41 @@ On IBM POWER8 S824 with TinyLlama 1.1B Q4_K:
 
 **8.81x speedup** over stock on "obsolete" hardware.
 
+### Reproducing the 147.54 t/s POWER8 Claim
+
+Use the dedicated comparison harness when you want to validate the headline
+TinyLlama result against a stock llama.cpp baseline. The documented comparison
+uses:
+
+- Hardware: IBM POWER8 S824, CPU-only, multi-NUMA Linux host.
+- Model: TinyLlama 1.1B Q4 GGUF, downloaded by `benchmark_coffers_vs_llamacpp.sh`
+  unless `--model` points to an existing local file.
+- Benchmark shape: `llama-bench` prompt processing `pp128` and generation `tg32`.
+- Repetitions: `RUNS=3` by default.
+- Threading: pass `--threads 64` for the documented POWER8 optimum, or record
+  the override you used in the generated report.
+- NUMA policy: stock llama.cpp is pinned to one NUMA node with
+  `STOCK_NUMA_NODE=0` by default; RAM Coffers uses `numactl --interleave=all`
+  with an existing verified RAM Coffers llama.cpp binary.
+
+On the POWER8 host, provide exact binary paths and source commits for both
+variants so reviewers can reproduce the same comparison:
+
+```bash
+./benchmark_coffers_vs_llamacpp.sh \
+  --threads 64 \
+  --stock-bin /opt/llama.cpp-stock/build/bin/llama-bench \
+  --stock-commit "$(git -C /opt/llama.cpp-stock rev-parse HEAD)" \
+  --coffers-bin /opt/llama.cpp-coffers/build/bin/llama-bench \
+  --coffers-commit "$(git -C /opt/llama.cpp-coffers rev-parse HEAD)"
+```
+
+The harness writes the environment snapshot, topology snapshot, raw logs, and a
+markdown comparison table to `benchmarks/out/`. Compare the generated `pp128`
+row against the README table above; do not report new headline numbers unless
+they come from a POWER8 run with the command, commits, model path, and raw logs
+attached.
+
 ### GPT-OSS 120B (MXFP4, MoE 128 experts) — PSE v4.0.0-vcipher
 
 | Metric | Speed |


### PR DESCRIPTION
## Summary
- add a focused README recipe for reproducing the 147.54 t/s POWER8 headline benchmark
- document the expected hardware, TinyLlama Q4 model, `pp128`/`tg32` benchmark shape, `RUNS=3`, `--threads 64`, NUMA policy, and exact stock/RAM Coffers command template
- tell contributors to attach commands, commits, model path, and raw logs before reporting new headline numbers

## Validation
- `git diff --check -- README.md` passed
- `python %TEMP%\\verify_ram_coffers_readme.py` passed (`POWER8 reproducibility README recipe ok`)
- `Get-Content -Raw benchmark_coffers_vs_llamacpp.sh | ForEach-Object { $_ -replace "`r", "" } | bash -n` passed for script syntax after CRLF normalization

## Notes
- README-only change; I did not run POWER8 benchmarks and do not claim new benchmark results.
- An attempted `benchmark_coffers_vs_llamacpp.sh --dry-run` was not counted as passing because this Windows/WSL shell path hit CRLF/BASH_SOURCE launcher issues before executing the script body.

## AI assistance
Implemented with AI assistance from Codex after inspecting the README, benchmark harness scripts, and existing benchmark docs. No secrets or local private data are included.
