### PR TITLE
docs: add benchmark reproduction contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,27 @@ Running on CPU-only POWER8 S824 with 512GB RAM. vcipher prefilter active for seq
 
 If you want to compare changes quickly, use this lightweight baseline procedure.
 
+### Reproducing the POWER8 headline result
+
+The headline table above should be treated as a `pp128` prompt-eval throughput
+comparison on an IBM POWER8 S824-class host. When reproducing or extending it,
+record the following contract next to the result so reviewers can compare runs:
+
+| Field | Reproducible value to report |
+|---|---|
+| Model | TinyLlama 1.1B Chat GGUF, Q4_K_M quantization (`tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf`) |
+| Benchmark binary | `llama-bench` from stock llama.cpp and a separately built RAM Coffers-patched llama.cpp tree |
+| Benchmark shape | `pp128` for prompt-eval throughput and `tg32` for decode throughput |
+| Repetitions | `RUNS=3` by default in `benchmark_coffers_vs_llamacpp.sh` |
+| Stock placement | single NUMA node, `STOCK_NUMA_NODE=0` unless otherwise stated |
+| RAM Coffers placement | interleaved / coffer-aware placement across available POWER8 NUMA nodes |
+| Compiler flags to record | llama.cpp commit, CMake options, compiler version, and POWER8 flags such as `-mcpu=power8`, `-mvsx`, `-maltivec`, and `-mcrypto` when used by the patched build |
+| Output metric | prompt-eval tokens/sec for `pp128`; decode tokens/sec for `tg32`; do not mix the two in one headline |
+
+The 147.54 t/s number is a prompt-eval (`pp128`) result, not a mixed
+prompt-plus-generation average. Decode throughput should be reported separately
+with the `tg32` row from `llama-bench`.
+
 ### 1) Capture machine topology
 
 ```bash
@@ -311,6 +332,12 @@ stock llama.cpp binary, but it does not synthesize a RAM Coffers binary from
 headers alone. Use `--coffers-bin` and `--coffers-commit` to point at an
 existing verified POWER8 build, and add `--stock-bin` / `--stock-commit` when
 you also want to use an external stock build.
+
+For claim-quality benchmark reports, include the generated topology file, the
+environment file, the exact stock and RAM Coffers commits, the model URL/path,
+`RUNS`, `THREADS`, `STOCK_NUMA_NODE`, and whether `--allow-single-numa` was used
+only for smoke testing. Single-NUMA or non-POWER8 runs are correctness/shape
+checks and should not be presented as POWER8 performance reproductions.
 
 ## License
 

--- a/benchmarks/README_HARNESS.md
+++ b/benchmarks/README_HARNESS.md
@@ -51,6 +51,27 @@ It downloads TinyLlama Q4, prepares the stock llama.cpp benchmark binary when
 not supplied, runs `llama-bench` with `pp128` and `tg32`, and writes a markdown
 table to `benchmarks/out/`.
 
+## POWER8 result reporting checklist
+
+For a claim-quality reproduction of the README headline, include these fields
+with the generated report:
+
+- Model: `tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf` or the exact alternate GGUF path
+- Benchmark shape: `pp128` prompt-eval and `tg32` decode reported separately
+- Stock binary path and stock llama.cpp commit
+- RAM Coffers binary path and RAM Coffers-patched llama.cpp commit
+- `RUNS`, `THREADS`, and `STOCK_NUMA_NODE`
+- `lscpu` and `numactl --hardware` output from the generated topology file
+- Compiler/CMake settings, especially POWER8 flags such as `-mcpu=power8`,
+  `-mvsx`, `-maltivec`, and `-mcrypto` when used
+- Whether the run used real multi-NUMA POWER8 hardware or `--allow-single-numa`
+  for a smoke test
+
+The README's 147.54 t/s figure is a `pp128` prompt-eval throughput number. Do
+not compare it to `tg32` decode throughput or to a mixed prompt-plus-generation
+average. Non-POWER8 and single-NUMA runs are useful for checking the harness
+shape, but they are not POWER8 performance reproductions.
+
 The harness intentionally refuses to build a synthetic RAM Coffers binary from
 copied headers alone. Pass `--coffers-bin` for a verified hand-patched
 llama.cpp build and `--coffers-commit` for the exact source commit used to build


### PR DESCRIPTION
## Summary

- Adds a compact POWER8 benchmark reproduction contract to the README for issue #662.
- Mirrors the claim-quality reporting checklist in `benchmarks/README_HARNESS.md`.
- Clarifies that the 147.54 t/s headline is a `pp128` prompt-eval number, while `tg32` decode throughput should be reported separately.

## Validation

- `git diff --check` passed, with only the existing LF-to-CRLF warning on Windows.
- `C:\Program Files\Git\bin\bash.exe -n benchmark_coffers_vs_llamacpp.sh benchmark_harness.sh` passed.
- `C:\Program Files\Git\bin\bash.exe benchmark_coffers_vs_llamacpp.sh --dry-run` passed and generated a dry-run report.

Closes #662.

Wallet: `RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8`