### PR TITLE
feat: DeepSeek v4 Pro on PS5 / Xbox 4th generation?

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,32 @@ Requires `-mcrypto` for `__builtin_crypto_vcipher()` / `__builtin_crypto_vcipher
 | `ggml-neuromorphic-coffers.h` | Brain hemisphere → NUMA cognitive routing |
 | `ggml-symbolic-neural-bridge.h` | PowerLISP ↔ neural integration |
 | **`apple-silicon/`** | **Apple Silicon PSE port — NEON + AES + unified memory coffers** |
+| **`gen9-cluster/`** | **DeepSeek V4 Pro across PS5 / Xbox Series consoles — coffers as a fleet** |
+
+## Ninth-Generation Console Cluster (NEW — August 2026)
+
+Coffers taken one level up: a coffer becomes a *memory tier inside a console*,
+and the fleet is a coffer hierarchy several hundred banks wide. The routing that
+POWER8 does across NUMA nodes, a fleet of PlayStation 5 and Xbox Series X/S
+consoles does across machines — with DeepSeek's own MoE router deciding which
+ones wake up.
+
+| Console coffer | Fast tier | Slow tier | Cold tier |
+|---|---|---|---|
+| Xbox Series X | 10 GB @ 560 GB/s | 3.5 GB @ 336 GB/s | 2.4 GB/s NVMe |
+| PS5 / Slim | 16 GB @ 448 GB/s | — | 5.5 GB/s NVMe |
+| Xbox Series S | 8 GB @ 224 GB/s | 2 GB @ 56 GB/s | 2.4 GB/s NVMe |
+| BC-250 / 4700S / 4800S | salvage boards, further downbinned | | |
+
+Only ~4% of a 1.36 T-parameter MoE runs per token, so the other 96% only has to
+be *held* — which is what a stack of consoles is good at. Estimated 9.4 tok/s
+for DeepSeek V4 Pro at 8k context on 170 consoles. See
+[`gen9-cluster/README.md`](gen9-cluster/README.md).
+
+```bash
+cd gen9-cluster
+python3 -m gen9_cluster size --model deepseek-v4-pro --ps5 100 --xbox-series-x 40
+```
 
 ## Apple Silicon Port (NEW — March 2026)
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Requires `-mcrypto` for `__builtin_crypto_vcipher()` / `__builtin_crypto_vcipher
 | `ggml-neuromorphic-coffers.h` | Brain hemisphere → NUMA cognitive routing |
 | `ggml-symbolic-neural-bridge.h` | PowerLISP ↔ neural integration |
 | **`apple-silicon/`** | **Apple Silicon PSE port — NEON + AES + unified memory coffers** |
-| **`gen9-cluster/`** | **DeepSeek V4 Pro across PS5 / Xbox Series consoles — coffers as a fleet** |
+| **`gen9-cluster/`** | **DeepSeek V4 Pro / Flash across PS5 / Xbox Series consoles — coffers as a fleet** |
 
 ## Ninth-Generation Console Cluster (NEW — August 2026)
 
@@ -222,14 +222,16 @@ ones wake up.
 | Xbox Series S | 8 GB @ 224 GB/s | 2 GB @ 56 GB/s | 2.4 GB/s NVMe |
 | BC-250 / 4700S / 4800S | salvage boards, further downbinned | | |
 
-Only ~4% of a 1.36 T-parameter MoE runs per token, so the other 96% only has to
-be *held* — which is what a stack of consoles is good at. Estimated 9.4 tok/s
-for DeepSeek V4 Pro at 8k context on 170 consoles. See
-[`gen9-cluster/README.md`](gen9-cluster/README.md).
+Only ~3% of a 1.6 T-parameter MoE runs per token, so the other 97% only has to
+be *held* — which is what a stack of consoles is good at. Estimated 10.8 tok/s
+for DeepSeek V4 Pro at 8k context on 170 consoles; 73 PS5s is the floor to hold
+it at all, and DeepSeek V4 Flash fits on 20. Both profiles are the published
+configurations. See [`gen9-cluster/README.md`](gen9-cluster/README.md).
 
 ```bash
 cd gen9-cluster
 python3 -m gen9_cluster size --model deepseek-v4-pro --ps5 100 --xbox-series-x 40
+python3 -m gen9_cluster size --model deepseek-v4-flash --ps5 24
 ```
 
 ## Apple Silicon Port (NEW — March 2026)

--- a/README.md
+++ b/README.md
@@ -225,6 +225,32 @@ Apple Silicon's unified memory means CPU and GPU share the same RAM — coffers 
 cd apple-silicon && make bench
 ```
 
+## x86-64 Port (August 2026)
+
+Third target for the collapse, and the only one that reproduces POWER8 exactly:
+`aesenc` and `vcipher` compute the same function, so `x86-64/aes-collapse.h` is
+a literal transcription, checked against a scalar FIPS-197 round.
+
+| POWER8 Primitive | x86-64 Equivalent |
+|-----------------|-------------------|
+| `vcipher` (AES round) | `_mm_aesenc_si128` |
+| `vcipherlast` | `_mm_aesenclast_si128` |
+| `vec_perm` (single-source) | `_mm_shuffle_epi8` |
+| `mftb` (entropy) | `rdtsc` (off by default — keys are deterministic) |
+
+Measured at 0.19 ns per round with four chains in flight, against 0.27 ns for a
+dependent `pshufb`. Two caveats worth reading before use: the ARM port is *not*
+the same function as this one or as POWER8, and mode 4's similarity metric does
+not rank similarity. Both are demonstrated by the bench. See
+[`x86-64/README.md`](x86-64/README.md).
+
+```bash
+cd x86-64 && make bench
+```
+
+`gen9-cluster` does not use it — that fleet's attention runs on RDNA2, which has
+no AES instruction.
+
 ## Fallback Behavior (non-POWER8 / single-NUMA systems)
 
 Trying the headers on an ordinary x86_64, aarch64, or single-socket box? The

--- a/gen9-cluster/.gitignore
+++ b/gen9-cluster/.gitignore
@@ -1,0 +1,3 @@
+*.spv
+kernel_test
+__pycache__/

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -15,43 +15,71 @@ across consoles, and DeepSeek's own MoE router decides which ones wake up.
 ```
                 shelf 0                          shelf 1
    ┌───────────────────────────────┐   ┌───────────────────────────────┐
-   │ host: Series X   layers 0-9   │   │ host: Series X   layers 10-19 │
-   │   attention + MLA KV cache    │   │                               │
-   │   router + shared expert      │──▶│   ... 74 blocks over 8 shelves│
+   │ host: Series X   layers 0-7   │   │ host: Series X   layers  8-15 │
+   │   attention + its KV cache    │   │                               │
+   │   router + shared expert      │──▶│   ... 62 blocks over 8 shelves│
    │ 21 more consoles: routed      │   │                               │
-   │   experts, ~8 lit per token   │   │                               │
+   │   experts, ~6 lit per token   │   │                               │
    └───────────────────────────────┘   └───────────────────────────────┘
 ```
 
 ## Why this is possible at all
 
-DeepSeek V4 Pro (assumed configuration — see below) is ~1345 GiB of FP8 weights
-and no console has more than 16 GB. Three properties make the fleet work
-anyway:
+DeepSeek V4 Pro is ~803 GiB of weights and no console has more than 16 GB.
+Three properties make the fleet work anyway:
 
-1. **Only ~4% of the model runs per token.** 52 of 1359 billion parameters
-   activate: attention, the router, one shared expert, and 8 of 384 routed
-   experts per layer. The other 96% only has to be *stored*, and storage is the
+1. **Only ~3% of the model runs per token.** 50 of 1600 billion parameters
+   activate: attention, the router, one shared expert, and 6 of 384 routed
+   experts per layer. The other 97% only has to be *stored*, and storage is the
    one thing a pile of consoles has.
 2. **Decode is bandwidth-bound, not compute-bound.** A PS5's 448 GB/s is what
    matters, and it is a genuinely good number — a 4700S carries the same DRAM
    on the same 256-bit bus, but reaching it from the CPU instead of the GPU
    measures 92.9 GB/s, a fifth as much, and the planner knows the difference.
-3. **FP8 is the native format.** One byte per parameter, with a scale per
-   128-element block, halves the console count against BF16 and roughly doubles
-   the token rate. `kernels/fp8.c` and `gen9_cluster/fp8.py` implement E4M3FN
-   and are tested against each other over all 256 codes.
+3. **The checkpoint ships quantised.** V4 stores its experts — which are nearly
+   all of it — in MXFP4, and everything read every token in FP8, so 1.6 T
+   parameters occupy 0.54 bytes each. That is the single biggest term in the
+   console count: V4 Pro has 2.4x V3's parameters and takes only 1.26x its
+   space. `kernels/fp8.c` and `gen9_cluster/fp8.py` implement E4M3FN and are
+   tested against each other over all 256 codes.
 
-The result is a plan, not a benchmark: **~9.4 tok/s estimated** for V4 Pro at
-8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250). That figure is
-arithmetic over memory bandwidth, network hops, and NVMe reads. Nothing in this
-repository has run on a console yet.
+The result is a plan, not a benchmark: **~10.8 tok/s estimated** for V4 Pro at
+8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250), and a **73-PS5
+floor** to hold it at all. V4 Flash is a fifth of the size and fits on **20**.
+Those figures are arithmetic over memory bandwidth, network hops, and NVMe
+reads. Nothing in this repository has run on a console yet.
+
+## The profiles
+
+| profile | params | activated | on disk | PS5s to hold it |
+|---|---|---|---|---|
+| `deepseek-v4-pro` | 1600 B | 50 B | 803 GiB | 73 |
+| `deepseek-v4-flash` | 291 B | 14 B | 148 GiB | 20 |
+| `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |
+| `deepseek-tiny` | — | — | 0.5 GiB | 1 (CI only) |
+
+Both V4 profiles are the published configurations, not extrapolations, and the
+tests check them against the published parameter counts. Two of their
+properties change how the planner thinks:
+
+- **Hybrid attention.** V4 alternates CSA (every 4 tokens compress to one
+  entry, then attend sparsely to the best 1024 of them) with HCA (every 128
+  tokens compress to one, attended densely), plus a sliding-window branch on
+  every layer. Neighbouring layers therefore differ by 32x in cache size, and a
+  CSA layer *reads* a small fraction of what it *holds* — so the planner sizes
+  residency and decode bandwidth separately, per layer, instead of multiplying
+  one KV figure by the layer count. The whole 1 M-token cache is 8.2 GiB, about
+  a seventh of V3's.
+- **Hyper-connections.** The residual stream is 4x hidden, so a shelf boundary
+  ships 56 KiB per token rather than 14. At 250 µs a hop that is still small
+  against a 92 ms token, but it is 4x what a V3-shaped model would cost.
 
 ## Quick start
 
 ```bash
 cd gen9-cluster
 python3 -m gen9_cluster model --model deepseek-v4-pro    # what it costs
+python3 -m gen9_cluster model --model deepseek-v4-flash  # the small one
 python3 -m gen9_cluster size  --model deepseek-v4-pro --ps5 100 \
         --xbox-series-x 40 --bc-250 30                   # how many consoles
 python3 -m gen9_cluster plan  fleet.json --config cluster.json
@@ -133,10 +161,10 @@ Four decisions, in order:
 
 1. **Shelves.** The fleet is cut into groups of ~22 consoles, dealt
    round-robin in capability order so no shelf inherits all the fast units. A
-   shelf is the expert fan-out group: a token's top-8 should be answerable
+   shelf is the expert fan-out group: a token's top-6 should be answerable
    without leaving it.
 2. **Layer ranges.** Each shelf gets a contiguous run of blocks, sized by its
-   capacity. One console per shelf is the *host*: it holds attention, the MLA KV
+   capacity. One console per shelf is the *host*: it holds attention, the KV
    cache, the router and the shared expert for those layers, and it must have
    both the room and ≥200 GB/s to do it.
 3. **Routed experts** are spread across that shelf's members, weighted by
@@ -177,11 +205,20 @@ and coordinator paths over real loopback sockets.
 **Estimated**: every throughput figure for a console. They come from datasheet
 bandwidth, the fan-out and hop structure of the plan, and NVMe read rates.
 
-**Assumed**: DeepSeek V4 Pro's configuration. No V4 Pro config is public. The
-profile here extrapolates the V2→V3 progression — 72 layers, hidden 8192, 384
-routed experts, top-8, MLA rank 512, 2 MTP heads, FP8 — and every plan it
-produces is stamped `ASSUMED CONFIGURATION`. `deepseek-v3` is a real
-configuration and is the honest thing to plan against today.
+**Read off the model cards**: both V4 configurations. `deepseek-v4-pro` and
+`deepseek-v4-flash` are the published `config.json` files, checked in the tests
+against the published parameter counts (1.6 T / 49 B activated and 284 B / 13 B).
+An earlier revision of this stack extrapolated V4 Pro from V3 and was wrong in
+almost every field; the `assumed` flag and its `ASSUMED CONFIGURATION` stamp
+remain in the code for the next unpublished model, but no shipped profile sets
+it.
+
+**Interpreted, not published**: how those fields turn into bytes. The paper
+gives the architecture, not a storage layout, so the per-layer weight counts in
+`HybridAttentionConfig.weight_params` are this repository's reading of it —
+validated against the published totals, which is a check on the sum and not on
+every term. The split between what a CSA layer *holds* and what it *reads* is
+likewise the paper's sparsity claim carried into the planner, not a measurement.
 
 **Not done**: nothing here has run on a PS5, an Xbox, or a BC-250. There is no
 D3D12 backend. The Vulkan and HIP kernels have never executed on a device.

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -154,8 +154,11 @@ rather than one per expert. See [docs/G9XC.md](docs/G9XC.md).
 - `node.py` — the console-side worker: shard store (RAM or mmap'd NVMe),
   expert execution, block forwarding.
 - `dispatch.py` — groups a token's experts by console, one batched request each,
-  reduces the replies in a fixed order so the same prompt gives the same token,
-  and fails over to a replica when one is available.
+  reduces the per-expert replies in the router's top-k order so the same prompt
+  gives the same token *whatever console holds which expert*, and fails over to
+  a replica when one is available.
+- `dedup.py` — a bounded per-node cache keyed by batch id, so a retry after a
+  timeout is replayed rather than re-run.
 - `coordinator.py` — chains shelves in layer order. An expert-only console can
   be routed around; a shelf *host* cannot, because it owns the KV cache.
 

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -43,7 +43,7 @@ Three properties make the fleet work anyway:
    space. `kernels/fp8.c` and `gen9_cluster/fp8.py` implement E4M3FN and are
    tested against each other over all 256 codes.
 
-The result is a plan, not a benchmark: **~10.8 tok/s estimated** for V4 Pro at
+The result is a plan, not a benchmark: **~11.1 tok/s estimated** for V4 Pro at
 8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250), and a **73-PS5
 floor** to hold it at all. V4 Flash is a fifth of the size and fits on **20**.
 Those figures are arithmetic over memory bandwidth, network hops, and NVMe
@@ -53,8 +53,8 @@ reads. Nothing in this repository has run on a console yet.
 
 | profile | params | activated | on disk | PS5s to hold it |
 |---|---|---|---|---|
-| `deepseek-v4-pro` | 1600 B | 50 B | 803 GiB | 73 |
-| `deepseek-v4-flash` | 291 B | 14 B | 148 GiB | 20 |
+| `deepseek-v4-pro` | 1599 B | 49 B | 802 GiB | 73 |
+| `deepseek-v4-flash` | 291 B | 13 B | 148 GiB | 20 |
 | `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |
 | `deepseek-tiny` | — | — | 0.5 GiB | 1 (CI only) |
 
@@ -68,11 +68,11 @@ properties change how the planner thinks:
   every layer. Neighbouring layers therefore differ by 32x in cache size, and a
   CSA layer *reads* a small fraction of what it *holds* — so the planner sizes
   residency and decode bandwidth separately, per layer, instead of multiplying
-  one KV figure by the layer count. The whole 1 M-token cache is 8.2 GiB, about
-  a seventh of V3's.
+  one KV figure by the layer count. The whole 1 M-token cache is 4.6 GiB, about
+  an eighth of V3's.
 - **Hyper-connections.** The residual stream is 4x hidden, so a shelf boundary
   ships 56 KiB per token rather than 14. At 250 µs a hop that is still small
-  against a 92 ms token, but it is 4x what a V3-shaped model would cost.
+  against a 90 ms token, but it is 4x what a V3-shaped model would cost.
 
 ## Quick start
 

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -34,9 +34,9 @@ anyway:
    experts per layer. The other 96% only has to be *stored*, and storage is the
    one thing a pile of consoles has.
 2. **Decode is bandwidth-bound, not compute-bound.** A PS5's 448 GB/s is what
-   matters, and it is a genuinely good number — a 4700S with the same silicon
-   but the GPU fused off is limited to about a quarter of it, and the planner
-   knows the difference.
+   matters, and it is a genuinely good number — a 4700S carries the same DRAM
+   on the same 256-bit bus, but reaching it from the CPU instead of the GPU
+   measures 92.9 GB/s, a fifth as much, and the planner knows the difference.
 3. **FP8 is the native format.** One byte per parameter, with a scale per
    128-element block, halves the console count against BF16 and roughly doubles
    the token rate. `kernels/fp8.c` and `gen9_cluster/fp8.py` implement E4M3FN
@@ -85,7 +85,8 @@ An inventory records what each *specific* unit actually has:
 | PS5 Pro | 64 / 60 | 16 GB @ 576 GB/s | 2 GB DDR5 (OS) | 5.5 GB/s |
 | Xbox Series X | 56 / 52 | 10 GB @ 560 GB/s | 6 GB @ 336 GB/s | 2.4 GB/s |
 | Xbox Series S | 24 / 20 | 8 GB @ 224 GB/s | 2 GB @ 56 GB/s | 2.4 GB/s |
-| AMD 4700S / 4800S | 56 / **0** | 16 GB @ ~112 GB/s | — | host NVMe |
+| AMD 4700S | 40 / **0** | — | 15 GB @ 92 GB/s | SATA 0.55 GB/s |
+| AMD 4800S | 56 / **0** | — | 15 GB @ 92 GB/s | 3.5 GB/s |
 | BC-250 | 40 / 24 (40 with override) | 16 GB @ 448 GB/s | — | host NVMe |
 
 Every console in this table is *already* a downbinned part, and a real fleet
@@ -96,12 +97,16 @@ effective()` folds it into the nominal SKU, and the planner reads only the
 effective numbers — so the fleet may be arbitrarily heterogeneous and the
 planner rebalances instead of refusing.
 
-The salvage boards are worth their own note. The 4700S and 4800S are console
-SoCs with the GPU fused off entirely: CPU-only nodes, and the GDDR6 that was
-sized for a GPU becomes a large slow coffer for cold experts. The BC-250 is the
-opposite — a PS5 Oberon part with 6 of 8 cores and 24 of 40 CUs enabled, running
-ordinary Linux with amdgpu, which makes it the member of this family whose GPU
-compute path gets exercised most routinely.
+The salvage boards are worth their own note. The 4700S (a PS5 Ariel die) and the
+4800S (a Series X one) have the GPU fused off entirely: CPU-only nodes, and the
+GDDR6 that was sized for a GPU becomes a large slow coffer for cold experts. It
+is bandwidth-rich for system memory and still short of the 200 GB/s a shelf host
+needs, so a fleet of nothing but kits cannot host a shelf at all. A card in the
+slot fixes that, but only on the 4800S: the 4700S's slot is PCIe 2.0 x4, and
+~2 GB/s cannot feed a GPU from board memory. The BC-250 is the opposite — a PS5
+Oberon part with 6 of 8 cores and 24 of 40 CUs enabled, running ordinary Linux
+with amdgpu, which makes it the member of this family whose GPU compute path
+gets exercised most routinely.
 
 ## Backends, and what each can be trusted with
 

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -1,0 +1,191 @@
+# gen9-cluster — DeepSeek V4 Pro across ninth-generation consoles
+
+A splitting and serving stack that runs a frontier MoE model on a fleet of
+PlayStation 5 and Xbox Series X/S consoles, including the variant boards that
+have components disabled and the salvage desktop parts built from the same
+silicon (AMD 4700S, 4800S, and the BC-250 blade).
+
+It is RAM Coffers' idea applied one level up. Upstream, a coffer is a NUMA bank
+inside one POWER8 box holding a known slice of the model. Here a coffer is a
+memory tier inside a console — a Series X is 10 GB at 560 GB/s plus 3.5 GB at
+336 GB/s plus a 2.4 GB/s NVMe — and the fleet is a coffer hierarchy several
+hundred banks wide. The routing that upstream does across NUMA nodes, this does
+across consoles, and DeepSeek's own MoE router decides which ones wake up.
+
+```
+                shelf 0                          shelf 1
+   ┌───────────────────────────────┐   ┌───────────────────────────────┐
+   │ host: Series X   layers 0-9   │   │ host: Series X   layers 10-19 │
+   │   attention + MLA KV cache    │   │                               │
+   │   router + shared expert      │──▶│   ... 74 blocks over 8 shelves│
+   │ 21 more consoles: routed      │   │                               │
+   │   experts, ~8 lit per token   │   │                               │
+   └───────────────────────────────┘   └───────────────────────────────┘
+```
+
+## Why this is possible at all
+
+DeepSeek V4 Pro (assumed configuration — see below) is ~1345 GiB of FP8 weights
+and no console has more than 16 GB. Three properties make the fleet work
+anyway:
+
+1. **Only ~4% of the model runs per token.** 52 of 1359 billion parameters
+   activate: attention, the router, one shared expert, and 8 of 384 routed
+   experts per layer. The other 96% only has to be *stored*, and storage is the
+   one thing a pile of consoles has.
+2. **Decode is bandwidth-bound, not compute-bound.** A PS5's 448 GB/s is what
+   matters, and it is a genuinely good number — a 4700S with the same silicon
+   but the GPU fused off is limited to about a quarter of it, and the planner
+   knows the difference.
+3. **FP8 is the native format.** One byte per parameter, with a scale per
+   128-element block, halves the console count against BF16 and roughly doubles
+   the token rate. `kernels/fp8.c` and `gen9_cluster/fp8.py` implement E4M3FN
+   and are tested against each other over all 256 codes.
+
+The result is a plan, not a benchmark: **~9.4 tok/s estimated** for V4 Pro at
+8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250). That figure is
+arithmetic over memory bandwidth, network hops, and NVMe reads. Nothing in this
+repository has run on a console yet.
+
+## Quick start
+
+```bash
+cd gen9-cluster
+python3 -m gen9_cluster model --model deepseek-v4-pro    # what it costs
+python3 -m gen9_cluster size  --model deepseek-v4-pro --ps5 100 \
+        --xbox-series-x 40 --bc-250 30                   # how many consoles
+python3 -m gen9_cluster plan  fleet.json --config cluster.json
+python3 -m gen9_cluster probe                            # measure this box
+python3 -m gen9_cluster serve --unit-id ps5-01           # run a node
+python3 -m gen9_cluster health cluster.json
+```
+
+An inventory records what each *specific* unit actually has:
+
+```json
+{"fleet": [
+  {"unit_id": "ps5-01", "sku": "ps5", "runtime": "ps5-linux",
+   "host": "10.0.0.11", "backend": "vulkan"},
+  {"unit_id": "ps5-07", "sku": "ps5", "runtime": "ps5-linux",
+   "host": "10.0.0.17",
+   "downbin": {"cu_disabled": 4, "gpu_ghz_cap": 1.8,
+               "tier_losses": {"gddr6": 2147483648},
+               "reasons": ["dead GDDR6 package", "fan replaced"]}},
+  {"unit_id": "bc-01", "sku": "bc-250", "runtime": "salvage-linux",
+   "host": "10.0.0.31", "cu_enabled_override": 40, "backend": "rocm",
+   "measured_gemv_gflops": 940.0}
+]}
+```
+
+## Hardware, and how much of it is really there
+
+| SKU | CUs (phys/enabled) | Fast coffer | Slow coffer | NVMe |
+|---|---|---|---|---|
+| PS5 / Slim | 40 / 36 | 16 GB @ 448 GB/s | — | 5.5 GB/s |
+| PS5 Pro | 64 / 60 | 16 GB @ 576 GB/s | 2 GB DDR5 (OS) | 5.5 GB/s |
+| Xbox Series X | 56 / 52 | 10 GB @ 560 GB/s | 6 GB @ 336 GB/s | 2.4 GB/s |
+| Xbox Series S | 24 / 20 | 8 GB @ 224 GB/s | 2 GB @ 56 GB/s | 2.4 GB/s |
+| AMD 4700S / 4800S | 56 / **0** | 16 GB @ ~112 GB/s | — | host NVMe |
+| BC-250 | 40 / 24 (40 with override) | 16 GB @ 448 GB/s | — | host NVMe |
+
+Every console in this table is *already* a downbinned part, and a real fleet
+downbins further in ways the SKU name cannot tell you: a dev-mode sandbox that
+hands out 5 GB, a dead memory package, a depopulated channel, a unit clocked
+down by a failed fan. `Downbin` records what one unit lost, `ConsoleUnit.
+effective()` folds it into the nominal SKU, and the planner reads only the
+effective numbers — so the fleet may be arbitrarily heterogeneous and the
+planner rebalances instead of refusing.
+
+The salvage boards are worth their own note. The 4700S and 4800S are console
+SoCs with the GPU fused off entirely: CPU-only nodes, and the GDDR6 that was
+sized for a GPU becomes a large slow coffer for cold experts. The BC-250 is the
+opposite — a PS5 Oberon part with 6 of 8 cores and 24 of 40 CUs enabled, running
+ordinary Linux with amdgpu, which makes it the member of this family whose GPU
+compute path gets exercised most routinely.
+
+## Backends, and what each can be trusted with
+
+| Backend | Where | Status |
+|---|---|---|
+| `cpu-avx2` | everywhere (Zen 2, no AVX-512) | built and tested here |
+| `vulkan` | PS5 under ps5-linux, BC-250 | shader compiles and validates; not run on a device |
+| `rocm` | opt-in, per node | see below |
+| `d3d12` | Xbox GDK/devkit only | not implemented |
+
+ROCm on gfx1013 is *supported but not assumed*. Debian ROCm builds do run on
+this target, but the library stack is uneven: some libraries do not ship the
+target at all, and others fall back to a lower capability level because their
+build scripts assume a higher gfx tier. So a node must declare `"backend":
+"rocm"` explicitly and supply `measured_gemv_gflops`; the planner will not
+invent a ROCm figure for a console. `kernels/expert_hip.hip` is written to build
+with plain `hipcc --offload-arch=gfx1013` and deliberately depends on no
+rocBLAS, Tensile, or hipBLASLt kernel — the tuned-library layer is exactly the
+part that is unreliable here. Vulkan/RADV remains the default GPU path.
+
+## How the model is split
+
+Four decisions, in order:
+
+1. **Shelves.** The fleet is cut into groups of ~22 consoles, dealt
+   round-robin in capability order so no shelf inherits all the fast units. A
+   shelf is the expert fan-out group: a token's top-8 should be answerable
+   without leaving it.
+2. **Layer ranges.** Each shelf gets a contiguous run of blocks, sized by its
+   capacity. One console per shelf is the *host*: it holds attention, the MLA KV
+   cache, the router and the shared expert for those layers, and it must have
+   both the room and ≥200 GB/s to do it.
+3. **Routed experts** are spread across that shelf's members, weighted by
+   measured or nominal throughput — an equal split would make the slowest
+   console the tail latency of every token.
+4. **Overflow** goes to the slow coffer, then to NVMe as a memory-mapped tier.
+   The page cache then keeps whichever experts actually get routed to, which
+   converges on the popular ones without anybody profiling them.
+
+A slow plan is still a plan: the planner warns about cross-shelf hops and NVMe
+streaming and reports an estimate, and only refuses when the weights genuinely
+do not fit in the tiers it is allowed to use.
+
+## Runtime
+
+`G9XC` is the wire protocol: a fixed 32-byte header, request-id multiplexing
+over persistent TCP with Nagle off, and one message per *console* per layer
+rather than one per expert. See [docs/G9XC.md](docs/G9XC.md).
+
+- `node.py` — the console-side worker: shard store (RAM or mmap'd NVMe),
+  expert execution, block forwarding.
+- `dispatch.py` — groups a token's experts by console, one batched request each,
+  reduces the replies in a fixed order so the same prompt gives the same token,
+  and fails over to a replica when one is available.
+- `coordinator.py` — chains shelves in layer order. An expert-only console can
+  be routed around; a shelf *host* cannot, because it owns the KV cache.
+
+## What is measured, what is estimated, what is assumed
+
+**Measured** (on this x86-64 build host, not a console): the CPU kernel at
+67 GFLOP/s and 134 GB/s effective; the SPIR-V shader compiles and passes
+`spirv-val`; 159 Python tests pass, including the protocol, transport, dispatch
+and coordinator paths over real loopback sockets.
+
+**Estimated**: every throughput figure for a console. They come from datasheet
+bandwidth, the fan-out and hop structure of the plan, and NVMe read rates.
+
+**Assumed**: DeepSeek V4 Pro's configuration. No V4 Pro config is public. The
+profile here extrapolates the V2→V3 progression — 72 layers, hidden 8192, 384
+routed experts, top-8, MLA rank 512, 2 MTP heads, FP8 — and every plan it
+produces is stamped `ASSUMED CONFIGURATION`. `deepseek-v3` is a real
+configuration and is the honest thing to plan against today.
+
+**Not done**: nothing here has run on a PS5, an Xbox, or a BC-250. There is no
+D3D12 backend. The Vulkan and HIP kernels have never executed on a device.
+
+See [docs/GEN9_SPLITTING.md](docs/GEN9_SPLITTING.md) for the arithmetic and
+[docs/REFERENCES.md](docs/REFERENCES.md) for the prior work this borrows from.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tests -t .   # 159 tests
+cd kernels && make && make test              # CPU kernel + FP8 conformance
+make vulkan                                  # needs glslang-tools
+make hip                                     # needs hipcc; skipped otherwise
+```

--- a/gen9-cluster/docs/G9XC.md
+++ b/gen9-cluster/docs/G9XC.md
@@ -1,4 +1,4 @@
-# G9XC — the wire protocol, version 1
+# G9XC — the wire protocol, version 2
 
 G9XC carries activations, expert requests and shard loads between a shelf
 coordinator and its consoles. It is a descendant of the PS3 port's P3XC, with
@@ -11,9 +11,14 @@ the changes ninth-generation hardware forces. Normative implementation:
 expert, so P3XC could put the expert id in the header. A PS5 holds dozens, and
 a token whose top-8 routes into three experts on one console must not cost three
 round trips. `EXPERT_BATCH` therefore names a *set* of experts with their gate
-weights, and the node replies with their gate-weighted sum as one
-`EXPERT_RESULT`. At 74 blocks and a quarter-millisecond hop this is the
-difference between ~5 ms and ~20 ms of pure latency per token.
+weights and gets one `EXPERT_RESULT` back. At 74 blocks and a
+quarter-millisecond hop this is the difference between ~5 ms and ~20 ms of pure
+latency per token.
+
+**The reply is one row per expert, not a sum.** This is P3XC's rule *kept*. A
+node returns `gate_i * expert_i(x)` for each expert it was asked for, tagged
+with the expert id, and the coordinator adds them in the router's top-k order.
+See [Reproducibility](#reproducibility) for why, and `FAST` for the way out.
 
 **Weights are FP8 with block scales.** The dtype field names
 `fp8-e4m3-b128` and a `LOAD_SHARD` carrying it also carries its scales, so a
@@ -32,7 +37,7 @@ delimiter scanning, no partial-parse states.
 ```
 offset size field
   0     4   magic        "G9XC"
-  4     1   version      1
+  4     1   version      2
   5     1   type         MsgType
   6     2   flags        Flags bitfield
   8     4   request_id   echoed by the reply
@@ -49,7 +54,7 @@ offset size field
 `struct` format: `<4sBBHIHHIBBHI4x`.
 
 A header is rejected unless it is exactly 32 bytes, starts with `G9XC`, has
-version 1, names a known `MsgType`, and declares `payload_len <= 64 MiB`. The
+version 2, names a known `MsgType`, and declares `payload_len <= 64 MiB`. The
 size cap exists so a corrupt length field cannot ask for all of memory; a
 legitimate frame is an activation (tens of KiB) or a shard chunk.
 
@@ -69,7 +74,7 @@ Request ids are per-connection, wrap at 2³², and skip 0.
 | 1 | `HELLO` | node → coord | `HelloPayload` |
 | 2 | `HELLO_ACK` | coord → node | empty |
 | 3 | `EXPERT_BATCH` | coord → node | `ExpertBatchPayload` |
-| 4 | `EXPERT_RESULT` | node → coord | vector (gate-weighted sum) |
+| 4 | `EXPERT_RESULT` | node → coord | `ExpertRowsPayload`, or a vector under `FAST` |
 | 5 | `BLOCK_FWD` | coord → node | vector (hidden state) |
 | 6 | `BLOCK_RESULT` | node → coord | vector |
 | 7 | `LOAD_SHARD` | coord → node | `ShardHeader` + body |
@@ -81,20 +86,31 @@ Request ids are per-connection, wrap at 2³², and skip 0.
 
 ### Flags
 
-| bit | name | meaning |
-|---|---|---|
-| 0 | `PARTIAL` | a partial sum the coordinator must add to others |
-| 1 | `FROM_STORAGE` | served from NVMe, not RAM — why this layer was slow |
-| 2 | `SHEDDING` | the node wants less of this |
+| bit | name | direction | meaning |
+|---|---|---|---|
+| 0 | `PARTIAL` | reply | a collapsed partial sum; set on a `FAST` reply and only there |
+| 1 | `FROM_STORAGE` | reply | served from NVMe, not RAM — why this layer was slow |
+| 2 | `BACKPRESSURE` | reply | the node wants less of this |
+| 3 | `FAST` | request | collapse this batch into one sum; opt-in, see below |
+| 4 | `PER_EXPERT` | reply | the payload is `ExpertRowsPayload`. The default |
+| 5 | `REPLAYED` | reply | served from the dedup cache; the experts did not run again |
 
 `FROM_STORAGE` is the one worth setting carefully. It is how a coordinator
 explains a slow layer instead of guessing at it.
+
+A coordinator **must reject** an `EXPERT_RESULT` carrying `PARTIAL` for a batch
+that did not set `FAST`. Such a reply is a node that re-associated the sum
+without being asked, and its number cannot be placed in top-k order; accepting
+it would produce a plausible wrong answer, which is the exact failure this
+design exists to prevent.
 
 ### `ExpertBatchPayload`
 
 ```
 u16  n_experts
 u32  n_activation        (elements, not bytes)
+u8   has_batch_id        0 or 1; any other value is malformed
+u64  batch_id            present only if has_batch_id == 1
 u16  expert_id           x n_experts
 f32  gate                x n_experts
 f32  activation          x n_activation
@@ -105,6 +121,30 @@ truncated tail would otherwise be a perfectly well-formed batch with a shorter
 hidden state, and the node would compute a confidently wrong answer from it.
 A decoder must require the payload to be exactly the implied size, and must
 reject a batch naming zero experts.
+
+`batch_id` names the *logical* batch, as distinct from the header's
+`request_id`, which is per-connection and is reallocated on reconnect. A
+coordinator reuses one `batch_id` across every attempt at the same batch; see
+[Errors and retries](#errors-and-retries).
+
+### `ExpertRowsPayload`
+
+The default `EXPERT_RESULT`, flagged `PER_EXPERT`.
+
+```
+u16  n_rows
+u32  width               elements per row
+u16  expert_id           x n_rows
+f32  row                 x n_rows * width   (row-major)
+```
+
+`row[i]` is `gate_i * expert_i(activation)`, with no cross-expert addition
+performed on the node. Rows may be returned in any order; the tag is what
+matters. A decoder must require the exact implied length and reject zero rows.
+
+A coordinator must check that the set of returned ids equals the set it asked
+for. A missing row is a missing term in the layer's sum, and silently dropping
+one costs an expert's contribution without any error being raised.
 
 ### `ShardHeader`
 
@@ -162,16 +202,100 @@ names one console.
 Retry safety is per operation, not per error:
 
 - `EXPERT_BATCH` is **stateless** — the same experts on the same activation
-  give the same sum — so it may be retried, and may be re-sent to a replica
+  give the same rows — so it may be retried, and may be re-sent to a replica
   console that holds *all* of the failed batch's experts.
 - `BLOCK_FWD` is **stateful**: it appends to the host's MLA KV cache. It is
   never retried automatically, and a shelf host is never failed over, because
   the KV cache for those layers exists only there.
 
+### Exactly-once, and where it stops
+
+A coordinator that times out cannot tell whether the console ran the experts
+before the socket died or after, so a plain retry is *at-least-once*. Every
+attempt at one batch therefore carries the same `batch_id`, and a node keeps a
+bounded cache of what it answered
+([`gen9_cluster/dedup.py`](../gen9_cluster/dedup.py)):
+
+- Same `batch_id`, same content: the first attempt's bytes are replayed,
+  flagged `REPLAYED`, and the weights are not touched again.
+- Same `batch_id`, still running: the retry **waits** for the first attempt
+  rather than starting a second pass. This is the common case on a console that
+  is merely slow, and it is where the saving actually is.
+- Same `batch_id`, different content: rejected with `ERROR`. Replaying the
+  wrong activation's output would be a wrong token that no log explains.
+- No `batch_id`: no deduplication. Legal, and only costs a console's time.
+
+The cache is bounded three ways — entries, total cached bytes, and a TTL — and
+never evicts a batch that is still running; when every tracked batch is in
+flight a new one is refused with `BACKPRESSURE` rather than something in flight
+being dropped. A failed batch is not cached as an answer, and a reply too large
+for the byte budget is returned but not retained.
+
+**This is per node process.** A retry sent to a *different* console (the
+replica path) cannot be deduplicated without shared state, which G9XC does not
+have and does not want. That case is safe for a different reason: the
+coordinator uses one reply and discards the other, so the duplicated execution
+cannot reach the sum. A node restart also clears the cache, and a retry across
+it re-executes.
+
+## Reproducibility
+
+Floating-point addition is not associative, so *the order a layer's experts are
+summed in is part of the answer*. G9XC fixes that order at the only place that
+knows it: the router's top-k ranking.
+
+- A node never adds two experts together unless asked. It returns rows.
+- The coordinator folds those rows left to right in top-k order, whatever order
+  the replies arrived in and whatever console each came from.
+- Every summation in the stack — coordinator reduction, a node collapsing a
+  `FAST` batch, a single-process reference run — goes through one `accumulate`
+  helper that folds left to right. Notably *not* `np.sum`, which sums pairwise:
+  that is more accurate, and it is a different number.
+
+What this buys: the same prompt gives the same bits regardless of how the
+planner spread the experts over the shelf. On a fleet of second-hand consoles
+that is not a theoretical property — a unit dies, the planner reshuffles, and
+without this the model would quietly start emitting different tokens, with no
+error anywhere and nothing in the logs pointing at the console that failed.
+
+### What it does not buy
+
+Reduction order is fixed; **kernel arithmetic is not**. A shelf may mix
+`cpu-avx2`, `vulkan` and `rocm` nodes, and those three do not accumulate an
+expert's FMAs in the same order internally. Two consoles running the same
+expert on different backends may therefore return rows differing in the last
+bits, and the layer sum differs with them.
+
+So, precisely: **for a fixed assignment of experts to backends, the output is
+reproducible and placement-independent.** Bit-identity across a heterogeneous
+fleet would additionally require pinning one reference kernel, which this stack
+deliberately does not do — its whole point is to use whatever silicon is in the
+rack. A deployment that needs fleet-wide bit-identity must run one backend.
+
+### `FAST`
+
+Setting `FAST` on an `EXPERT_BATCH` asks the node to collapse its experts into
+one gate-weighted sum, replied with `PARTIAL`. The coordinator then has no
+per-expert structure to reduce and falls back to summing by unit id: still
+deterministic run to run, no longer invariant under a replan.
+
+The trade is reply bandwidth. Exact mode sends `k` rows per layer where `FAST`
+sends one per console touched. At the V4-Pro profile (hidden 8192, k=8, 69 MoE
+layers) that is ~18.1 MB/token exact against ~15.4 MB/token collapsed, because
+a shelf wide enough to be worth building already scatters the top-8 across
+~6.8 consoles — the sum being collapsed is usually one or two terms long. ~17%
+of reply bandwidth is a poor price for an answer that depends on the current
+plan, which is why exact is the default and `FAST` is a flag.
+
 ## Versioning
 
-`version` is a hard match in v1: a frame with a different version is rejected
-at the header. Adding a message type is backwards compatible (unknown types are
+`version` is a hard match: a frame with a different version is rejected at the
+header. Adding a message type is backwards compatible (unknown types are
 rejected as malformed, which is the intended outcome for a peer that should not
 be sending them); changing a payload layout is not, and requires the version
 byte to move.
+
+**v1 → v2.** `EXPERT_RESULT` became `ExpertRowsPayload` by default, and
+`ExpertBatchPayload` gained `has_batch_id`/`batch_id`. A v1 node and a v2
+coordinator disagree about the shape of every expert reply, so the version
+check catches it at the first frame rather than as wrong logits an hour later.

--- a/gen9-cluster/docs/G9XC.md
+++ b/gen9-cluster/docs/G9XC.md
@@ -1,0 +1,177 @@
+# G9XC — the wire protocol, version 1
+
+G9XC carries activations, expert requests and shard loads between a shelf
+coordinator and its consoles. It is a descendant of the PS3 port's P3XC, with
+the changes ninth-generation hardware forces. Normative implementation:
+[`gen9_cluster/protocol.py`](../gen9_cluster/protocol.py).
+
+## What changed from P3XC, and why
+
+**A console holds many experts, not one.** A PS3 had 256 MB and held a single
+expert, so P3XC could put the expert id in the header. A PS5 holds dozens, and
+a token whose top-8 routes into three experts on one console must not cost three
+round trips. `EXPERT_BATCH` therefore names a *set* of experts with their gate
+weights, and the node replies with their gate-weighted sum as one
+`EXPERT_RESULT`. At 74 blocks and a quarter-millisecond hop this is the
+difference between ~5 ms and ~20 ms of pure latency per token.
+
+**Weights are FP8 with block scales.** The dtype field names
+`fp8-e4m3-b128` and a `LOAD_SHARD` carrying it also carries its scales, so a
+shard ships in the format the checkpoint already uses and is never materialised
+at fp32 on the way.
+
+**Little-endian.** P3XC was big-endian because the Cell's PPE was. Every console
+here is x86-64, so wire order is host order and encoding is a memcpy.
+
+## Framing
+
+A fixed 32-byte header, then exactly `payload_len` bytes. Fixed-size headers
+mean a reader can read a header, learn the length, and read exactly that: no
+delimiter scanning, no partial-parse states.
+
+```
+offset size field
+  0     4   magic        "G9XC"
+  4     1   version      1
+  5     1   type         MsgType
+  6     2   flags        Flags bitfield
+  8     4   request_id   echoed by the reply
+ 12     2   layer
+ 14     2   expert       first expert, where a single one is meant
+ 16     4   token        position, for KV-cache correlation
+ 20     1   dtype        DType
+ 21     1   rank         tensor rank hint
+ 22     2   reserved     zero
+ 24     4   payload_len  bytes following the header
+ 28     4   padding      zero, to align the payload to 32
+```
+
+`struct` format: `<4sBBHIHHIBBHI4x`.
+
+A header is rejected unless it is exactly 32 bytes, starts with `G9XC`, has
+version 1, names a known `MsgType`, and declares `payload_len <= 64 MiB`. The
+size cap exists so a corrupt length field cannot ask for all of memory; a
+legitimate frame is an activation (tens of KiB) or a shard chunk.
+
+## Multiplexing
+
+Every frame carries `request_id`; a reply echoes it. The transport matches
+replies to requests by that id alone, so several requests may be in flight on
+one connection. Connections are persistent with `TCP_NODELAY` set — at 74
+blocks per token, connection setup or Nagle delay would dominate.
+
+Request ids are per-connection, wrap at 2³², and skip 0.
+
+## Message types
+
+| # | Type | Direction | Payload |
+|---|---|---|---|
+| 1 | `HELLO` | node → coord | `HelloPayload` |
+| 2 | `HELLO_ACK` | coord → node | empty |
+| 3 | `EXPERT_BATCH` | coord → node | `ExpertBatchPayload` |
+| 4 | `EXPERT_RESULT` | node → coord | vector (gate-weighted sum) |
+| 5 | `BLOCK_FWD` | coord → node | vector (hidden state) |
+| 6 | `BLOCK_RESULT` | node → coord | vector |
+| 7 | `LOAD_SHARD` | coord → node | `ShardHeader` + body |
+| 8 | `LOAD_ACK` | node → coord | empty |
+| 9 | `PING` / 10 `PONG` | either | empty |
+| 11 | `STATUS` / 12 `STATUS_REPLY` | coord → node | JSON |
+| 13 | `ERROR` | either | UTF-8 message, ≤4096 bytes |
+| 14 | `SHUTDOWN` | coord → node | empty |
+
+### Flags
+
+| bit | name | meaning |
+|---|---|---|
+| 0 | `PARTIAL` | a partial sum the coordinator must add to others |
+| 1 | `FROM_STORAGE` | served from NVMe, not RAM — why this layer was slow |
+| 2 | `SHEDDING` | the node wants less of this |
+
+`FROM_STORAGE` is the one worth setting carefully. It is how a coordinator
+explains a slow layer instead of guessing at it.
+
+### `ExpertBatchPayload`
+
+```
+u16  n_experts
+u32  n_activation        (elements, not bytes)
+u16  expert_id           x n_experts
+f32  gate                x n_experts
+f32  activation          x n_activation
+```
+
+The activation length is *stated*, not inferred from the remaining buffer. A
+truncated tail would otherwise be a perfectly well-formed batch with a shorter
+hidden state, and the node would compute a confidently wrong answer from it.
+A decoder must require the payload to be exactly the implied size, and must
+reject a batch naming zero experts.
+
+### `ShardHeader`
+
+```
+u16  layer
+u16  first_expert
+u16  n_experts
+u32  hidden_size
+u32  intermediate_size
+u8   dtype
+u16  tier_len
+     tier                ascii: "fast" | "slow" | "ssd"
+```
+
+followed by the body. For `FP32`, the body is
+`n_experts × 3 × hidden × intermediate` little-endian floats, in gate, up, down
+order per expert.
+
+For `FP8_E4M3_B128` the body is **all codes, then all block scales**:
+
+```
+u8   code    x n_experts * 3 * hidden * intermediate
+f32  scale   x n_experts * 3 * ceil(hidden * intermediate / 128)
+```
+
+Separated rather than interleaved, so the codes land contiguous and
+page-aligned in the coffer: a GPU backend uploads them as one buffer, and a
+memory-mapped shard reads them without a gather. The scales are three orders of
+magnitude smaller and can afford to be a second, small transfer. A body of the
+wrong length is refused with `ERROR` — a shard whose scales are missing would
+otherwise decode to plausible-looking noise.
+
+### `HelloPayload`
+
+```
+u64  weight_bytes
+u64  fast_bytes
+f64  gemv_gflops
+u8   protocol_version
+     then 4 length-prefixed utf-8 strings:
+     unit_id, sku, backend, runtime
+```
+
+A node announces what it *is*, not what the plan believes it to be. A console
+back from a repair with fewer CUs, a smaller sandbox or a different backend is
+then caught at connect time rather than by mystery slowness three hours later.
+
+## Errors and retries
+
+A node turns a malformed request into an `ERROR` frame with the same
+`request_id`; it does not drop the connection. The transport raises the error
+to the caller attributed to the unit that produced it, so a fleet-wide symptom
+names one console.
+
+Retry safety is per operation, not per error:
+
+- `EXPERT_BATCH` is **stateless** — the same experts on the same activation
+  give the same sum — so it may be retried, and may be re-sent to a replica
+  console that holds *all* of the failed batch's experts.
+- `BLOCK_FWD` is **stateful**: it appends to the host's MLA KV cache. It is
+  never retried automatically, and a shelf host is never failed over, because
+  the KV cache for those layers exists only there.
+
+## Versioning
+
+`version` is a hard match in v1: a frame with a different version is rejected
+at the header. Adding a message type is backwards compatible (unknown types are
+rejected as malformed, which is the intended outcome for a peer that should not
+be sending them); changing a payload layout is not, and requires the version
+byte to move.

--- a/gen9-cluster/docs/G9XC.md
+++ b/gen9-cluster/docs/G9XC.md
@@ -9,9 +9,9 @@ the changes ninth-generation hardware forces. Normative implementation:
 
 **A console holds many experts, not one.** A PS3 had 256 MB and held a single
 expert, so P3XC could put the expert id in the header. A PS5 holds dozens, and
-a token whose top-8 routes into three experts on one console must not cost three
+a token whose top-6 routes into three experts on one console must not cost three
 round trips. `EXPERT_BATCH` therefore names a *set* of experts with their gate
-weights and gets one `EXPERT_RESULT` back. At 74 blocks and a
+weights and gets one `EXPERT_RESULT` back. At 62 blocks and a
 quarter-millisecond hop this is the difference between ~5 ms and ~20 ms of pure
 latency per token.
 
@@ -62,7 +62,7 @@ legitimate frame is an activation (tens of KiB) or a shard chunk.
 
 Every frame carries `request_id`; a reply echoes it. The transport matches
 replies to requests by that id alone, so several requests may be in flight on
-one connection. Connections are persistent with `TCP_NODELAY` set — at 74
+one connection. Connections are persistent with `TCP_NODELAY` set — at 62
 blocks per token, connection setup or Nagle delay would dominate.
 
 Request ids are per-connection, wrap at 2³², and skip 0.
@@ -280,12 +280,13 @@ per-expert structure to reduce and falls back to summing by unit id: still
 deterministic run to run, no longer invariant under a replan.
 
 The trade is reply bandwidth. Exact mode sends `k` rows per layer where `FAST`
-sends one per console touched. At the V4-Pro profile (hidden 8192, k=8, 69 MoE
-layers) that is ~18.1 MB/token exact against ~15.4 MB/token collapsed, because
-a shelf wide enough to be worth building already scatters the top-8 across
-~6.8 consoles — the sum being collapsed is usually one or two terms long. ~17%
-of reply bandwidth is a poor price for an answer that depends on the current
-plan, which is why exact is the default and `FAST` is a flag.
+sends one per console touched. At the published V4-Pro profile (hidden 7168,
+k=6, 61 MoE layers) that is ~5.2 MB/token exact against ~4.7 MB/token
+collapsed, because a shelf wide enough to be worth building already scatters
+the top-6 across ~5.4 of its 22 consoles — the sum being collapsed is usually
+one or two terms long. ~12% of reply bandwidth is a poor price for an answer
+that depends on the current plan, which is why exact is the default and `FAST`
+is a flag.
 
 ## Versioning
 

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -5,25 +5,25 @@ claim.
 
 ## The problem
 
-DeepSeek V4 Pro is **803 GiB** — 1.6 T parameters, but MXFP4 experts and FP8
-everywhere else come to 0.54 bytes each. The largest console in this family has
-16 GB of RAM, of which about 13 GB is reachable, so the model needs ~62
-consoles just to be *stored* and 73 once each shelf host also has to hold its
-layers' hot blocks and cache.
+DeepSeek V4 Pro is **802 GiB** — 1,599 B parameters (1,573 B excluding the MTP
+head), but MXFP4 experts and FP8 everywhere else come to 0.54 bytes each. The
+largest console in this family has 16 GB of RAM, of which about 13 GB is
+reachable, so the model needs ~62 consoles just to be *stored* and 73 once each
+shelf host also has to hold its layers' hot blocks and cache.
 
 What makes this tractable rather than absurd is that MoE decode touches almost
 none of it:
 
 | per token, per MoE layer | size |
 |---|---|
-| attention (CSA layer, incl. indexer and grouped output) | ~353 MiB |
-| attention (HCA layer) | ~290 MiB |
+| attention (CSA layer, incl. indexer and grouped output) | ~316 MiB |
+| attention (HCA layer) | ~293 MiB |
 | router + shared expert | ~36 MiB |
 | 6 routed experts of 384 | ~201 MiB |
-| **total read** | **~530-590 MiB** |
-| stored but untouched | ~12.4 GiB |
+| **total read** | **~530-555 MiB** |
+| stored but untouched | ~12.9 GiB |
 
-50 of 1600 billion parameters activate. The other 97% has to be held somewhere
+~49 B of 1,599 B parameters activate. The other 97% has to be held somewhere
 with an address, and that is precisely what a stack of consoles is good for.
 
 V4 Flash is the same architecture at a fifth of the scale — 148 GiB, 43 layers,
@@ -67,8 +67,8 @@ floor is why a 4700S — a PS5 die with the GPU fused off, its GDDR6 measuring
 Compressed attention is what makes long context affordable, and in V4 it is
 compressed along the *sequence*: a CSA layer folds every 4 tokens into one
 512-wide shared-KV entry and an HCA layer every 128, so the whole cache at a
-million tokens is 8.2 GiB rather than the 65 GiB V3's MLA would need — and at
-8k it is 74 MiB, small enough that context is not what decides the fleet size.
+million tokens is 4.6 GiB rather than the 36 GiB V3's MLA would need — and at
+8k it is 43 MiB, small enough that context is not what decides the fleet size.
 
 The two kinds are interleaved, so **neighbouring layers differ by 32x in cache
 size** and the planner sizes each block separately (`block_kv_bytes`). Sizing
@@ -100,7 +100,7 @@ Per token, the estimate sums:
 - per block: the KV the block has to *read*, which under CSA is not the KV it
   holds — the FP4 indexer scans every compressed entry but attention then reads
   only the 1024 it selected, so a million-token CSA layer reads ~17 MiB of a
-  260 MiB cache. Treating residency as the read cost would overstate
+  154 MiB cache. Treating residency as the read cost would overstate
   long-context decode by an order of magnitude,
 - per block: the slowest expert console's `expert_bytes / bandwidth`, since the
   fan-out is concurrent and the gather waits for the last reply,
@@ -118,7 +118,7 @@ Worked example, 100 PS5 + 40 Series X + 30 BC-250:
 ```
 deepseek-v4-pro on 170 consoles in 8 shelves
   context               8192 tokens
-  decode estimate       10.84 tok/s (92 ms/token)
+  decode estimate       11.14 tok/s (90 ms/token)
   consoles per layer    ~6 lit by one token
   streamed from NVMe    3.0 GiB of experts
 ```

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -1,0 +1,142 @@
+# Splitting DeepSeek V4 Pro across a console fleet
+
+The arithmetic behind `gen9_cluster.planner`, and what it does and does not
+claim.
+
+## The problem
+
+DeepSeek V4 Pro, on the assumed configuration in `model.py`, is **1345 GiB of
+FP8 weights**. The largest console in this family has 16 GB of RAM, of which
+about 13 GB is reachable. So the model needs ~104 consoles just to be *stored*,
+before anything runs.
+
+What makes this tractable rather than absurd is that MoE decode touches almost
+none of it:
+
+| per token, per MoE layer | size |
+|---|---|
+| attention (MLA, incl. LoRA projections) | ~180 MiB |
+| router + shared expert | ~121 MiB |
+| 8 routed experts of 384 | ~396 MiB |
+| **total read** | **~700 MiB** |
+| stored but untouched | ~18.2 GiB |
+
+52 of 1359 billion parameters activate. The other 96% has to be held somewhere
+with an address, and that is precisely what a stack of consoles is good for.
+
+## The four decisions
+
+### 1. Shelves
+
+The fleet is cut into groups of ~22 (`DEFAULT_SHELF_SIZE`), dealt round-robin
+in descending capability order. Round-robin rather than contiguous because a
+shelf's slowest member sets the floor for every layer it owns: one shelf
+inheriting all the Series X units and another all the Series S ones would make
+the second shelf's layers permanently the slow ones.
+
+A shelf is the *expert fan-out group*. A token's top-8 experts for a layer
+should be answerable inside one shelf, so a layer costs one fan-out and one
+gather, not a tour of the fleet.
+
+### 2. Layer ranges
+
+Each shelf takes a contiguous run of blocks, sized in proportion to its
+capacity, so a shelf of Series S consoles takes fewer layers rather than the
+same number and overflowing to NVMe.
+
+The block count is `n_layers + n_mtp_heads` — the MTP heads are full decoder
+blocks and have to be placed like any other.
+
+One member of each shelf is the **host**. It holds, for that shelf's layers:
+
+- attention weights and the MLA KV cache,
+- the router,
+- the shared expert (always on, so it must never be a network hop),
+- the layer norms.
+
+A host must have both the room and ≥200 GB/s (`HOT_BANDWIDTH_FLOOR_GBPS`). That
+floor is why a 4700S — same silicon as a Series X, GPU fused off, ~112 GB/s —
+can hold cold experts but is never chosen as a host.
+
+The MLA compressed KV cache is what makes an 8k context affordable: rank 512
+instead of 160 full heads is ~9 MiB per layer per 8k tokens rather than ~160.
+Without it the KV cache alone would evict the weights.
+
+### 3. Routed experts
+
+Spread across the shelf's members, weighted by throughput — measured where the
+inventory gives a figure, nominal otherwise. An equal split would make the
+slowest console in the shelf the tail latency of every token that routes to it,
+and with top-8 across 22 consoles, most tokens touch a slow one.
+
+### 4. Overflow
+
+In order: fast coffer → slow coffer → NVMe as a memory-mapped tier.
+
+Mapping rather than reading is what makes NVMe usable. The page cache then
+retains whichever experts actually get routed to, which converges on the
+popular ones without anybody having to profile them — the same effect
+KTransformers gets by explicitly pinning hot experts to the GPU, arrived at by
+letting the kernel do it.
+
+## Throughput estimate
+
+Per token, the estimate sums:
+
+- per block: `hot_bytes / (host bandwidth × efficiency)`,
+- per block: the slowest expert console's `expert_bytes / bandwidth`, since the
+  fan-out is concurrent and the gather waits for the last reply,
+- NVMe reads where experts live there,
+- `(n_shelves − 1) × hop_seconds` for crossing between shelves.
+
+`BANDWIDTH_EFFICIENCY` derates each backend from datasheet peak. Hop cost
+defaults to 250 µs, which is a plausible switched-gigabit round trip for a
+16 KiB activation and is the single most consequential guess in the model.
+
+Worked example, 100 PS5 + 40 Series X + 30 BC-250:
+
+```
+deepseek-v4-pro (ASSUMED CONFIGURATION) on 170 consoles in 8 shelves
+  context               8192 tokens
+  decode estimate       9.42 tok/s (106 ms/token)
+  consoles per layer    ~8 lit by one token
+  streamed from NVMe    6.0 GiB of experts
+```
+
+Seven inter-shelf hops cost ~1.8 ms of the 106 ms, so this configuration is
+memory-bandwidth-bound rather than network-bound. That flips if the fleet is
+built from many small consoles: 300 Series S units would be 14 shelves and the
+hops start to matter. It is also the reason the eventual PS6 answer is *fewer,
+larger* nodes rather than more of these.
+
+## Why the planner warns instead of refusing
+
+A slow plan is still a plan. Warnings cover: assumed model configuration,
+inter-shelf hop count, NVMe streaming volume, cross-shelf expert spill, and
+shelves left with no layers. A `PlanningError` is raised only when the weights
+genuinely do not fit in the tiers the planner was allowed to use, and the
+message says what would fix it (more fast-coffer consoles, or a shorter
+context).
+
+## Failure behaviour
+
+- **An expert-only console dies**: its batch is retried on a replica that holds
+  *all* of the failed batch's experts, since a partial replica would silently
+  drop terms from the sum. Where no such replica exists, the token fails
+  visibly rather than quietly losing experts.
+- **A shelf host dies**: no failover. The MLA KV cache for those layers exists
+  only there, so continuing would produce a fluent, wrong continuation. The
+  request fails and the session must be replayed elsewhere.
+
+## Status of every number here
+
+**Measured on the x86-64 build host** (not a console): CPU kernel 67 GFLOP/s /
+134 GB/s effective; SPIR-V compiles and passes `spirv-val`; 159 Python tests
+pass.
+
+**Estimated**: all console throughput. Datasheet bandwidth, derated, plus hop
+and NVMe terms.
+
+**Assumed**: the V4 Pro configuration itself, marked as such in every output.
+
+**Not attempted**: execution on a PS5, an Xbox, or a BC-250.

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -5,24 +5,30 @@ claim.
 
 ## The problem
 
-DeepSeek V4 Pro, on the assumed configuration in `model.py`, is **1345 GiB of
-FP8 weights**. The largest console in this family has 16 GB of RAM, of which
-about 13 GB is reachable. So the model needs ~104 consoles just to be *stored*,
-before anything runs.
+DeepSeek V4 Pro is **803 GiB** — 1.6 T parameters, but MXFP4 experts and FP8
+everywhere else come to 0.54 bytes each. The largest console in this family has
+16 GB of RAM, of which about 13 GB is reachable, so the model needs ~62
+consoles just to be *stored* and 73 once each shelf host also has to hold its
+layers' hot blocks and cache.
 
 What makes this tractable rather than absurd is that MoE decode touches almost
 none of it:
 
 | per token, per MoE layer | size |
 |---|---|
-| attention (MLA, incl. LoRA projections) | ~180 MiB |
-| router + shared expert | ~121 MiB |
-| 8 routed experts of 384 | ~396 MiB |
-| **total read** | **~700 MiB** |
-| stored but untouched | ~18.2 GiB |
+| attention (CSA layer, incl. indexer and grouped output) | ~353 MiB |
+| attention (HCA layer) | ~290 MiB |
+| router + shared expert | ~36 MiB |
+| 6 routed experts of 384 | ~201 MiB |
+| **total read** | **~530-590 MiB** |
+| stored but untouched | ~12.4 GiB |
 
-52 of 1359 billion parameters activate. The other 96% has to be held somewhere
+50 of 1600 billion parameters activate. The other 97% has to be held somewhere
 with an address, and that is precisely what a stack of consoles is good for.
+
+V4 Flash is the same architecture at a fifth of the scale — 148 GiB, 43 layers,
+256 experts — and its floor is **20 PS5s**, which is the first point in this
+family where the fleet is a shelf rather than a rack.
 
 ## The four decisions
 
@@ -34,7 +40,7 @@ shelf's slowest member sets the floor for every layer it owns: one shelf
 inheriting all the Series X units and another all the Series S ones would make
 the second shelf's layers permanently the slow ones.
 
-A shelf is the *expert fan-out group*. A token's top-8 experts for a layer
+A shelf is the *expert fan-out group*. A token's top-6 experts for a layer
 should be answerable inside one shelf, so a layer costs one fan-out and one
 gather, not a tour of the fleet.
 
@@ -49,7 +55,7 @@ blocks and have to be placed like any other.
 
 One member of each shelf is the **host**. It holds, for that shelf's layers:
 
-- attention weights and the MLA KV cache,
+- attention weights and that layer's KV cache,
 - the router,
 - the shared expert (always on, so it must never be a network hop),
 - the layer norms.
@@ -58,16 +64,23 @@ A host must have both the room and ≥200 GB/s (`HOT_BANDWIDTH_FLOOR_GBPS`). Tha
 floor is why a 4700S — a PS5 die with the GPU fused off, its GDDR6 measuring
 92.9 GB/s from the CPU — can hold cold experts but is never chosen as a host.
 
-The MLA compressed KV cache is what makes an 8k context affordable: rank 512
-instead of 160 full heads is ~9 MiB per layer per 8k tokens rather than ~160.
-Without it the KV cache alone would evict the weights.
+Compressed attention is what makes long context affordable, and in V4 it is
+compressed along the *sequence*: a CSA layer folds every 4 tokens into one
+512-wide shared-KV entry and an HCA layer every 128, so the whole cache at a
+million tokens is 8.2 GiB rather than the 65 GiB V3's MLA would need — and at
+8k it is 74 MiB, small enough that context is not what decides the fleet size.
+
+The two kinds are interleaved, so **neighbouring layers differ by 32x in cache
+size** and the planner sizes each block separately (`block_kv_bytes`). Sizing
+from an average would under-provision every CSA host and waste room on every
+HCA one.
 
 ### 3. Routed experts
 
 Spread across the shelf's members, weighted by throughput — measured where the
 inventory gives a figure, nominal otherwise. An equal split would make the
 slowest console in the shelf the tail latency of every token that routes to it,
-and with top-8 across 22 consoles, most tokens touch a slow one.
+and with top-6 across 22 consoles, most tokens touch a slow one.
 
 ### 4. Overflow
 
@@ -84,26 +97,33 @@ letting the kernel do it.
 Per token, the estimate sums:
 
 - per block: `hot_bytes / (host bandwidth × efficiency)`,
+- per block: the KV the block has to *read*, which under CSA is not the KV it
+  holds — the FP4 indexer scans every compressed entry but attention then reads
+  only the 1024 it selected, so a million-token CSA layer reads ~17 MiB of a
+  260 MiB cache. Treating residency as the read cost would overstate
+  long-context decode by an order of magnitude,
 - per block: the slowest expert console's `expert_bytes / bandwidth`, since the
   fan-out is concurrent and the gather waits for the last reply,
 - NVMe reads where experts live there,
 - `(n_shelves − 1) × hop_seconds` for crossing between shelves.
 
 `BANDWIDTH_EFFICIENCY` derates each backend from datasheet peak. Hop cost
-defaults to 250 µs, which is a plausible switched-gigabit round trip for a
-16 KiB activation and is the single most consequential guess in the model.
+defaults to 250 µs, which is a plausible switched-gigabit round trip — for V4
+that activation is 56 KiB rather than 14, because hyper-connections make the
+residual stream four times hidden-wide and a pipeline boundary has to carry all
+of it. The hop cost is still the single most consequential guess in the model.
 
 Worked example, 100 PS5 + 40 Series X + 30 BC-250:
 
 ```
-deepseek-v4-pro (ASSUMED CONFIGURATION) on 170 consoles in 8 shelves
+deepseek-v4-pro on 170 consoles in 8 shelves
   context               8192 tokens
-  decode estimate       9.42 tok/s (106 ms/token)
-  consoles per layer    ~8 lit by one token
-  streamed from NVMe    6.0 GiB of experts
+  decode estimate       10.84 tok/s (92 ms/token)
+  consoles per layer    ~6 lit by one token
+  streamed from NVMe    3.0 GiB of experts
 ```
 
-Seven inter-shelf hops cost ~1.8 ms of the 106 ms, so this configuration is
+Seven inter-shelf hops cost ~1.8 ms of the 92 ms, so this configuration is
 memory-bandwidth-bound rather than network-bound. That flips if the fleet is
 built from many small consoles: 300 Series S units would be 14 shelves and the
 hops start to matter. It is also the reason the eventual PS6 answer is *fewer,
@@ -124,7 +144,7 @@ context).
   *all* of the failed batch's experts, since a partial replica would silently
   drop terms from the sum. Where no such replica exists, the token fails
   visibly rather than quietly losing experts.
-- **A shelf host dies**: no failover. The MLA KV cache for those layers exists
+- **A shelf host dies**: no failover. The KV cache for those layers exists
   only there, so continuing would produce a fluent, wrong continuation. The
   request fails and the session must be replayed elsewhere.
 
@@ -137,6 +157,10 @@ pass.
 **Estimated**: all console throughput. Datasheet bandwidth, derated, plus hop
 and NVMe terms.
 
-**Assumed**: the V4 Pro configuration itself, marked as such in every output.
+**Read from the model cards**: both V4 configurations, checked in the tests
+against their published parameter counts. How those fields become bytes — the
+per-layer weight terms, and the split between cache held and cache read — is
+this repository's reading of the paper, validated on the totals rather than
+term by term.
 
 **Not attempted**: execution on a PS5, an Xbox, or a BC-250.

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -55,8 +55,8 @@ One member of each shelf is the **host**. It holds, for that shelf's layers:
 - the layer norms.
 
 A host must have both the room and ≥200 GB/s (`HOT_BANDWIDTH_FLOOR_GBPS`). That
-floor is why a 4700S — same silicon as a Series X, GPU fused off, ~112 GB/s —
-can hold cold experts but is never chosen as a host.
+floor is why a 4700S — a PS5 die with the GPU fused off, its GDDR6 measuring
+92.9 GB/s from the CPU — can hold cold experts but is never chosen as a host.
 
 The MLA compressed KV cache is what makes an 8k context affordable: rank 512
 instead of 160 full heads is ~9 MiB per layer per 8k tokens rather than ~160.

--- a/gen9-cluster/docs/REFERENCES.md
+++ b/gen9-cluster/docs/REFERENCES.md
@@ -4,17 +4,43 @@ What this design borrows, and from whom. Grouped by what it was borrowed *for*.
 
 ## The model
 
+- **DeepSeek-V4.** DeepSeek-AI, 2026.
+  [arXiv:2606.19348](https://arxiv.org/abs/2606.19348).
+  The architecture both V4 profiles implement: conv-compressed self-attention
+  (CSA) interleaved with hyper-compressed attention (HCA) over shared KV
+  entries, a sliding-window branch on every layer, an FP4 lightning indexer
+  selecting which compressed entries a query attends to, manifold-constrained
+  hyper-connections widening the residual stream, hash-gated leading MoE
+  layers, and FP4 expert weights dequantised to FP8 for compute.
+  `HybridAttentionConfig` is this paper's attention; the per-layer weight terms
+  in `weight_params` are this repository's reading of it, checked against the
+  published parameter totals rather than term by term.
+- **DeepSeek-V4-Pro and DeepSeek-V4-Flash model cards.** DeepSeek-AI, 2026.
+  <https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro> and
+  <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash>.
+  The `config.json` of each is the source of every field in `DEEPSEEK_V4_PRO`
+  and `DEEPSEEK_V4_FLASH`, including the verbatim `compress_ratios` schedule
+  that tells the planner which layers are CSA, which are HCA, and which are
+  pure sliding window. Earlier revisions of this stack extrapolated V4 Pro from
+  V3 and were wrong in nearly every field; the profiles are no longer marked
+  `assumed`, and the tests pin them to the cards' 1.6 T / 49 B and 284 B / 13 B.
 - **DeepSeek-V3 Technical Report.** DeepSeek-AI, 2024.
   [arXiv:2412.19437](https://arxiv.org/abs/2412.19437).
-  The source of the decoder shape this stack extrapolates from: MLA,
-  DeepSeekMoE with fine-grained routed experts plus an always-on shared expert,
-  auxiliary-loss-free load balancing, multi-token prediction, and native FP8
-  training. `model.py`'s `deepseek-v3` profile is this paper's configuration;
-  `deepseek-v4-pro` is an extrapolation and is marked as such in every output.
+  MLA, DeepSeekMoE with fine-grained routed experts plus an always-on shared
+  expert, auxiliary-loss-free load balancing, multi-token prediction, and
+  native FP8 training. `model.py`'s `deepseek-v3` profile is this paper's
+  configuration, and it is the calibration case: its published parameter counts
+  are what the sizing arithmetic is checked against.
 - **DeepSeek-V2.** DeepSeek-AI, 2024.
   [arXiv:2405.04434](https://arxiv.org/abs/2405.04434).
   Introduces multi-head latent attention. The compressed KV cache is why an 8k
   context is affordable here at all — see `MLAConfig.kv_cache_bytes_per_token`.
+- **OCP Microscaling Formats (MX) Specification v1.0.** Open Compute Project,
+  2023.
+  <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>
+  E2M1 values with one E8M0 scale per 32 elements. The scale is 6.25% on top of
+  the payload, which is the difference between 0.5 and 0.53125 bytes per expert
+  parameter and, at 1.6 T parameters, about 46 GiB — four consoles.
 - **DeepSeekMoE.** Dai et al., 2024.
   [arXiv:2401.06066](https://arxiv.org/abs/2401.06066).
   Fine-grained expert segmentation and shared-expert isolation. Small experts

--- a/gen9-cluster/docs/REFERENCES.md
+++ b/gen9-cluster/docs/REFERENCES.md
@@ -1,0 +1,129 @@
+# References and prior work
+
+What this design borrows, and from whom. Grouped by what it was borrowed *for*.
+
+## The model
+
+- **DeepSeek-V3 Technical Report.** DeepSeek-AI, 2024.
+  [arXiv:2412.19437](https://arxiv.org/abs/2412.19437).
+  The source of the decoder shape this stack extrapolates from: MLA,
+  DeepSeekMoE with fine-grained routed experts plus an always-on shared expert,
+  auxiliary-loss-free load balancing, multi-token prediction, and native FP8
+  training. `model.py`'s `deepseek-v3` profile is this paper's configuration;
+  `deepseek-v4-pro` is an extrapolation and is marked as such in every output.
+- **DeepSeek-V2.** DeepSeek-AI, 2024.
+  [arXiv:2405.04434](https://arxiv.org/abs/2405.04434).
+  Introduces multi-head latent attention. The compressed KV cache is why an 8k
+  context is affordable here at all — see `MLAConfig.kv_cache_bytes_per_token`.
+- **DeepSeekMoE.** Dai et al., 2024.
+  [arXiv:2401.06066](https://arxiv.org/abs/2401.06066).
+  Fine-grained expert segmentation and shared-expert isolation. Small experts
+  are what make an expert a *unit of placement* small enough to fit a console;
+  the shared expert is why every shelf host must hold one locally.
+- **FP8-LM: Training FP8 Large Language Models.** Peng et al., 2023.
+  [arXiv:2310.18313](https://arxiv.org/abs/2310.18313).
+- **FP8 Formats for Deep Learning.** Micikevicius et al., 2022.
+  [arXiv:2209.05433](https://arxiv.org/abs/2209.05433).
+  The E4M3/E5M2 definitions. `kernels/fp8.c` and `gen9_cluster/fp8.py`
+  implement E4M3FN as used by DeepSeek's checkpoints and by
+  `torch.float8_e4m3fn`.
+
+## Running big MoE models on hardware that should not fit them
+
+- **KTransformers.** KVCache-AI / Tsinghua MADSys.
+  <https://github.com/kvcache-ai/ktransformers>.
+  The CPU/GPU hybrid MoE playbook this stack applies across machines instead of
+  within one: keep attention, router and shared expert on the fast device, keep
+  routed experts on the slow large device, move activations rather than
+  weights. The shelf-host/expert-member division in `planner.py` is this idea
+  with a network in the middle.
+- **llama.cpp** MoE CPU offload (`--n-cpu-moe`, `--override-tensor`).
+  <https://github.com/ggml-org/llama.cpp>.
+  Establishes that per-tensor placement across memory tiers is the practical
+  knob, and that mmap plus the page cache is a serviceable weight-streaming
+  tier. `ShardStore`'s mmap'd NVMe tier follows this rather than building an
+  expert cache with its own eviction policy.
+- **DeepSpeed-Inference / ZeRO-Inference.** Aminabadi et al., SC 2022.
+  [arXiv:2207.00032](https://arxiv.org/abs/2207.00032).
+  Pipeline plus expert parallelism across heterogeneous memory, and the
+  observation that MoE inference is bound by weight movement rather than FLOPs.
+- **FlexGen: High-Throughput Generative Inference with a Single GPU.**
+  Sheng et al., ICML 2023. [arXiv:2303.06865](https://arxiv.org/abs/2303.06865).
+  The GPU/CPU/disk tiering model behind the fast → slow → NVMe fallback order.
+- **Petals: Collaborative Inference of Large Models.** Borzunov et al., 2022.
+  [arXiv:2209.01188](https://arxiv.org/abs/2209.01188).
+  Pipeline stages over commodity nodes with a real network between them, and
+  the failure semantics that follow: a stateless stage can be re-routed, a
+  stage holding cache state cannot. `dispatch.py` and `coordinator.py` take the
+  same position for expert consoles versus shelf hosts.
+- **Mixtral of Experts.** Jiang et al., 2024.
+  [arXiv:2401.04088](https://arxiv.org/abs/2401.04088).
+  Expert-locality measurements motivating throughput-weighted placement.
+- **Fiddler**, Kamahori et al., 2024.
+  [arXiv:2402.07033](https://arxiv.org/abs/2402.07033), and
+  **MoE-Infinity**, Xue et al., 2024.
+  [arXiv:2401.14361](https://arxiv.org/abs/2401.14361).
+  Two treatments of expert activation skew — the reason NVMe-resident experts
+  are workable rather than uniformly fatal, since the page cache retains the
+  ones that are actually routed to.
+
+## RAM Coffers itself
+
+- **RAM Coffers: NUMA-Distributed Weight Banking.** Boudreaux, 2026.
+  [10.5281/zenodo.18321905](https://doi.org/10.5281/zenodo.18321905).
+  The parent architecture. This stack applies the coffer idea one level up: a
+  coffer becomes a console memory tier, and routing happens across consoles
+  rather than NUMA banks. See the repository root README.
+- The `kimi-k3-playstation3` branch of this repository, for the P3XC protocol
+  that G9XC descends from and for the shelf/coordinator structure. The
+  adaptations are documented in [G9XC.md](G9XC.md).
+
+## Console hardware
+
+Console silicon specifications are vendor-disclosed rather than measured here;
+figures in `hardware.py` are marked `UNVERIFIED` where that is the case.
+
+- **AMD RDNA 2 Instruction Set Architecture Reference Guide**, AMD, 2020, and
+  the RDNA 2 whitepaper — CU structure and clock behaviour for the GPUs in this
+  family.
+- **Zen 2 microarchitecture.** Suggs, Subramony & Bouvier, *IEEE Micro* 40(2),
+  2020. [doi:10.1109/MM.2020.2974217](https://doi.org/10.1109/MM.2020.2974217).
+  AVX2 without AVX-512, which is why `kernels/expert_avx2.c` targets FMA3/AVX2
+  and nothing wider.
+- **Hot Chips 32 (2020)**: the Xbox Series X SoC ("Scarlett") and PS5 SoC
+  presentations — CU counts, the Series X split 10 GB/6 GB memory topology, and
+  the PS5's variable-clock scheme.
+- Sony, *The Road to PS5* (2020) — 448 GB/s unified GDDR6, the 5.5 GB/s NVMe
+  and its decompression path.
+- **ps5-linux-loader** and the PS5 amdgpu (GFX1013) work.
+  <https://github.com/ps5-payload-dev>. Establishes what a PS5 node can
+  actually run: FW 3.00–7.61, phat and slim, amdgpu with GFX1013.
+- **BC-250**: the Sony Oberon-derived blade, and the community Linux/amdgpu
+  work on it. The member of this family whose GPU compute path is most
+  routinely exercised, hence its role in the fleet as the sanity check for the
+  Vulkan path.
+- AMD 4700S / 4800S desktop kits: console SoCs with the GPU fused off, GDDR6 as
+  system memory at greatly reduced effective bandwidth. Modelled as CPU-only
+  nodes with a large slow coffer.
+
+## Compute backends
+
+- **ROCm** on gfx1013. Debian's ROCm packaging does run on this target, but
+  library coverage is uneven: some libraries do not ship the target and others
+  fall back to a lower capability level because their build scripts assume a
+  higher gfx tier. This is why `ComputeBackend.ROCM.throughput_is_assumed` is
+  true and a ROCm node must supply `measured_gemv_gflops`.
+  `kernels/expert_hip.hip` avoids rocBLAS, Tensile and hipBLASLt for exactly
+  this reason.
+- **Mesa RADV** Vulkan compute — the default GPU path. No tuned-library
+  assumptions, and it is the driver the PS5 Linux work actually uses.
+- **Vulkan 1.1** compute shaders, `VK_KHR_8bit_storage` for the FP8 code path.
+
+## A note on attribution
+
+Where this stack does something the same way as one of the above, it is because
+that work established it, not because it was arrived at independently. The
+places where it diverges — batching a console's whole expert set into one
+frame, refusing to fail over a shelf host, requiring measured throughput for
+ROCm nodes — are diverging *from* these designs for reasons given in the code
+comments at each site.

--- a/gen9-cluster/docs/REFERENCES.md
+++ b/gen9-cluster/docs/REFERENCES.md
@@ -103,8 +103,21 @@ figures in `hardware.py` are marked `UNVERIFIED` where that is the case.
   routinely exercised, hence its role in the fleet as the sanity check for the
   Vulkan path.
 - AMD 4700S / 4800S desktop kits: console SoCs with the GPU fused off, GDDR6 as
-  system memory at greatly reduced effective bandwidth. Modelled as CPU-only
-  nodes with a large slow coffer.
+  system memory at greatly reduced effective bandwidth. Different harvests, not
+  revisions of each other — the 4700S is a PS5 "Ariel" die
+  ([Tom's Hardware teardown](https://www.tomshardware.com/reviews/amd-4700s-desktop-kit-review-ps5-cpu),
+  which also measures the GDDR6 at 92.9 GB/s copy and 145 ns), the 4800S a
+  Series X one
+  ([Digital Foundry](https://www.digitalfoundry.net/articles/digitalfoundry-2023-amd-4800s-desktop-kit-review-play-pc-games-on-the-xbox-series-x-cpu)).
+  Modelled as CPU-only nodes with a large slow coffer.
+
+  A card in the slot does not make either one a small PS5. Both slots are x4:
+  PCIe 2.0 x4 (~2 GB/s) on the 4700S, PCIe 4.0 x4 (~7.9 GB/s) on the 4800S. A
+  GPU there can only run experts that fit in its own VRAM, because reaching the
+  board's 15 GB across that link is two orders of magnitude slower than the
+  console memory the design assumes. Supporting it properly needs a memory model
+  where a tier's bandwidth depends on which backend is reading it — the same
+  change the Steam Machine's split GDDR6/DDR5 would need, and not yet made.
 
 ## Compute backends
 

--- a/gen9-cluster/gen9_cluster/__init__.py
+++ b/gen9-cluster/gen9_cluster/__init__.py
@@ -1,0 +1,40 @@
+"""DeepSeek MoE inference across ninth-generation console hardware.
+
+A fleet of PlayStation 5s, Xbox Series X/S consoles, and the salvage boards
+built from the same silicon (AMD 4700S/4800S, BC-250), running one DeepSeek
+model between them under the RAM Coffers memory-tier model.
+
+The pieces, in the order they are used:
+
+``hardware``    console SKUs, per-unit downbinning, memory coffers, backends
+``model``       DeepSeek profiles and the sizes derived from them
+``planner``     what goes on which console, and what that should cost
+``protocol``    the G9XC wire format
+``transport``   persistent multiplexed connections
+``node``        the console-side worker
+``dispatch``    per-layer expert fan-out and reduction
+``coordinator`` shelf and fleet drivers
+``inventory``   fleet files, probing, and plan/config generation
+"""
+
+from .hardware import (BOARD_TO_SKU, SKUS, ComputeBackend, ConsoleSKU,
+                       ConsoleUnit, Downbin, EffectiveCapability, MemoryTier,
+                       Runtime, StorageSpec, FleetSummary, fleet_summary,
+                       sku_for)
+from .model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_PRO, PROFILES,
+                    MLAConfig, ModelProfile, MoEConfig, profile_for)
+from .planner import (PlanningError, SplitPlan, StagePlan, UnitPlan,
+                      describe_plan, plan_split)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "BOARD_TO_SKU", "SKUS", "ComputeBackend", "ConsoleSKU", "ConsoleUnit",
+    "Downbin", "EffectiveCapability", "MemoryTier", "Runtime", "StorageSpec",
+    "FleetSummary", "fleet_summary", "sku_for",
+    "DEEPSEEK_TINY", "DEEPSEEK_V3", "DEEPSEEK_V4_PRO", "PROFILES", "MLAConfig",
+    "ModelProfile", "MoEConfig", "profile_for",
+    "PlanningError", "SplitPlan", "StagePlan", "UnitPlan", "describe_plan",
+    "plan_split",
+    "__version__",
+]

--- a/gen9-cluster/gen9_cluster/__init__.py
+++ b/gen9-cluster/gen9_cluster/__init__.py
@@ -21,8 +21,10 @@ from .hardware import (BOARD_TO_SKU, SKUS, ComputeBackend, ConsoleSKU,
                        ConsoleUnit, Downbin, EffectiveCapability, MemoryTier,
                        Runtime, StorageSpec, FleetSummary, fleet_summary,
                        sku_for)
-from .model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_PRO, PROFILES,
-                    MLAConfig, ModelProfile, MoEConfig, profile_for)
+from .model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_FLASH,
+                    DEEPSEEK_V4_PRO, PROFILES, AttentionConfig,
+                    HybridAttentionConfig, MLAConfig, ModelProfile, MoEConfig,
+                    QuantSpec, profile_for)
 from .planner import (PlanningError, SplitPlan, StagePlan, UnitPlan,
                       describe_plan, plan_split)
 
@@ -32,8 +34,9 @@ __all__ = [
     "BOARD_TO_SKU", "SKUS", "ComputeBackend", "ConsoleSKU", "ConsoleUnit",
     "Downbin", "EffectiveCapability", "MemoryTier", "Runtime", "StorageSpec",
     "FleetSummary", "fleet_summary", "sku_for",
-    "DEEPSEEK_TINY", "DEEPSEEK_V3", "DEEPSEEK_V4_PRO", "PROFILES", "MLAConfig",
-    "ModelProfile", "MoEConfig", "profile_for",
+    "DEEPSEEK_TINY", "DEEPSEEK_V3", "DEEPSEEK_V4_FLASH", "DEEPSEEK_V4_PRO",
+    "PROFILES", "AttentionConfig", "HybridAttentionConfig", "MLAConfig",
+    "ModelProfile", "MoEConfig", "QuantSpec", "profile_for",
     "PlanningError", "SplitPlan", "StagePlan", "UnitPlan", "describe_plan",
     "plan_split",
     "__version__",

--- a/gen9-cluster/gen9_cluster/__main__.py
+++ b/gen9-cluster/gen9_cluster/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/gen9-cluster/gen9_cluster/backends.py
+++ b/gen9-cluster/gen9_cluster/backends.py
@@ -1,0 +1,181 @@
+"""Binding the console-side kernels to the node worker.
+
+The node calls one thing — an :class:`~gen9_cluster.node.ExpertRunner` — and this
+module decides what is behind it. Selection is by what is actually installed on
+*this* console, not by what the inventory file claims, because the inventory is
+written by a human and the console is the authority on its own libraries.
+
+Order of preference on a given console:
+
+1. ``libgen9_cpu.so`` if it built here (AVX2, and on Zen 2 that is the ceiling).
+2. numpy, which is correct, portable, and slow enough that it should only ever
+   be a bring-up path.
+
+The GPU backends are deliberately *not* auto-selected. A Vulkan or HIP runner
+needs a device, a queue, a compiled pipeline, and a memory allocation strategy
+that outlives a single call; wiring that up belongs to the node's startup, and
+guessing at it here would produce a fleet where some consoles silently fell back
+to the CPU and nobody noticed until the plan's estimates stopped matching
+reality. :func:`describe_backends` reports what is available so a deployment can
+fail loudly instead.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import shutil
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from . import fp8
+from .node import ExpertRunner, ExpertWeights
+
+#: Where the Makefile leaves the CPU library.
+_DEFAULT_LIB = Path(__file__).resolve().parent.parent / "kernels" / "libgen9_cpu.so"
+
+
+class CpuKernelRunner(ExpertRunner):
+    """Runs experts through the AVX2 kernel in ``libgen9_cpu.so``."""
+
+    name = "cpu-avx2"
+
+    def __init__(self, library: Optional[Path] = None):
+        path = Path(library) if library else _DEFAULT_LIB
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{path} not built; run `make` in kernels/ (or pass a path)")
+        self._lib = ctypes.CDLL(str(path))
+        f32 = ctypes.POINTER(ctypes.c_float)
+        u8 = ctypes.POINTER(ctypes.c_uint8)
+        self._lib.gen9_expert_f32.argtypes = [f32, f32, f32, f32, f32, f32,
+                                              ctypes.c_int, ctypes.c_int]
+        self._lib.gen9_expert_f32.restype = None
+        self._lib.gen9_expert_fp8.argtypes = [u8, f32, u8, f32, u8, f32, f32,
+                                              f32, f32, ctypes.c_int,
+                                              ctypes.c_int]
+        self._lib.gen9_expert_fp8.restype = None
+        self._scratch: Optional[np.ndarray] = None
+
+    def __call__(self, activation: np.ndarray,
+                 experts: Sequence[ExpertWeights],
+                 gates: Sequence[float]) -> np.ndarray:
+        x = np.ascontiguousarray(activation, dtype=np.float32)
+        hidden = x.size
+        out = np.zeros(hidden, dtype=np.float32)
+        if not experts:
+            return out
+        intermediate = experts[0].gate.shape[0]
+        if self._scratch is None or self._scratch.size < 2 * intermediate:
+            self._scratch = np.zeros(2 * intermediate, dtype=np.float32)
+        scratch = self._scratch
+        partial = np.zeros(hidden, dtype=np.float32)
+
+        for weights, gate in zip(experts, gates):
+            if weights.quantised:
+                self._run_fp8(weights, x, partial, scratch, hidden,
+                              intermediate)
+            else:
+                self._run_f32(weights, x, partial, scratch, hidden,
+                              intermediate)
+            out += np.float32(gate) * partial
+        return out
+
+    def _run_f32(self, weights: ExpertWeights, x: np.ndarray,
+                 partial: np.ndarray, scratch: np.ndarray, hidden: int,
+                 intermediate: int) -> None:
+        # Bind the contiguous arrays to names first. Taking .ctypes on a
+        # temporary produced by ascontiguousarray inside the call would let that
+        # temporary be collected while the kernel is still reading through the
+        # pointer into it.
+        f32 = ctypes.POINTER(ctypes.c_float)
+        gate_w = _contiguous(weights.gate)
+        up_w = _contiguous(weights.up)
+        down_w = _contiguous(weights.down)
+        self._lib.gen9_expert_f32(
+            gate_w.ctypes.data_as(f32), up_w.ctypes.data_as(f32),
+            down_w.ctypes.data_as(f32), x.ctypes.data_as(f32),
+            partial.ctypes.data_as(f32), scratch.ctypes.data_as(f32),
+            ctypes.c_int(hidden), ctypes.c_int(intermediate))
+
+    def _run_fp8(self, weights: ExpertWeights, x: np.ndarray,
+                 partial: np.ndarray, scratch: np.ndarray, hidden: int,
+                 intermediate: int) -> None:
+        """The FP8 path: the kernel dequantises inline, so the weights are
+        never materialised at fp32 and the read is a quarter the bytes.
+
+        The C kernel indexes scales per row, which is the same layout as the
+        flat blocks in :mod:`gen9_cluster.fp8` exactly when the row length is a
+        whole number of 128-element blocks. Anything else is refused here
+        rather than read at the wrong offsets.
+        """
+        if weights.scales is None:
+            raise ValueError("FP8 expert arrived without block scales")
+        if hidden % fp8.BLOCK or intermediate % fp8.BLOCK:
+            raise ValueError(
+                f"the FP8 kernel needs both dimensions to be a multiple of "
+                f"{fp8.BLOCK}; got hidden={hidden}, "
+                f"intermediate={intermediate}")
+        f32 = ctypes.POINTER(ctypes.c_float)
+        u8 = ctypes.POINTER(ctypes.c_uint8)
+        gate_w = np.ascontiguousarray(weights.gate, dtype=np.uint8)
+        up_w = np.ascontiguousarray(weights.up, dtype=np.uint8)
+        down_w = np.ascontiguousarray(weights.down, dtype=np.uint8)
+        flat = np.ascontiguousarray(weights.scales, dtype=np.float32).reshape(-1)
+        per_matrix = fp8.n_blocks(hidden * intermediate)
+        gate_s = np.ascontiguousarray(flat[:per_matrix])
+        up_s = np.ascontiguousarray(flat[per_matrix:2 * per_matrix])
+        down_s = np.ascontiguousarray(flat[2 * per_matrix:3 * per_matrix])
+        self._lib.gen9_expert_fp8(
+            gate_w.ctypes.data_as(u8), gate_s.ctypes.data_as(f32),
+            up_w.ctypes.data_as(u8), up_s.ctypes.data_as(f32),
+            down_w.ctypes.data_as(u8), down_s.ctypes.data_as(f32),
+            x.ctypes.data_as(f32), partial.ctypes.data_as(f32),
+            scratch.ctypes.data_as(f32), ctypes.c_int(hidden),
+            ctypes.c_int(intermediate))
+
+
+def _contiguous(array: np.ndarray) -> np.ndarray:
+    """A C-contiguous fp32 view, copying only when the input is not one."""
+    return np.ascontiguousarray(array, dtype=np.float32)
+
+
+def select_runner(prefer: Optional[str] = None) -> ExpertRunner:
+    """Pick the best runner this console can actually use.
+
+    ``prefer`` names a backend from the inventory; if it is unavailable here the
+    fallback is used and the caller can see the difference in
+    :attr:`ExpertRunner.name`, which the node reports in its STATUS reply. That
+    is how a fleet notices that one console has quietly become four times slower
+    than its plan assumed.
+    """
+    if prefer in (None, "cpu-avx2"):
+        try:
+            return CpuKernelRunner()
+        except (FileNotFoundError, OSError):
+            return ExpertRunner()
+    # Vulkan/HIP runners are constructed explicitly by the node's startup with
+    # a device and pipeline; there is nothing safe to auto-select here.
+    try:
+        return CpuKernelRunner()
+    except (FileNotFoundError, OSError):
+        return ExpertRunner()
+
+
+def describe_backends() -> List[str]:
+    """What compute paths exist on this machine, for ``g9-probe``."""
+    lines = []
+    lines.append(f"cpu kernel     {'built' if _DEFAULT_LIB.exists() else 'not built'}"
+                 f" ({_DEFAULT_LIB})")
+    spv = _DEFAULT_LIB.parent / "expert.comp.spv"
+    lines.append(f"vulkan shader  {'compiled' if spv.exists() else 'not compiled'}")
+    vulkaninfo = shutil.which("vulkaninfo")
+    lines.append(f"vulkaninfo     {vulkaninfo or 'absent'}")
+    hip = _DEFAULT_LIB.parent / "libgen9_hip.so"
+    lines.append(f"hip kernel     {'built' if hip.exists() else 'not built'}")
+    lines.append(f"hipcc          {shutil.which('hipcc') or 'absent'}")
+    lines.append(f"rocminfo       {shutil.which('rocminfo') or 'absent'}")
+    lines.append(f"cpu threads    {os.cpu_count()}")
+    return lines

--- a/gen9-cluster/gen9_cluster/backends.py
+++ b/gen9-cluster/gen9_cluster/backends.py
@@ -59,28 +59,28 @@ class CpuKernelRunner(ExpertRunner):
         self._lib.gen9_expert_fp8.restype = None
         self._scratch: Optional[np.ndarray] = None
 
-    def __call__(self, activation: np.ndarray,
-                 experts: Sequence[ExpertWeights],
-                 gates: Sequence[float]) -> np.ndarray:
+    def rows(self, activation: np.ndarray,
+             experts: Sequence[ExpertWeights],
+             gates: Sequence[float]) -> np.ndarray:
         x = np.ascontiguousarray(activation, dtype=np.float32)
         hidden = x.size
-        out = np.zeros(hidden, dtype=np.float32)
+        out = np.empty((len(experts), hidden), dtype=np.float32)
         if not experts:
             return out
         intermediate = experts[0].gate.shape[0]
         if self._scratch is None or self._scratch.size < 2 * intermediate:
             self._scratch = np.zeros(2 * intermediate, dtype=np.float32)
         scratch = self._scratch
-        partial = np.zeros(hidden, dtype=np.float32)
 
-        for weights, gate in zip(experts, gates):
+        for index, (weights, gate) in enumerate(zip(experts, gates)):
+            # A row of a C-contiguous array is itself contiguous, so the kernel
+            # writes its expert's output straight into place.
+            row = out[index]
             if weights.quantised:
-                self._run_fp8(weights, x, partial, scratch, hidden,
-                              intermediate)
+                self._run_fp8(weights, x, row, scratch, hidden, intermediate)
             else:
-                self._run_f32(weights, x, partial, scratch, hidden,
-                              intermediate)
-            out += np.float32(gate) * partial
+                self._run_f32(weights, x, row, scratch, hidden, intermediate)
+            row *= np.float32(gate)
         return out
 
     def _run_f32(self, weights: ExpertWeights, x: np.ndarray,

--- a/gen9-cluster/gen9_cluster/cli.py
+++ b/gen9-cluster/gen9_cluster/cli.py
@@ -1,0 +1,272 @@
+"""Command line: ``python -m gen9_cluster <command>``.
+
+Five commands, matching the five things an operator does:
+
+``model``   what a checkpoint costs, before any hardware exists
+``size``    how many consoles of each kind would be needed
+``plan``    place a model on a real inventory, and say what it should run at
+``probe``   measure what *this* console can do, and write it back
+``serve``   run the node worker on a console
+``health``  ask a planned fleet what it thinks it is
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from . import __version__
+from .backends import describe_backends, select_runner
+from .hardware import GB, fleet_summary, SKUS
+from .inventory import (addresses, deployment_config, load_fleet,
+                        save_fleet, synthetic_fleet, units)
+from .model import PROFILES, describe, profile_for
+from .planner import PlanningError, describe_plan, plan_split
+
+
+def _add_plan_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--model", default="deepseek-v4-pro",
+                        choices=sorted(PROFILES),
+                        help="model profile to place")
+    parser.add_argument("--context", type=int, default=8192,
+                        help="context length the KV cache must hold")
+    parser.add_argument("--shelf-size", type=int, default=22,
+                        help="consoles per shelf (the expert fan-out group)")
+    parser.add_argument("--no-ssd", action="store_true",
+                        help="refuse to place experts on NVMe")
+    parser.add_argument("--hop-ms", type=float, default=0.25,
+                        help="one-way network hop, in milliseconds")
+
+
+def cmd_model(args: argparse.Namespace) -> int:
+    for name in ([args.model] if args.model else sorted(PROFILES)):
+        print("\n".join(describe(profile_for(name))))
+        print()
+    return 0
+
+
+def cmd_size(args: argparse.Namespace) -> int:
+    """Answer "how many consoles?" before anyone has bought any."""
+    profile = profile_for(args.model)
+    given = vars(args)
+    counts = {sku: given.get(sku.replace("-", "_")) or 0 for sku in SKUS}
+    counts = {sku: n for sku, n in counts.items() if n}
+    if not counts:
+        print("give at least one --<sku> count, e.g. --ps5 40 --xbox-series-x 20",
+              file=sys.stderr)
+        return 2
+    fleet = synthetic_fleet(counts)
+    print(f"total weights: {profile.total_bytes() / GB:.1f} GiB "
+          f"({profile.name}"
+          + (", ASSUMED CONFIGURATION" if profile.assumed else "") + ")")
+    print("\n".join(_fleet_capacity_lines(fleet)))
+    try:
+        plan = plan_split(profile, units(fleet), context_tokens=args.context,
+                          shelf_size=args.shelf_size,
+                          allow_ssd_tier=not args.no_ssd,
+                          hop_seconds=args.hop_ms / 1000.0)
+    except PlanningError as exc:
+        print(f"\nDOES NOT FIT: {exc}")
+        return 1
+    print()
+    print("\n".join(describe_plan(plan, per_console=False)))
+    return 0
+
+
+def _fleet_capacity_lines(fleet) -> List[str]:
+    summary = fleet_summary(units(fleet))
+    lines = [f"fleet: {summary.units} consoles, "
+             f"{summary.weight_bytes / GB:.1f} GiB usable for weights "
+             f"({summary.fast_bytes / GB:.1f} GiB of it in fast coffers), "
+             f"{summary.gemv_gflops:.0f} GFLOP/s nominal"]
+    for sku, count in sorted(summary.by_sku.items()):
+        lines.append(f"  {count:>4} x {sku}")
+    return lines
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    fleet = load_fleet(Path(args.fleet))
+    profile = profile_for(args.model)
+    try:
+        plan = plan_split(profile, units(fleet), context_tokens=args.context,
+                          shelf_size=args.shelf_size,
+                          allow_ssd_tier=not args.no_ssd,
+                          hop_seconds=args.hop_ms / 1000.0)
+    except PlanningError as exc:
+        print(f"cannot place {profile.name} on this fleet: {exc}",
+              file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(plan.to_dict(), indent=2))
+    else:
+        print("\n".join(describe_plan(plan)))
+    if args.config:
+        Path(args.config).write_text(
+            json.dumps(deployment_config(plan, fleet), indent=2) + "\n")
+        print(f"\ndeployment config written to {args.config}")
+    return 0
+
+
+def cmd_probe(args: argparse.Namespace) -> int:
+    """Measure this console, rather than trusting the datasheet.
+
+    Any node the planner cannot predict — every ROCm node, anything with an
+    unusual downbin — should be probed and its number written into the
+    inventory. The plan is only as honest as its slowest assumption.
+    """
+    print(f"gen9-cluster {__version__} probe")
+    print("\n".join(describe_backends()))
+
+    runner = select_runner(args.backend)
+    hidden, intermediate = args.hidden, args.intermediate
+    rng = np.random.default_rng(0)
+    from .node import ExpertWeights
+    weights = [ExpertWeights(
+        gate=rng.standard_normal((intermediate, hidden), dtype=np.float32),
+        up=rng.standard_normal((intermediate, hidden), dtype=np.float32),
+        down=rng.standard_normal((hidden, intermediate), dtype=np.float32))]
+    x = rng.standard_normal(hidden, dtype=np.float32)
+
+    runner(x, weights, [1.0])                       # warm the caches
+    started = time.perf_counter()
+    for _ in range(args.iterations):
+        runner(x, weights, [1.0])
+    elapsed = time.perf_counter() - started
+
+    flops = 2.0 * 3.0 * hidden * intermediate * args.iterations
+    gflops = flops / elapsed / 1e9
+    bytes_read = 3.0 * hidden * intermediate * 4.0 * args.iterations
+    print(f"\nrunner            {runner.name}")
+    print(f"expert shape      {hidden} x {intermediate}")
+    print(f"measured          {gflops:.1f} GFLOP/s, "
+          f"{bytes_read / elapsed / 1e9:.1f} GB/s, "
+          f"{elapsed / args.iterations * 1e3:.2f} ms/expert")
+
+    if args.write_fleet and args.unit_id:
+        path = Path(args.write_fleet)
+        fleet = load_fleet(path)
+        for entry in fleet:
+            if entry.unit.unit_id == args.unit_id:
+                entry.unit.measured_gemv_gflops = round(gflops, 1)
+                break
+        else:
+            print(f"unit {args.unit_id!r} is not in {path}", file=sys.stderr)
+            return 1
+        save_fleet(path, fleet)
+        print(f"wrote measured_gemv_gflops={gflops:.1f} for {args.unit_id} "
+              f"into {path}")
+    return 0
+
+
+def cmd_serve(args: argparse.Namespace) -> int:
+    """Run the node worker, loading whatever the deployment config assigns."""
+    from .node import NodeServer, ShardStore
+
+    config = json.loads(Path(args.config).read_text())
+    node_config = config["nodes"].get(args.unit_id)
+    if node_config is None:
+        print(f"{args.unit_id!r} has no section in {args.config}",
+              file=sys.stderr)
+        return 1
+    store = ShardStore(capacity_bytes=node_config.get("capacity_bytes", 0))
+    runner = select_runner(node_config.get("backend"))
+    server = NodeServer(store, unit_id=args.unit_id, host=args.host,
+                        port=args.port or node_config.get("port", 9713),
+                        runner=runner, sku=node_config.get("sku", "unknown"),
+                        backend=node_config.get("backend", "cpu-avx2"))
+    shards = node_config.get("shards", [])
+    experts = sum(s["n_experts"] for s in shards)
+    print(f"{args.unit_id}: serving on {args.host}:{server.port}, "
+          f"{len(shards)} shards / {experts} experts assigned, "
+          f"{len(node_config.get('hot_layers', []))} hot layers, "
+          f"runner={runner.name}")
+    print("weights are loaded over G9XC by the coordinator (LOAD_SHARD)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping")
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    from .coordinator import FleetCoordinator
+
+    fleet = load_fleet(Path(args.fleet))
+    profile = profile_for(args.model)
+    plan = plan_split(profile, units(fleet), context_tokens=args.context,
+                      shelf_size=args.shelf_size)
+
+    def router(layer, state):
+        k = profile.moe.top_k
+        return list(range(k)), [1.0 / k] * k
+
+    with FleetCoordinator(plan, addresses(fleet), router=router) as fc:
+        for unit_id, status in fc.health().items():
+            print(f"{unit_id:<16} {status}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gen9_cluster",
+        description="DeepSeek inference across PS5 / Xbox Series / salvage "
+                    "console hardware")
+    parser.add_argument("--version", action="version",
+                        version=f"gen9-cluster {__version__}")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_model = sub.add_parser("model", help="size a model profile")
+    p_model.add_argument("--model", default=None, choices=sorted(PROFILES))
+    p_model.set_defaults(func=cmd_model)
+
+    p_size = sub.add_parser("size", help="how many consoles would be needed")
+    _add_plan_arguments(p_size)
+    for sku in sorted(SKUS):
+        p_size.add_argument(f"--{sku}", type=int, default=0,
+                            dest=sku.replace("-", "_"),
+                            help=f"number of {sku} consoles")
+    p_size.set_defaults(func=cmd_size)
+
+    p_plan = sub.add_parser("plan", help="place a model on an inventory")
+    p_plan.add_argument("fleet", help="inventory JSON")
+    _add_plan_arguments(p_plan)
+    p_plan.add_argument("--json", action="store_true", help="emit the raw plan")
+    p_plan.add_argument("--config", help="write a deployment config here")
+    p_plan.set_defaults(func=cmd_plan)
+
+    p_probe = sub.add_parser("probe", help="measure this console")
+    p_probe.add_argument("--backend", default=None)
+    p_probe.add_argument("--hidden", type=int, default=4096)
+    p_probe.add_argument("--intermediate", type=int, default=1024)
+    p_probe.add_argument("--iterations", type=int, default=5)
+    p_probe.add_argument("--write-fleet", help="inventory to update in place")
+    p_probe.add_argument("--unit-id", help="which entry to update")
+    p_probe.set_defaults(func=cmd_probe)
+
+    p_serve = sub.add_parser("serve", help="run the node worker")
+    p_serve.add_argument("config", help="deployment config from `plan --config`")
+    p_serve.add_argument("unit_id")
+    p_serve.add_argument("--host", default="0.0.0.0")
+    p_serve.add_argument("--port", type=int, default=0)
+    p_serve.set_defaults(func=cmd_serve)
+
+    p_health = sub.add_parser("health", help="ask a fleet what it thinks it is")
+    p_health.add_argument("fleet")
+    _add_plan_arguments(p_health)
+    p_health.set_defaults(func=cmd_health)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gen9-cluster/gen9_cluster/coordinator.py
+++ b/gen9-cluster/gen9_cluster/coordinator.py
@@ -80,11 +80,15 @@ class ShelfCoordinator:
                  placement: Placement, router: Router,
                  pool: Optional[ConnectionPool] = None,
                  request_timeout: float = 10.0,
-                 dense_layers: int = 0):
+                 dense_layers: int = 0, fast: bool = False):
         self.stage = stage
         self.addresses = addresses
         self.router = router
         self.dense_layers = dense_layers
+        #: Off by default: see :mod:`gen9_cluster.dispatch` for what turning it
+        #: on costs. It saves reply bandwidth and makes the output depend on
+        #: the current plan.
+        self.fast = fast
         self.pool = pool or ConnectionPool()
         self.dispatcher = ExpertDispatcher(placement, addresses, pool=self.pool,
                                            request_timeout=request_timeout)
@@ -134,7 +138,8 @@ class ShelfCoordinator:
         #    economic argument for MoE on hardware like this.
         expert_ids, gates = self.router(layer, state)
         routed, stats = self.dispatcher.run_layer(layer, state, expert_ids,
-                                                  gates, token=token)
+                                                  gates, token=token,
+                                                  fast=self.fast)
         self._last_stats = stats
         return state + routed
 
@@ -143,7 +148,8 @@ class FleetCoordinator:
     """Chains shelves in layer order; the front door for a whole fleet."""
 
     def __init__(self, plan, addresses: Dict[str, NodeAddress], *,
-                 router: Router, request_timeout: float = 10.0):
+                 router: Router, request_timeout: float = 10.0,
+                 fast: bool = False):
         self.plan = plan
         self.addresses = addresses
         self.pool = ConnectionPool()
@@ -153,7 +159,7 @@ class FleetCoordinator:
             ShelfCoordinator(stage, addresses, placement=placement,
                              router=router, pool=self.pool,
                              request_timeout=request_timeout,
-                             dense_layers=dense)
+                             dense_layers=dense, fast=fast)
             for stage in plan.stages
         ]
 

--- a/gen9-cluster/gen9_cluster/coordinator.py
+++ b/gen9-cluster/gen9_cluster/coordinator.py
@@ -1,0 +1,215 @@
+"""Shelf and fleet coordinators: driving a token through the plan.
+
+Two levels, matching the two levels of the split:
+
+:class:`ShelfCoordinator` owns one shelf — a contiguous range of blocks, a host
+console holding their hot weights, and the members holding their routed experts.
+It runs its range end to end without talking to any other shelf.
+
+:class:`FleetCoordinator` chains the shelves. It hands the activation to shelf 0,
+takes what comes out, hands it to shelf 1, and so on. That is the *entire*
+inter-shelf protocol, and it is that small on purpose: one 32 KiB activation per
+boundary, no weights, no KV, no coordination barrier. The hierarchy exists for
+the same reason Condor's PS3 cluster had head nodes over subclusters — one
+coordinator cannot hold hundreds of sockets open and still make its latency
+budget, but it can hold eight.
+
+Fault behaviour is deliberately blunt and visible. A shelf whose host console
+dies cannot continue: the KV cache for its layers lived there, and inventing a
+replacement would mean silently answering with a different conversation. So the
+coordinator raises, names the console, and lets the operator decide — restart
+the shelf from a checkpointed KV cache, or re-plan without that console. Expert
+consoles, by contrast, are replaceable mid-token, because they hold nothing but
+weights.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .dispatch import (DispatchStats, ExpertDispatcher, NodeAddress, Placement,
+                       placement_from_plan)
+from .errors import Gen9Error
+from .protocol import Frame, MsgType, decode_vector, encode_vector
+from .transport import ConnectionPool
+
+#: Given a layer index and a hidden state, return (expert_ids, gate_weights).
+Router = Callable[[int, np.ndarray], Tuple[Sequence[int], Sequence[float]]]
+
+
+@dataclass
+class LayerTrace:
+    """Per-layer timing, which is the only way to find the slow console."""
+
+    layer: int
+    seconds: float
+    consoles: int
+    storage_hits: int
+    retries: int
+
+
+@dataclass
+class TokenTrace:
+    seconds: float = 0.0
+    layers: List[LayerTrace] = field(default_factory=list)
+
+    @property
+    def slowest(self) -> Optional[LayerTrace]:
+        return max(self.layers, key=lambda trace: trace.seconds) if self.layers else None
+
+    def summary(self) -> str:
+        worst = self.slowest
+        tail = (f", slowest layer {worst.layer} at {worst.seconds * 1000:.1f} ms"
+                if worst else "")
+        storage = sum(t.storage_hits for t in self.layers)
+        retries = sum(t.retries for t in self.layers)
+        return (f"{self.seconds * 1000:.0f} ms/token over {len(self.layers)} "
+                f"blocks{tail}"
+                + (f", {storage} NVMe hits" if storage else "")
+                + (f", {retries} retries" if retries else ""))
+
+
+class ShelfCoordinator:
+    """Drives the blocks assigned to one shelf."""
+
+    def __init__(self, stage, addresses: Dict[str, NodeAddress], *,
+                 placement: Placement, router: Router,
+                 pool: Optional[ConnectionPool] = None,
+                 request_timeout: float = 10.0,
+                 dense_layers: int = 0):
+        self.stage = stage
+        self.addresses = addresses
+        self.router = router
+        self.dense_layers = dense_layers
+        self.pool = pool or ConnectionPool()
+        self.dispatcher = ExpertDispatcher(placement, addresses, pool=self.pool,
+                                           request_timeout=request_timeout)
+        self.request_timeout = request_timeout
+        self._last_stats = DispatchStats()
+
+    def close(self) -> None:
+        self.dispatcher.close()
+
+    @property
+    def host_unit(self) -> str:
+        return self.stage.host_unit
+
+    def run(self, activation: np.ndarray, *, token: int = 0,
+            trace: Optional[TokenTrace] = None) -> np.ndarray:
+        """Run every block of this shelf's range over one activation."""
+        state = activation
+        for layer in self.stage.layers:
+            started = time.perf_counter()
+            state = self._run_block(layer, state, token)
+            stats = self._last_stats
+            if trace is not None:
+                trace.layers.append(LayerTrace(
+                    layer=layer, seconds=time.perf_counter() - started,
+                    consoles=stats.consoles_contacted,
+                    storage_hits=stats.storage_hits, retries=stats.retries))
+        return state
+
+    def _run_block(self, layer: int, activation: np.ndarray,
+                   token: int) -> np.ndarray:
+        # 1. The hot block runs on the shelf's host: attention against the KV
+        #    cache that lives there, the router, the always-on shared expert.
+        address = self.addresses[self.host_unit]
+        conn = self.pool.get(self.host_unit, address.host, address.port)
+        reply = conn.request(
+            Frame(MsgType.BLOCK_FWD, 0, encode_vector(activation), layer=layer,
+                  token=token), timeout=self.request_timeout)
+        state = decode_vector(reply.payload).astype(np.float32, copy=False)
+
+        # 2. Dense layers have no routed experts; the block is the whole layer.
+        if layer < self.dense_layers:
+            self._last_stats = DispatchStats(consoles_contacted=1)
+            return state
+
+        # 3. The router's choice decides which consoles are woken. Everything
+        #    else in the fleet stays idle for this token, which is the entire
+        #    economic argument for MoE on hardware like this.
+        expert_ids, gates = self.router(layer, state)
+        routed, stats = self.dispatcher.run_layer(layer, state, expert_ids,
+                                                  gates, token=token)
+        self._last_stats = stats
+        return state + routed
+
+
+class FleetCoordinator:
+    """Chains shelves in layer order; the front door for a whole fleet."""
+
+    def __init__(self, plan, addresses: Dict[str, NodeAddress], *,
+                 router: Router, request_timeout: float = 10.0):
+        self.plan = plan
+        self.addresses = addresses
+        self.pool = ConnectionPool()
+        placement = placement_from_plan(plan)
+        dense = _dense_layer_count(plan)
+        self.shelves = [
+            ShelfCoordinator(stage, addresses, placement=placement,
+                             router=router, pool=self.pool,
+                             request_timeout=request_timeout,
+                             dense_layers=dense)
+            for stage in plan.stages
+        ]
+
+    def close(self) -> None:
+        for shelf in self.shelves:
+            shelf.close()
+        self.pool.close()
+
+    def __enter__(self) -> "FleetCoordinator":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    def forward(self, activation: np.ndarray, *, token: int = 0
+                ) -> Tuple[np.ndarray, TokenTrace]:
+        """One token through every shelf, in order."""
+        trace = TokenTrace()
+        started = time.perf_counter()
+        state = np.asarray(activation, dtype=np.float32)
+        for shelf in self.shelves:
+            try:
+                state = shelf.run(state, token=token, trace=trace)
+            except Gen9Error as exc:
+                if exc.unit_id == shelf.host_unit:
+                    raise Gen9Error(
+                        f"shelf {shelf.stage.stage_id} lost its host console, "
+                        f"which held the KV cache for layers "
+                        f"{shelf.stage.first_layer}-"
+                        f"{shelf.stage.first_layer + shelf.stage.n_layers - 1}; "
+                        f"the shelf must be restarted, not failed over",
+                        unit_id=shelf.host_unit) from exc
+                raise
+        trace.seconds = time.perf_counter() - started
+        return state, trace
+
+    def health(self) -> Dict[str, str]:
+        """Ping every console named in the plan; report what answers."""
+        status: Dict[str, str] = {}
+        for unit_id, address in sorted(self.addresses.items()):
+            try:
+                conn = self.pool.get(unit_id, address.host, address.port)
+                reply = conn.request(Frame(MsgType.STATUS, 0), timeout=2.0)
+                status[unit_id] = reply.payload.decode("utf-8", "replace")
+            except Gen9Error as exc:
+                status[unit_id] = f"DOWN: {exc}"
+        return status
+
+
+def _dense_layer_count(plan) -> int:
+    """Recover the dense-layer count from the plan's own placement.
+
+    The first layer that has routed experts anywhere is the first MoE layer;
+    reading it off the plan avoids threading the model profile through the
+    runtime, which would only be used for this one number.
+    """
+    layers_with_experts = {shard.layer for unit in plan.units.values()
+                           for shard in unit.shards}
+    return min(layers_with_experts) if layers_with_experts else 0

--- a/gen9-cluster/gen9_cluster/dedup.py
+++ b/gen9-cluster/gen9_cluster/dedup.py
@@ -1,0 +1,273 @@
+"""Bounded batch-id dedup, so a retried expert batch runs once.
+
+A coordinator whose socket dies mid-batch cannot tell whether the node ran the
+experts before the connection went away or after. Re-sending is therefore
+*at-least-once execution*. For routed experts that is merely wasteful — the
+computation is a pure function of (activation, weights) and mutates nothing —
+but "merely wasteful" is a console-second on hardware that has single-digit
+tokens per second to give, and it is spent at exactly the moment the fleet is
+already in trouble.
+
+This cache turns it back into exactly-once. A batch carries a 64-bit
+``batch_id`` (:class:`~gen9_cluster.protocol.ExpertBatchPayload`); the node runs
+it under that id and remembers the encoded reply, so a retry of the same logical
+batch gets the first attempt's bytes rather than a second pass over the weights.
+A retry that arrives while the first attempt is still running *waits* for it
+instead of racing it, which also collapses the duplicate-work case that a
+coordinator with an over-eager timeout creates on a slow console.
+
+The cache binds each id to a fingerprint of the request content. A reused id
+carrying a different activation, layer, expert list or gate vector is a
+coordinator bug, and it is rejected rather than answered with a stale reply:
+replaying the wrong bytes would be a wrong token that no log would explain.
+
+Three bounds keep this from becoming unbounded per-token state on a console with
+10 GB of usable memory and a model to hold in it:
+
+* ``max_entries`` — at most this many logical batches tracked. When every
+  tracked batch is still running, a new one is refused with
+  :class:`DedupCapacityError` rather than evicting work in flight; completed
+  batches are evicted oldest-first to make room.
+* ``max_bytes`` — completed replies are counted precisely and evicted
+  least-recently-finished until a new one fits. A reply larger than the whole
+  budget is returned but not retained, so a later retry re-executes it.
+* ``ttl`` — a completed reply older than this is dropped on the next touch. A
+  retry after that re-executes, and is honestly at-least-once again.
+
+A retry that lands on a *different console* (the dispatcher's replica path)
+cannot be deduplicated without shared state, which this deliberately does not
+introduce. That case is safe for a different reason: the coordinator accepts one
+reply and discards the other, so the duplicate execution cannot reach the sum.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+#: Retained replies per node. A shelf coordinator has at most a few batches in
+#: flight per node at a time; this is generous enough to cover a burst of
+#: retries without being a memory decision anyone has to think about.
+DEFAULT_DEDUP_ENTRIES = 128
+
+#: How long a completed reply stays replayable, in seconds. Longer than any
+#: sane request timeout, short enough that a wedged fleet drains.
+DEFAULT_DEDUP_TTL = 60.0
+
+#: Total completed-reply byte budget. At V4-Pro width one exact reply is
+#: ``k`` rows of 32 KiB, so 32 MiB is a few hundred cached replies — noise
+#: against a coffer, and bounded whatever the traffic does.
+DEFAULT_DEDUP_BYTES = 32 * 1024 * 1024
+
+
+class MismatchedBatchError(ValueError):
+    """The same batch id arrived with different content."""
+
+
+class DedupCapacityError(RuntimeError):
+    """Every tracked batch is in flight; there is no room to start another."""
+
+
+def batch_fingerprint(layer: int, expert_ids: Sequence[int],
+                      gates: Sequence[float], activation: np.ndarray,
+                      fast: bool) -> bytes:
+    """A stable digest of everything that changes a batch's correct answer.
+
+    Deliberately includes ``fast``: the collapsed sum and the per-expert rows
+    are different bytes and different arithmetic, so serving one where the
+    other was asked for is not a cache hit.
+    """
+    digest = hashlib.sha256()
+    digest.update(b"g9xc-batch\x00")
+    digest.update(int(layer).to_bytes(4, "little"))
+    digest.update(b"\x01" if fast else b"\x00")
+    digest.update(len(expert_ids).to_bytes(4, "little"))
+    for expert in expert_ids:
+        digest.update(int(expert).to_bytes(4, "little"))
+    digest.update(np.ascontiguousarray(gates, dtype="<f4").tobytes())
+    digest.update(np.ascontiguousarray(activation, dtype="<f4").tobytes())
+    return digest.digest()
+
+
+class _Slot:
+    """One logical batch: in flight, then its reply bytes."""
+
+    __slots__ = ("done", "reply", "error", "started", "finished",
+                 "fingerprint", "cached", "size")
+
+    def __init__(self, fingerprint: bytes) -> None:
+        self.done = threading.Event()
+        self.reply: Optional[bytes] = None
+        self.error: Optional[BaseException] = None
+        self.started = time.monotonic()
+        self.finished: Optional[float] = None
+        self.fingerprint = fingerprint
+        self.cached = True          # False for errors and oversized replies
+        self.size = 0
+
+
+class DedupCache:
+    """Runs a batch at most once per ``(batch_id, fingerprint)``, within bounds."""
+
+    def __init__(self, max_entries: int = DEFAULT_DEDUP_ENTRIES,
+                 ttl: float = DEFAULT_DEDUP_TTL,
+                 max_bytes: int = DEFAULT_DEDUP_BYTES) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be >= 1")
+        if ttl <= 0:
+            raise ValueError("ttl must be > 0")
+        if max_bytes < 0:
+            raise ValueError("max_bytes must be >= 0")
+        self.max_entries = max_entries
+        self.ttl = ttl
+        self.max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._slots: Dict[int, _Slot] = {}
+        self._bytes = 0
+        #: Observability. The tests assert on these, and so should an operator
+        #: wondering why a shelf is doing more work than the plan says.
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+        self.expiries = 0
+        self.rejected = 0
+        self.oversized = 0
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._slots)
+
+    @property
+    def bytes_used(self) -> int:
+        with self._lock:
+            return self._bytes
+
+    def run(self, batch_id: Optional[int], fingerprint: bytes,
+            compute: Callable[[], bytes],
+            timeout: Optional[float] = None) -> Tuple[bytes, bool]:
+        """Return ``(reply_bytes, replayed)``, computing the reply at most once.
+
+        ``batch_id`` of ``None`` always computes: an unnamed batch has nothing
+        to deduplicate on.
+        """
+        if batch_id is None:
+            return compute(), False
+        with self._lock:
+            self._expire_locked()
+            existing = self._slots.get(batch_id)
+            if existing is not None:
+                if existing.fingerprint != fingerprint:
+                    raise MismatchedBatchError(
+                        f"batch id {batch_id} was reused with different "
+                        f"content; refusing to replay the first answer")
+                self.hits += 1
+            else:
+                if not self._reserve_locked():
+                    self.rejected += 1
+                    raise DedupCapacityError(
+                        f"all {self.max_entries} tracked batches are in flight")
+                self.misses += 1
+                slot = self._slots[batch_id] = _Slot(fingerprint)
+        # Deliberately outside the lock: waiting for someone else's batch must
+        # not stall every other batch on this console for the length of a
+        # kernel run.
+        if existing is not None:
+            return self._await(batch_id, existing, timeout), True
+        try:
+            reply = compute()
+        except BaseException as exc:            # noqa: BLE001 - re-raised
+            slot.error = exc
+            slot.finished = time.monotonic()
+            slot.cached = False
+            slot.done.set()
+            with self._lock:
+                self._slots.pop(batch_id, None)
+            raise
+        self._finish(batch_id, slot, reply)
+        return reply, False
+
+    def replay(self, batch_id: int) -> Optional[bytes]:
+        """The remembered reply for ``batch_id``, if it is still cached."""
+        with self._lock:
+            self._expire_locked()
+            slot = self._slots.get(batch_id)
+        if slot is None or not slot.done.is_set() or not slot.cached:
+            return None
+        return slot.reply
+
+    def clear(self) -> None:
+        with self._lock:
+            self._slots.clear()
+            self._bytes = 0
+
+    # -- internals ---------------------------------------------------------
+    def _await(self, batch_id: int, slot: _Slot,
+               timeout: Optional[float]) -> bytes:
+        """Wait for the attempt already running under this id."""
+        if not slot.done.wait(timeout):
+            raise TimeoutError(f"batch {batch_id} is still running from an "
+                               f"earlier attempt")
+        if slot.error is not None:
+            raise slot.error
+        if slot.reply is None:
+            raise RuntimeError(f"batch {batch_id} completed without a reply")
+        return slot.reply
+
+    def _reserve_locked(self) -> bool:
+        """Make room for one new batch without evicting anything in flight."""
+        while len(self._slots) >= self.max_entries:
+            victim = self._oldest_completed_locked()
+            if victim is None:
+                return False
+            self._drop_locked(victim)
+            self.evictions += 1
+        return True
+
+    def _finish(self, batch_id: int, slot: _Slot, reply: bytes) -> None:
+        slot.reply = reply
+        slot.finished = time.monotonic()
+        slot.size = len(reply)
+        slot.done.set()
+        with self._lock:
+            if slot.size > self.max_bytes:
+                # Too large to retain. Answer it, then forget it, so a later
+                # retry re-executes rather than the budget being blown by one
+                # outlier. Waiters already woken hold this reply.
+                slot.cached = False
+                self.oversized += 1
+                self._slots.pop(batch_id, None)
+                return
+            self._make_room_locked(slot.size)
+            self._bytes += slot.size
+
+    def _make_room_locked(self, needed: int) -> None:
+        while self._bytes + needed > self.max_bytes:
+            victim = self._oldest_completed_locked()
+            if victim is None:
+                break
+            self._drop_locked(victim)
+            self.evictions += 1
+
+    def _oldest_completed_locked(self) -> Optional[int]:
+        candidates: List[Tuple[float, int]] = [
+            (slot.finished, bid) for bid, slot in self._slots.items()
+            if slot.done.is_set() and slot.cached and slot.finished is not None]
+        return min(candidates)[1] if candidates else None
+
+    def _expire_locked(self) -> None:
+        cutoff = time.monotonic() - self.ttl
+        stale = [bid for bid, slot in self._slots.items()
+                 if slot.done.is_set() and slot.cached
+                 and slot.finished is not None and slot.finished < cutoff]
+        for bid in stale:
+            self._drop_locked(bid)
+            self.expiries += 1
+
+    def _drop_locked(self, batch_id: int) -> None:
+        slot = self._slots.pop(batch_id, None)
+        if slot is not None and slot.done.is_set() and slot.cached:
+            self._bytes = max(0, self._bytes - slot.size)

--- a/gen9-cluster/gen9_cluster/dispatch.py
+++ b/gen9-cluster/gen9_cluster/dispatch.py
@@ -5,25 +5,38 @@ token on the V4-Pro profile. Three decisions define it.
 
 **Group by console before sending.** A token's eight experts may live on three
 consoles. Naively that is eight requests; grouped, it is three, and each console
-returns the gate-weighted sum of the experts it holds. Round trips, not FLOPs,
-are what a console fleet is short of.
+answers for every expert it holds in one reply. Round trips, not FLOPs, are what
+a console fleet is short of.
 
-**Send concurrently, reduce deterministically.** The requests go out together
-and land in whatever order the network decides, but the partial sums are added
-back in a fixed order (by unit id). Floating-point addition is not associative,
-so reducing in arrival order would make the same prompt produce different
-tokens on different runs — a bug that is invisible until it is infuriating.
+**Send concurrently, reduce in top-k order.** The requests go out together and
+land in whatever order the network decides, but the reduction does not depend on
+the network *or on the placement*. Each console returns one row per expert,
+tagged with the expert it came from, and this module adds them strictly in the
+order the router ranked them — the same order, and therefore bit-for-bit the
+same sum, that a single machine holding all the experts would produce.
+
+Reducing by unit id instead would be reproducible run to run but not across
+plans: floating-point addition is not associative, so moving one expert to
+another console would silently change the logits and eventually the token. On a
+fleet of second-hand consoles, where a dead unit means a replan, that is a
+model whose output quietly depends on which console last failed.
+``fast=True`` accepts exactly that in exchange for the bandwidth.
 
 **Retry only what is safe to retry.** An expert evaluation mutates nothing, so a
 timeout or a dropped connection can be re-dispatched to a replica; the error
 types in :mod:`gen9_cluster.errors` carry that decision so this module never has
 to infer it from an errno. If no replica holds the expert, the dispatcher fails
 the token rather than silently dropping an expert from the sum — a quietly wrong
-answer is worse than a loud failure.
+answer is worse than a loud failure. Every attempt at a given batch reuses one
+``batch_id``, so a retry that reaches the *same* console (the common case: a
+timeout on a console that is merely slow) is answered from its dedup cache
+instead of running the experts twice.
 """
 
 from __future__ import annotations
 
+import itertools
+import secrets
 import threading
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -32,13 +45,28 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
-from .errors import Gen9Error, ShardMissing
-from .protocol import (ExpertBatchPayload, Flags, Frame, MsgType,
-                       decode_vector)
+from .errors import Gen9Error, ProtocolError, ShardMissing
+from .protocol import (ExpertBatchPayload, ExpertRowsPayload, Flags, Frame,
+                       MsgType, accumulate, decode_vector)
 from .transport import ConnectionPool, NodeConnection
 
 #: (layer, expert) -> the unit ids that hold it, best first.
 Placement = Dict[Tuple[int, int], List[str]]
+
+#: Key a FAST reply is filed under: it is one console's whole batch collapsed,
+#: so it belongs to no single expert. Negative, so it can never collide with a
+#: real expert id.
+_WHOLE_BATCH = -1
+
+#: Batch ids are drawn from a per-process random base and then counted up.
+#: Random so two coordinators (a restart, a standby taking over) cannot collide
+#: on a node's dedup cache and be served each other's answers; counted so the
+#: ids inside one process are cheap and unique.
+_BATCH_SEQUENCE = itertools.count(secrets.randbits(48) << 16)
+
+
+def _new_batch_id() -> int:
+    return next(_BATCH_SEQUENCE) % (1 << 64)
 
 
 @dataclass
@@ -56,6 +84,10 @@ class DispatchStats:
     experts_run: int = 0
     retries: int = 0
     storage_hits: int = 0
+    #: Replies a console served from its dedup cache instead of recomputing.
+    #: Non-zero means retries are landing back on the original console, which
+    #: is cheap; it is the *retries* count that costs a round trip.
+    replays: int = 0
     failed_units: List[str] = field(default_factory=list)
 
 
@@ -126,38 +158,69 @@ class ExpertDispatcher:
     # -- the hot path -----------------------------------------------------
     def run_layer(self, layer: int, activation: np.ndarray,
                   expert_ids: Sequence[int], gates: Sequence[float], *,
-                  token: int = 0) -> Tuple[np.ndarray, DispatchStats]:
-        """Run one MoE layer's routed experts and return their summed output."""
+                  token: int = 0,
+                  fast: bool = False) -> Tuple[np.ndarray, DispatchStats]:
+        """Run one MoE layer's routed experts and return their summed output.
+
+        ``expert_ids`` is the router's top-k *in rank order*, and that order is
+        the reduction order. With ``fast=False`` (the default) the result is
+        the same bits regardless of how the experts are spread over the shelf.
+        With ``fast=True`` each console collapses its own experts first, which
+        is fewer bytes on the wire and an answer that depends on the plan.
+        """
         stats = DispatchStats()
         batches = self.group_by_unit(layer, expert_ids, gates)
         stats.consoles_contacted = len(batches)
         stats.experts_run = len(expert_ids)
+        batch_id = _new_batch_id()
 
         futures = {
             unit: self._executor.submit(self._call_unit, unit, layer,
-                                        activation, ids, weights, token, stats)
+                                        activation, ids, weights, token, stats,
+                                        batch_id, fast)
             for unit, (ids, weights) in batches.items()
         }
-        partials: Dict[str, np.ndarray] = {}
+        replies: Dict[str, Dict[int, np.ndarray]] = {}
         errors: List[BaseException] = []
         for unit, future in futures.items():
             try:
-                partials[unit] = future.result()
+                replies[unit] = future.result()
             except BaseException as exc:                    # noqa: BLE001
                 errors.append(exc)
                 stats.failed_units.append(unit)
         if errors:
             raise errors[0]
 
-        # Deterministic reduction: sorted by unit id, never by arrival.
-        out = np.zeros_like(activation, dtype=np.float32)
-        for unit in sorted(partials):
-            out += partials[unit]
-        return out, stats
+        if fast:
+            # One partial per console, so top-k order is not recoverable and
+            # unit id is the only stable order left. Reproducible per plan,
+            # not across plans — which is what asking for FAST means.
+            return accumulate([replies[unit][_WHOLE_BATCH]
+                               for unit in sorted(replies)]), stats
+
+        by_expert: Dict[int, np.ndarray] = {}
+        for rows in replies.values():
+            by_expert.update(rows)
+        ordered = []
+        for expert in expert_ids:
+            row = by_expert.get(int(expert))
+            if row is None:
+                raise ProtocolError(
+                    f"no console returned a row for expert {int(expert)}; "
+                    f"the layer's sum would be missing a term", layer=layer,
+                    expert=int(expert))
+            ordered.append(row)
+        return accumulate(ordered), stats
 
     def _call_unit(self, unit: str, layer: int, activation: np.ndarray,
                    expert_ids: Sequence[int], gates: Sequence[float],
-                   token: int, stats: DispatchStats) -> np.ndarray:
+                   token: int, stats: DispatchStats, batch_id: int,
+                   fast: bool) -> Dict[int, np.ndarray]:
+        """One console's contribution, keyed by expert id.
+
+        A ``FAST`` reply has no per-expert structure, so it is returned under
+        :data:`_WHOLE_BATCH` and the caller reduces by unit id instead.
+        """
         attempted: List[str] = []
         target: Optional[str] = unit
         last: Optional[BaseException] = None
@@ -168,16 +231,19 @@ class ExpertDispatcher:
                 conn = self._connect(target)
                 payload = ExpertBatchPayload(tuple(int(e) for e in expert_ids),
                                              tuple(float(g) for g in gates),
-                                             activation).encode()
+                                             activation, batch_id).encode()
                 reply = conn.request(
                     Frame(MsgType.EXPERT_BATCH, 0, payload, layer=layer,
-                          token=token),
+                          token=token,
+                          flags=Flags.FAST if fast else Flags.NONE),
                     timeout=self.request_timeout)
                 if reply.flags & Flags.FROM_STORAGE:
                     stats.storage_hits += 1
+                if reply.flags & Flags.REPLAYED:
+                    stats.replays += 1
                 self._mark_up(target)
-                return decode_vector(reply.payload).astype(np.float32,
-                                                           copy=False)
+                return self._decode_reply(reply, target, layer, expert_ids,
+                                          fast)
             except Gen9Error as exc:
                 last = exc
                 self._mark_down(target)
@@ -193,6 +259,39 @@ class ExpertDispatcher:
                     raise
         assert last is not None
         raise last
+
+    def _decode_reply(self, reply: Frame, unit: str, layer: int,
+                      expert_ids: Sequence[int],
+                      fast: bool) -> Dict[int, np.ndarray]:
+        """Turn a console's reply into rows, checking it answered what we asked.
+
+        A node that returns a partial sum to a batch that did not set ``FAST``
+        is a version or configuration mismatch, and accepting it would produce
+        a plausible-looking number with the wrong arithmetic behind it. That is
+        precisely the failure this design exists to prevent, so it is refused.
+        """
+        per_expert = bool(reply.flags & Flags.PER_EXPERT)
+        if fast:
+            if per_expert:
+                raise ProtocolError(
+                    "console answered a FAST batch with per-expert rows",
+                    unit_id=unit, layer=layer)
+            return {_WHOLE_BATCH: decode_vector(reply.payload).astype(
+                np.float32, copy=False)}
+        if not per_expert:
+            raise ProtocolError(
+                "console collapsed a batch that did not ask for FAST; its "
+                "reduction order is unknown and its answer cannot be placed "
+                "in top-k order", unit_id=unit, layer=layer)
+        rows = ExpertRowsPayload.decode(reply.payload)
+        expected = {int(e) for e in expert_ids}
+        got = set(rows.expert_ids)
+        if got != expected:
+            raise ProtocolError(
+                f"console answered for experts {sorted(got)}, was asked for "
+                f"{sorted(expected)}", unit_id=unit, layer=layer)
+        return {int(eid): rows.rows[index]
+                for index, eid in enumerate(rows.expert_ids)}
 
     def _replica_for(self, layer: int, expert_ids: Sequence[int],
                      attempted: Sequence[str]) -> Optional[str]:

--- a/gen9-cluster/gen9_cluster/dispatch.py
+++ b/gen9-cluster/gen9_cluster/dispatch.py
@@ -1,0 +1,234 @@
+"""Fan a token's top-k out to the consoles that hold those experts.
+
+This is the hot path: it runs once per MoE layer per token, so ~69 times per
+token on the V4-Pro profile. Three decisions define it.
+
+**Group by console before sending.** A token's eight experts may live on three
+consoles. Naively that is eight requests; grouped, it is three, and each console
+returns the gate-weighted sum of the experts it holds. Round trips, not FLOPs,
+are what a console fleet is short of.
+
+**Send concurrently, reduce deterministically.** The requests go out together
+and land in whatever order the network decides, but the partial sums are added
+back in a fixed order (by unit id). Floating-point addition is not associative,
+so reducing in arrival order would make the same prompt produce different
+tokens on different runs — a bug that is invisible until it is infuriating.
+
+**Retry only what is safe to retry.** An expert evaluation mutates nothing, so a
+timeout or a dropped connection can be re-dispatched to a replica; the error
+types in :mod:`gen9_cluster.errors` carry that decision so this module never has
+to infer it from an errno. If no replica holds the expert, the dispatcher fails
+the token rather than silently dropping an expert from the sum — a quietly wrong
+answer is worse than a loud failure.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .errors import Gen9Error, ShardMissing
+from .protocol import (ExpertBatchPayload, Flags, Frame, MsgType,
+                       decode_vector)
+from .transport import ConnectionPool, NodeConnection
+
+#: (layer, expert) -> the unit ids that hold it, best first.
+Placement = Dict[Tuple[int, int], List[str]]
+
+
+@dataclass
+class NodeAddress:
+    unit_id: str
+    host: str
+    port: int
+
+
+@dataclass
+class DispatchStats:
+    """What the last layer actually cost, for the operator and the logs."""
+
+    consoles_contacted: int = 0
+    experts_run: int = 0
+    retries: int = 0
+    storage_hits: int = 0
+    failed_units: List[str] = field(default_factory=list)
+
+
+class ExpertDispatcher:
+    """Routes expert work for one shelf."""
+
+    def __init__(self, placement: Placement,
+                 addresses: Dict[str, NodeAddress], *,
+                 pool: Optional[ConnectionPool] = None,
+                 max_retries: int = 1,
+                 request_timeout: float = 10.0,
+                 max_workers: int = 32):
+        self.placement = placement
+        self.addresses = addresses
+        self.pool = pool or ConnectionPool()
+        self.max_retries = max_retries
+        self.request_timeout = request_timeout
+        self._executor = ThreadPoolExecutor(max_workers=max_workers,
+                                            thread_name_prefix="g9-dispatch")
+        self._down: Dict[str, bool] = {}
+        self._lock = threading.Lock()
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=False)
+        self.pool.close()
+
+    def __enter__(self) -> "ExpertDispatcher":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    # -- routing ----------------------------------------------------------
+    def group_by_unit(self, layer: int, expert_ids: Sequence[int],
+                      gates: Sequence[float]
+                      ) -> Dict[str, Tuple[List[int], List[float]]]:
+        """Split a token's top-k into one batch per console that holds them."""
+        grouped: Dict[str, Tuple[List[int], List[float]]] = defaultdict(
+            lambda: ([], []))
+        for expert, gate in zip(expert_ids, gates):
+            unit = self._owner(layer, expert)
+            ids, weights = grouped[unit]
+            ids.append(int(expert))
+            weights.append(float(gate))
+        return dict(grouped)
+
+    def _owner(self, layer: int, expert: int, *,
+               skip: Sequence[str] = ()) -> str:
+        holders = self.placement.get((layer, int(expert)))
+        if not holders:
+            raise ShardMissing("no console in the plan holds this expert",
+                               layer=layer, expert=int(expert))
+        for unit in holders:
+            if unit in skip:
+                continue
+            with self._lock:
+                if self._down.get(unit):
+                    continue
+            return unit
+        # Every holder is marked down; try them anyway rather than failing the
+        # token on stale liveness state.
+        for unit in holders:
+            if unit not in skip:
+                return unit
+        raise ShardMissing("every console holding this expert has failed",
+                           layer=layer, expert=int(expert))
+
+    # -- the hot path -----------------------------------------------------
+    def run_layer(self, layer: int, activation: np.ndarray,
+                  expert_ids: Sequence[int], gates: Sequence[float], *,
+                  token: int = 0) -> Tuple[np.ndarray, DispatchStats]:
+        """Run one MoE layer's routed experts and return their summed output."""
+        stats = DispatchStats()
+        batches = self.group_by_unit(layer, expert_ids, gates)
+        stats.consoles_contacted = len(batches)
+        stats.experts_run = len(expert_ids)
+
+        futures = {
+            unit: self._executor.submit(self._call_unit, unit, layer,
+                                        activation, ids, weights, token, stats)
+            for unit, (ids, weights) in batches.items()
+        }
+        partials: Dict[str, np.ndarray] = {}
+        errors: List[BaseException] = []
+        for unit, future in futures.items():
+            try:
+                partials[unit] = future.result()
+            except BaseException as exc:                    # noqa: BLE001
+                errors.append(exc)
+                stats.failed_units.append(unit)
+        if errors:
+            raise errors[0]
+
+        # Deterministic reduction: sorted by unit id, never by arrival.
+        out = np.zeros_like(activation, dtype=np.float32)
+        for unit in sorted(partials):
+            out += partials[unit]
+        return out, stats
+
+    def _call_unit(self, unit: str, layer: int, activation: np.ndarray,
+                   expert_ids: Sequence[int], gates: Sequence[float],
+                   token: int, stats: DispatchStats) -> np.ndarray:
+        attempted: List[str] = []
+        target: Optional[str] = unit
+        last: Optional[BaseException] = None
+        for attempt in range(self.max_retries + 1):
+            if target is None:
+                break
+            try:
+                conn = self._connect(target)
+                payload = ExpertBatchPayload(tuple(int(e) for e in expert_ids),
+                                             tuple(float(g) for g in gates),
+                                             activation).encode()
+                reply = conn.request(
+                    Frame(MsgType.EXPERT_BATCH, 0, payload, layer=layer,
+                          token=token),
+                    timeout=self.request_timeout)
+                if reply.flags & Flags.FROM_STORAGE:
+                    stats.storage_hits += 1
+                self._mark_up(target)
+                return decode_vector(reply.payload).astype(np.float32,
+                                                           copy=False)
+            except Gen9Error as exc:
+                last = exc
+                self._mark_down(target)
+                if not exc.retry_safe:
+                    raise
+                attempted.append(target)
+                stats.retries += 1
+                # A replica for *all* of these experts, or nothing: splitting a
+                # failed batch across two replicas would double-count any expert
+                # both of them hold.
+                target = self._replica_for(layer, expert_ids, attempted)
+                if target is None:
+                    raise
+        assert last is not None
+        raise last
+
+    def _replica_for(self, layer: int, expert_ids: Sequence[int],
+                     attempted: Sequence[str]) -> Optional[str]:
+        candidates: Optional[set] = None
+        for expert in expert_ids:
+            holders = {unit for unit in self.placement.get((layer, int(expert)),
+                                                           [])
+                       if unit not in attempted}
+            candidates = holders if candidates is None else candidates & holders
+            if not candidates:
+                return None
+        return sorted(candidates)[0] if candidates else None
+
+    def _connect(self, unit: str) -> NodeConnection:
+        address = self.addresses.get(unit)
+        if address is None:
+            raise ShardMissing(f"no address known for console {unit!r}",
+                               unit_id=unit)
+        return self.pool.get(unit, address.host, address.port)
+
+    def _mark_down(self, unit: str) -> None:
+        with self._lock:
+            self._down[unit] = True
+        self.pool.drop(unit)
+
+    def _mark_up(self, unit: str) -> None:
+        with self._lock:
+            if self._down.get(unit):
+                self._down[unit] = False
+
+
+def placement_from_plan(plan) -> Placement:
+    """Build the (layer, expert) -> consoles index from a :class:`SplitPlan`."""
+    placement: Placement = defaultdict(list)
+    for unit in plan.units.values():
+        for shard in unit.shards:
+            for expert in shard.expert_ids:
+                placement[(shard.layer, expert)].append(unit.unit_id)
+    return dict(placement)

--- a/gen9-cluster/gen9_cluster/errors.py
+++ b/gen9-cluster/gen9_cluster/errors.py
@@ -1,0 +1,98 @@
+"""Failure types, each carrying the node it happened on and whether to retry.
+
+The whole point of naming these separately is the ``retry_safe`` flag. A fleet
+of second-hand consoles fails constantly and in boring ways — a console
+overheats, a switch port flaps, someone's housemate turns one off — and the
+coordinator has to answer one question about every failure without thinking:
+*may I send this work somewhere else?* Sending a token's expert twice is
+harmless; sending it after the node already applied it to a KV cache is not.
+So the answer is a property of the failure, decided where the failure is
+raised, and never guessed at the call site.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class Gen9Error(Exception):
+    """Base for every failure attributable to a node."""
+
+    #: True when the request provably did not take effect, so a retry elsewhere
+    #: cannot double-apply anything.
+    retry_safe = False
+
+    def __init__(self, message: str, *, unit_id: Optional[str] = None,
+                 layer: Optional[int] = None, expert: Optional[int] = None):
+        self.unit_id = unit_id
+        self.layer = layer
+        self.expert = expert
+        where = f" [{unit_id}]" if unit_id else ""
+        if layer is not None:
+            where += f" layer {layer}"
+            if expert is not None:
+                where += f" expert {expert}"
+        super().__init__(message + where)
+
+
+class ConnectError(Gen9Error):
+    """The connection could not be established. Nothing was sent."""
+
+    retry_safe = True
+
+
+class TimeoutError_(Gen9Error):
+    """No reply within the deadline.
+
+    Not retry-safe in general: the node may be mid-computation and its reply may
+    still arrive on a connection the coordinator has stopped reading. The
+    coordinator's recovery is to drop the connection and re-dispatch, which is
+    only correct for stateless expert work — hence
+    :class:`ExpertTimeout` for the case where it is.
+    """
+
+    retry_safe = False
+
+
+class ExpertTimeout(TimeoutError_):
+    """A routed-expert call timed out.
+
+    Expert evaluation is a pure function of (activation, weights): it mutates
+    nothing on the node, so re-dispatching to a replica is always safe even if
+    the original is still grinding away.
+    """
+
+    retry_safe = True
+
+
+class ProtocolError(Gen9Error):
+    """A frame that does not parse, or a reply that does not match its request.
+
+    Never retry-safe: the connection's framing is no longer trustworthy, so the
+    only correct recovery is to close it.
+    """
+
+    retry_safe = False
+
+
+class ShardMissing(Gen9Error):
+    """The node does not hold the (layer, expert) that was asked of it.
+
+    Means the plan and the node's actual residency disagree — a deployment bug,
+    not a transient fault. Retry-safe only in the sense that another replica may
+    genuinely hold it.
+    """
+
+    retry_safe = True
+
+
+class CapacityError(Gen9Error):
+    """The node refused a load because it would not fit in its coffers."""
+
+    retry_safe = False
+
+
+class KernelError(Gen9Error):
+    """The compute backend failed: shader compile, HIP launch, allocation."""
+
+    retry_safe = True

--- a/gen9-cluster/gen9_cluster/fp8.py
+++ b/gen9-cluster/gen9_cluster/fp8.py
@@ -1,0 +1,113 @@
+"""FP8 E4M3FN with 128-element block scales, in numpy.
+
+DeepSeek ships its weights in FP8 with a scale per 128-element block, and that
+is what makes the model fit on hardware like this at all: 1 byte per parameter
+instead of 2 halves the number of consoles needed, and decode is bandwidth-bound
+so it roughly doubles the token rate as well.
+
+This module is the *portable* implementation. It exists for three jobs: loading
+FP8 shards on a console whose compiled kernel is not available, checking the
+compiled kernel against something independent, and letting the reference runner
+work in FP8 without pretending numpy has an E4M3 dtype. Where
+``libgen9_cpu.so`` exists the C path in ``kernels/fp8.c`` is faster and the two
+agree bit for bit on the table; this is not a second, divergent definition of
+the format.
+
+E4M3FN, as used by DeepSeek and by ``torch.float8_e4m3fn``: 1 sign bit,
+4 exponent bits with bias 7, 3 mantissa bits, no infinities, and 0x7F/0xFF as
+the only NaNs. Max normal is 448, min subnormal is 2**-9.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+#: Elements sharing one scale factor. Matches DeepSeek's checkpoints.
+BLOCK = 128
+
+#: Largest finite magnitude the format can hold.
+MAX_NORMAL = 448.0
+
+
+def _build_table() -> np.ndarray:
+    table = np.zeros(256, dtype=np.float32)
+    for code in range(256):
+        sign = -1.0 if code & 0x80 else 1.0
+        exponent = (code >> 3) & 0xF
+        mantissa = code & 0x7
+        if exponent == 0:
+            magnitude = mantissa * 0.125 * 2.0 ** -6
+        elif exponent == 0xF and mantissa == 0x7:
+            magnitude = float("nan")
+        else:
+            magnitude = (1.0 + mantissa * 0.125) * 2.0 ** (exponent - 7)
+        table[code] = sign * magnitude
+    return table
+
+
+#: code -> value, built once. Decoding is a gather, not arithmetic.
+TABLE = _build_table()
+
+
+def decode(codes: np.ndarray) -> np.ndarray:
+    """Decode raw E4M3FN bytes, without applying any scale."""
+    return TABLE[np.asarray(codes, dtype=np.uint8)]
+
+
+def dequantize(codes: np.ndarray, scales: np.ndarray) -> np.ndarray:
+    """Decode a blockwise-quantised tensor to fp32.
+
+    ``codes`` is any shape; blocks run along the flattened array, which is the
+    layout the checkpoints use. ``scales`` holds one float per block.
+    """
+    flat = np.asarray(codes, dtype=np.uint8).reshape(-1)
+    blocks = (flat.size + BLOCK - 1) // BLOCK
+    scale_array = np.asarray(scales, dtype=np.float32).reshape(-1)
+    if scale_array.size != blocks:
+        raise ValueError(f"{flat.size} values need {blocks} block scales, "
+                         f"got {scale_array.size}")
+    padded = blocks * BLOCK
+    values = np.zeros(padded, dtype=np.float32)
+    values[:flat.size] = TABLE[flat]
+    scaled = values.reshape(blocks, BLOCK) * scale_array[:, None]
+    return scaled.reshape(-1)[:flat.size].reshape(np.shape(codes))
+
+
+def quantize(values: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Quantise to E4M3FN with per-block scales.
+
+    The scale is chosen so the largest magnitude in the block lands on the
+    format's maximum. This is what keeps the error relative rather than
+    absolute, and it is why a block of tiny weights next to a large outlier
+    does not collapse to zero.
+    """
+    flat = np.asarray(values, dtype=np.float32).reshape(-1)
+    blocks = (flat.size + BLOCK - 1) // BLOCK
+    padded = np.zeros(blocks * BLOCK, dtype=np.float32)
+    padded[:flat.size] = flat
+    grid = padded.reshape(blocks, BLOCK)
+
+    peak = np.abs(grid).max(axis=1)
+    scales = np.where(peak > 0, peak / MAX_NORMAL, 1.0).astype(np.float32)
+    normalised = grid / scales[:, None]
+
+    # Nearest code by value. 256 candidates, so a search beats writing out the
+    # bit-twiddling a second time, and it cannot disagree with TABLE.
+    finite = np.where(np.isnan(TABLE), np.inf, TABLE)
+    order = np.argsort(finite)
+    ordered = finite[order]
+    idx = np.searchsorted(ordered, normalised.reshape(-1))
+    idx = np.clip(idx, 1, len(ordered) - 1)
+    lower, upper = ordered[idx - 1], ordered[idx]
+    pick = np.where(np.abs(normalised.reshape(-1) - lower)
+                    <= np.abs(upper - normalised.reshape(-1)), idx - 1, idx)
+    codes = order[pick].astype(np.uint8)
+    return (codes.reshape(blocks * BLOCK)[:flat.size].reshape(
+        np.shape(values)), scales)
+
+
+def n_blocks(count: int) -> int:
+    """How many block scales ``count`` values need."""
+    return (count + BLOCK - 1) // BLOCK

--- a/gen9-cluster/gen9_cluster/hardware.py
+++ b/gen9-cluster/gen9_cluster/hardware.py
@@ -14,13 +14,13 @@ small coffer hierarchy:
     PS5 Pro         16 GB @ 576 GB/s  + 2 GB DDR5 OS-only + 5.5 GB/s NVMe
 
 The same silicon is also sold *outside* a console shell, harvested harder: the
-AMD 4700S/4800S desktop kits are Series X SoCs with the GPU fused off entirely
-and the 16 GB GDDR6 soldered to an ITX board, and the BC-250 blade is a PS5
-Oberon/Cyan Skillfish part with 6 of 8 CPU cores and 24 of 40 CUs enabled by the
-driver. Those boards are the cheapest way to add capacity to a fleet, they run a
-normal Linux, and the BC-250 in particular is the only member of the family with
-a *routinely exercised* GPU compute path — so they are first-class SKUs here,
-not a footnote.
+AMD 4700S desktop kit is a PS5 "Ariel" SoC and the 4800S a Series X one, both
+with the GPU fused off entirely and 16 GB of GDDR6 soldered to the board as
+system memory, and the BC-250 blade is a PS5 Oberon/Cyan Skillfish part with 6
+of 8 CPU cores and 24 of 40 CUs enabled by the driver. Those boards are the
+cheapest way to add capacity to a fleet, they run a normal Linux, and the BC-250
+in particular is the only member of the family with a *routinely exercised* GPU
+compute path — so they are first-class SKUs here, not a footnote.
 
 Two things this module exists to get right:
 
@@ -428,29 +428,40 @@ XBOX_SERIES_S = ConsoleSKU(
 AMD_4700S = ConsoleSKU(
     sku="amd-4700s",
     family="salvage",
-    marketing_name="AMD 4700S Desktop Kit (Series X SoC, GPU fused off)",
-    cpu_cores=8, cpu_threads=16, cpu_ghz=4.0,
-    cu_physical=56, cu_enabled=0, gpu_ghz=0.0, gpu_tflops_fp32=0.0,
-    # 16 GB GDDR6 soldered to the board and used as system memory. The DRAM is
-    # the console's, but the CPU reaches it through a fabric never meant to be
-    # the only client: measured desktop throughput and latency are far short of
-    # the console's 560 GB/s figure (UNVERIFIED; budgeted at a fifth of it,
-    # which is still several times a DDR4 desktop).
-    tiers=(MemoryTier("gddr6", 16 * GB, 112.0, 1 * GB),),
-    storage=StorageSpec(capacity_bytes=512 * GB, read_gbps=3.5),
+    marketing_name="AMD 4700S Desktop Kit (PS5 'Ariel' SoC, GPU fused off)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.2,
+    cu_physical=40, cu_enabled=0, gpu_ghz=0.0, gpu_tflops_fp32=0.0,
+    # 16 GB GDDR6 (8 SK hynix packages, 256-bit, 14 Gbps) soldered to the board
+    # and used as system memory. The DRAM is the console's, but the CPU reaches
+    # it through a fabric never meant to be its only client: 92.9 GB/s AIDA64
+    # copy, against the PS5 GPU's 448 GB/s, at 145 ns rather than DDR4's 74 ns
+    # (MEASURED by Tom's Hardware on a retail kit, not by us). Latency that high
+    # is survivable here because expert GEMV reads are sequential.
+    tiers=(MemoryTier("gddr6", 16 * GB, 92.0, 1 * GB),),
+    # SATA only: the board has no M.2 and the sole PCIe slot may not be spent on
+    # a carrier card, so the cold tier is a 6 Gb/s SSD, not an NVMe.
+    storage=StorageSpec(capacity_bytes=512 * GB, read_gbps=0.55),
     backends=(ComputeBackend.CPU_AVX2,),
     board_revisions=("4700s-itx",),
     notes="GPU permanently disabled, so this is a pure CPU node with an unusual "
           "amount of bandwidth-rich memory: the natural host for cold routed "
-          "experts. A PCIe x16 slot exists but no discrete GPU is assumed.",
+          "experts. The slot is x16 mechanically but PCIe 2.0 x4 electrically "
+          "(~2 GB/s), too narrow to feed a card's VRAM from board memory; a "
+          "card added here is a compute unit for what already fits in it.",
 )
 
 AMD_4800S = replace(
     AMD_4700S, sku="amd-4800s",
-    marketing_name="AMD 4800S Desktop Kit (Series X SoC, GPU fused off)",
+    marketing_name="AMD 4800S Desktop Kit (Xbox Series X SoC, GPU fused off)",
+    cpu_ghz=4.0, cu_physical=56,
+    # Same memory arrangement, but the board is mATX with an M.2 for storage and
+    # a PCIe 4.0 x4 slot (~7.9 GB/s) instead of the 4700S's Gen2 x4.
+    storage=StorageSpec(capacity_bytes=512 * GB, read_gbps=3.5),
     board_revisions=("4800s-matx",),
-    notes="Later mATX revision of the same harvest, sold through OEMs. Same "
-          "CPU-only capability model as the 4700S.",
+    notes="The later kit is a different harvest, not a revision: Series X "
+          "silicon rather than the 4700S's PS5 Ariel, clocked to 4.0 GHz, with "
+          "an M.2 and a Gen4 x4 slot. Same CPU-only capability model, but the "
+          "wider slot is what makes a discrete card worth considering.",
 )
 
 BC_250 = ConsoleSKU(

--- a/gen9-cluster/gen9_cluster/hardware.py
+++ b/gen9-cluster/gen9_cluster/hardware.py
@@ -1,0 +1,812 @@
+"""Ninth-generation console hardware model: SKUs, coffers, and downbinning.
+
+RAM Coffers (upstream) partitions a model across NUMA banks inside one POWER8
+box, each bank a "coffer" holding a known slice of knowledge. A ninth-generation
+console has the same structure in miniature and for free: its unified GDDR6 is
+*already* split into bandwidth tiers by the hardware designers, and its NVMe is a
+third tier fast enough to stream weights. So a console is not one coffer, it is a
+small coffer hierarchy:
+
+    Xbox Series X   10 GB @ 560 GB/s  (fast coffer)  + 6 GB @ 336 GB/s (3.5 GB
+                    usable after the OS reservation, slow coffer) + 2.4 GB/s NVMe
+    Xbox Series S    8 GB @ 224 GB/s  + 2 GB @ 56 GB/s + 2.4 GB/s NVMe
+    PS5 / PS5 Slim  16 GB @ 448 GB/s  (single tier) + 5.5 GB/s NVMe
+    PS5 Pro         16 GB @ 576 GB/s  + 2 GB DDR5 OS-only + 5.5 GB/s NVMe
+
+The same silicon is also sold *outside* a console shell, harvested harder: the
+AMD 4700S/4800S desktop kits are Series X SoCs with the GPU fused off entirely
+and the 16 GB GDDR6 soldered to an ITX board, and the BC-250 blade is a PS5
+Oberon/Cyan Skillfish part with 6 of 8 CPU cores and 24 of 40 CUs enabled by the
+driver. Those boards are the cheapest way to add capacity to a fleet, they run a
+normal Linux, and the BC-250 in particular is the only member of the family with
+a *routinely exercised* GPU compute path — so they are first-class SKUs here,
+not a footnote.
+
+Two things this module exists to get right:
+
+**Variant boards with components disabled.** Every one of these consoles is a
+downbinned part *by design* — the Series X ships 56 physical CUs and enables 52,
+the PS5 ships 40 and enables 36 — and the fleet a real deployment gets hold of
+adds its own reductions on top: a dev-mode sandbox that only hands out ~5 GB, a
+board with a dead GDDR6 package, a Series S whose 10th memory channel is
+depopulated, a console throttled to a lower clock by a failed fan. None of that
+may be inferred from the SKU name. :class:`Downbin` records what a *specific*
+unit lost, :class:`ConsoleUnit.effective` folds it into the nominal SKU, and the
+planner in ``planner.py`` only ever reads the effective numbers. A fleet is
+therefore allowed to be wildly heterogeneous; the planner rebalances rather than
+refusing.
+
+**Backends differ in what they can be trusted to do.** A PS5 running
+``ps5-linux`` gets a GFX1013 amdgpu, which Vulkan/RADV drives well; ROCm builds
+for gfx1013 exist and can be pointed at, but parts of the ROCm library stack
+either do not ship that target or fall back to a lower capability level because
+their build scripts assume a higher gfx tier, so ROCm throughput must be
+*measured per node* rather than assumed. An Xbox in retail Dev Mode has no
+compute-shader path we can rely on and a hard memory sandbox. Hence
+:class:`ComputeBackend` and the per-unit ``measured_gemv_gflops`` override.
+
+Nothing here touches hardware; it is a datasheet plus arithmetic, so a fleet can
+be planned from a laptop. Numbers marked ``UNVERIFIED`` in comments come from
+vendor disclosures rather than measurement on the fleet.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field, replace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+MB = 1024 * 1024
+GB = 1024 * MB
+
+
+class ComputeBackend(enum.Enum):
+    """How a console actually runs the GEMV kernel.
+
+    The distinction matters to the planner because a console's usable throughput
+    is a property of its *software* path as much as its silicon.
+    """
+
+    #: Zen 2 cores, AVX2 (no AVX-512 on Zen 2), 8 cores / 16 threads.
+    CPU_AVX2 = "cpu-avx2"
+    #: Vulkan compute via RADV on the console's amdgpu (PS5 under ps5-linux).
+    #: The default GPU path: no tuned-library assumptions, works on GFX1013.
+    VULKAN = "vulkan"
+    #: ROCm/HIP. Usable where a working gfx1013 ROCm stack is installed (Debian
+    #: builds do run), but library coverage is uneven: parts of the userspace
+    #: stack do not ship the target at all and others fall back to a lower
+    #: capability level because their build scripts assume a higher gfx tier.
+    #: Declare it per node and let the planner use ``measured_gemv_gflops``
+    #: rather than a nominal figure.
+    ROCM = "rocm"
+    #: Direct3D 12 compute, the only GPU path an Xbox GDK title has. Reachable
+    #: with a real GDK/devkit; NOT reachable from a retail Dev Mode UWP app with
+    #: any throughput worth planning around.
+    D3D12 = "d3d12"
+
+    @property
+    def is_gpu(self) -> bool:
+        return self is not ComputeBackend.CPU_AVX2
+
+    @property
+    def throughput_is_assumed(self) -> bool:
+        """True when the nominal figure must not be trusted without measuring.
+
+        ROCm on a console GPU hits libraries that may silently drop to a lower
+        capability path; Vulkan compute we write ourselves, so its ceiling is the
+        hardware's.
+        """
+        return self is ComputeBackend.ROCM
+
+
+class Runtime(enum.Enum):
+    """The software environment a console node runs under."""
+
+    #: ps5-linux (patched-hypervisor Linux, PS5 phat/slim, FW 3.00-7.61):
+    #: full 8c/16t at 3.5 GHz and the GPU at 2.23 GHz via amdgpu/GFX1013.
+    PS5_LINUX = "ps5-linux"
+    #: PS5 homebrew ELF under HEN: CPU only, no GPU compute, reduced allocator.
+    PS5_HEN = "ps5-hen"
+    #: Retail Xbox Series Dev Mode. Hard memory sandbox (app ~1 GB, Creators
+    #: game ~5 GB), partial CPU cores, no dependable compute path.
+    XBOX_DEVMODE = "xbox-devmode"
+    #: Xbox GDK title on a devkit / activated console: full memory and D3D12.
+    XBOX_GDK = "xbox-gdk"
+    #: A stock Linux distribution on a desktop/blade board built from console
+    #: silicon (4700S, 4800S, BC-250). No sandbox, no hypervisor, ordinary
+    #: amdgpu where a GPU survives the harvest.
+    SALVAGE_LINUX = "salvage-linux"
+    #: Not a console: an x86-64 host standing in for one in tests and bring-up.
+    HOST_SIM = "host-sim"
+
+    @property
+    def console_family(self) -> str:
+        if self in (Runtime.PS5_LINUX, Runtime.PS5_HEN):
+            return "playstation"
+        if self in (Runtime.XBOX_DEVMODE, Runtime.XBOX_GDK):
+            return "xbox"
+        if self is Runtime.SALVAGE_LINUX:
+            return "salvage"
+        return "host"
+
+
+@dataclass(frozen=True)
+class MemoryTier:
+    """One bandwidth tier of a console's unified memory: a coffer.
+
+    ``os_reserved_bytes`` is memory the platform keeps for itself and is
+    subtracted before anything is placed. ``bandwidth_gbps`` is the vendor's
+    figure for the tier, in GB/s.
+    """
+
+    name: str
+    total_bytes: int
+    bandwidth_gbps: float
+    os_reserved_bytes: int = 0
+    #: False for a tier that exists but cannot hold weights read every token
+    #: (e.g. the PS5 Pro's 2 GB DDR5, which is OS-only).
+    usable_for_weights: bool = True
+
+    @property
+    def usable_bytes(self) -> int:
+        if not self.usable_for_weights:
+            return 0
+        return max(0, self.total_bytes - self.os_reserved_bytes)
+
+
+@dataclass(frozen=True)
+class StorageSpec:
+    """The console's NVMe, used as the cold coffer for streamed experts."""
+
+    capacity_bytes: int
+    read_gbps: float                 # raw sequential
+    compressed_read_gbps: float = 0.0  # with the console's hardware decompressor
+
+    @property
+    def effective_read_gbps(self) -> float:
+        return max(self.read_gbps, self.compressed_read_gbps)
+
+
+@dataclass(frozen=True)
+class ConsoleSKU:
+    """Nominal datasheet for one console model.
+
+    ``cu_physical`` vs ``cu_enabled`` is the vendor's own downbin: these consoles
+    ship with compute units fused off for yield (Series X 56 -> 52, PS5 40 -> 36,
+    Series S 24 -> 20). Per-unit losses beyond that live in :class:`Downbin`.
+    """
+
+    sku: str
+    family: str                     # "playstation" | "xbox"
+    marketing_name: str
+    cpu_cores: int
+    cpu_threads: int
+    cpu_ghz: float
+    cu_physical: int
+    cu_enabled: int
+    gpu_ghz: float
+    gpu_tflops_fp32: float
+    tiers: Tuple[MemoryTier, ...]
+    storage: StorageSpec
+    #: Backends the model can reach at all, most preferred first.
+    backends: Tuple[ComputeBackend, ...] = (ComputeBackend.CPU_AVX2,)
+    #: Board variants that are electrically the same compute part (a digital
+    #: edition is the same SoC minus a Blu-ray drive), recorded so an inventory
+    #: can name the board it has without inventing a new capability row.
+    board_revisions: Tuple[str, ...] = ()
+    notes: str = ""
+
+    @property
+    def total_memory_bytes(self) -> int:
+        return sum(t.total_bytes for t in self.tiers)
+
+    @property
+    def weight_memory_bytes(self) -> int:
+        return sum(t.usable_bytes for t in self.tiers)
+
+    @property
+    def fast_tier(self) -> MemoryTier:
+        """The highest-bandwidth tier that can hold weights."""
+        usable = [t for t in self.tiers if t.usable_bytes > 0]
+        if not usable:
+            raise ValueError(f"{self.sku} has no tier usable for weights")
+        return max(usable, key=lambda t: t.bandwidth_gbps)
+
+
+@dataclass(frozen=True)
+class Downbin:
+    """What one physical unit lost relative to its SKU.
+
+    Every field is a *reduction*, so an all-zero ``Downbin`` is a pristine
+    console and the planner needs no special case for one. Reasons are free text
+    and end up in the plan's audit trail, because "why is this node holding four
+    fewer experts" is the first question a fleet operator asks.
+
+    ``memory_bytes_lost`` is applied to the tiers named in ``tier_losses`` when
+    those are given, and to the slow tier first otherwise — a dead GDDR6 package
+    takes capacity off one tier, not off the console uniformly.
+    """
+
+    cu_disabled: int = 0
+    cpu_cores_disabled: int = 0
+    cpu_ghz_cap: Optional[float] = None
+    gpu_ghz_cap: Optional[float] = None
+    #: tier name -> bytes lost on that tier.
+    tier_losses: Dict[str, int] = field(default_factory=dict)
+    #: tier name -> fraction of the tier's bandwidth still available (0..1).
+    tier_bandwidth_scale: Dict[str, float] = field(default_factory=dict)
+    #: Hard ceiling on what the process may allocate at all (Dev Mode sandbox).
+    memory_budget_bytes: Optional[int] = None
+    reasons: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.cu_disabled < 0 or self.cpu_cores_disabled < 0:
+            raise ValueError("downbin counts are reductions and cannot be negative")
+        for tier, scale in self.tier_bandwidth_scale.items():
+            if not 0.0 < scale <= 1.0:
+                raise ValueError(
+                    f"bandwidth scale for tier {tier!r} must be in (0, 1], got {scale}")
+
+    @property
+    def is_pristine(self) -> bool:
+        return (self.cu_disabled == 0 and self.cpu_cores_disabled == 0
+                and self.cpu_ghz_cap is None and self.gpu_ghz_cap is None
+                and not self.tier_losses and not self.tier_bandwidth_scale
+                and self.memory_budget_bytes is None)
+
+    def merge(self, other: "Downbin") -> "Downbin":
+        """Combine two reductions (a sandbox plus a hardware fault)."""
+        tier_losses = dict(self.tier_losses)
+        for name, lost in other.tier_losses.items():
+            tier_losses[name] = tier_losses.get(name, 0) + lost
+        scales = dict(self.tier_bandwidth_scale)
+        for name, scale in other.tier_bandwidth_scale.items():
+            scales[name] = scales.get(name, 1.0) * scale
+        budgets = [b for b in (self.memory_budget_bytes,
+                               other.memory_budget_bytes) if b is not None]
+        caps = [c for c in (self.cpu_ghz_cap, other.cpu_ghz_cap) if c is not None]
+        gpu_caps = [c for c in (self.gpu_ghz_cap, other.gpu_ghz_cap)
+                    if c is not None]
+        return Downbin(
+            cu_disabled=self.cu_disabled + other.cu_disabled,
+            cpu_cores_disabled=self.cpu_cores_disabled + other.cpu_cores_disabled,
+            cpu_ghz_cap=min(caps) if caps else None,
+            gpu_ghz_cap=min(gpu_caps) if gpu_caps else None,
+            tier_losses=tier_losses,
+            tier_bandwidth_scale=scales,
+            memory_budget_bytes=min(budgets) if budgets else None,
+            reasons=self.reasons + other.reasons)
+
+
+@dataclass(frozen=True)
+class EffectiveCapability:
+    """What a specific unit can actually be asked to do.
+
+    This is the only view the planner consumes. ``weight_bytes`` is what may hold
+    weights after OS reservations, per-unit memory loss, and any sandbox ceiling;
+    ``coffers`` is that capacity split by bandwidth tier, fastest first.
+    """
+
+    unit_id: str
+    sku: str
+    runtime: Runtime
+    backend: ComputeBackend
+    cu_active: int
+    cpu_cores_active: int
+    cpu_ghz: float
+    gpu_ghz: float
+    gemv_gflops: float
+    coffers: Tuple[MemoryTier, ...]
+    storage: StorageSpec
+    throughput_measured: bool
+    warnings: Tuple[str, ...] = ()
+
+    @property
+    def weight_bytes(self) -> int:
+        return sum(t.usable_bytes for t in self.coffers)
+
+    @property
+    def fast_bytes(self) -> int:
+        return self.coffers[0].usable_bytes if self.coffers else 0
+
+    @property
+    def fast_bandwidth_gbps(self) -> float:
+        return self.coffers[0].bandwidth_gbps if self.coffers else 0.0
+
+    def weight_bytes_at_least(self, bandwidth_gbps: float) -> int:
+        """Capacity in tiers at or above a bandwidth floor.
+
+        Used to place weights that are read every token (attention, shared
+        expert, router) only where reading them is affordable.
+        """
+        return sum(t.usable_bytes for t in self.coffers
+                   if t.bandwidth_gbps >= bandwidth_gbps)
+
+
+# --------------------------------------------------------------------------
+# SKU table
+# --------------------------------------------------------------------------
+# Vendor-disclosed figures. Memory reservations are the publicly stated
+# game-available splits; where a platform never stated one, the value is marked
+# UNVERIFIED and chosen conservatively (reserving more, not less).
+
+_PS5_STORAGE = StorageSpec(capacity_bytes=825 * GB, read_gbps=5.5,
+                           compressed_read_gbps=8.0)
+_PS5_SLIM_STORAGE = StorageSpec(capacity_bytes=1024 * GB, read_gbps=5.5,
+                                compressed_read_gbps=8.0)
+_PS5_PRO_STORAGE = StorageSpec(capacity_bytes=2048 * GB, read_gbps=5.5,
+                               compressed_read_gbps=8.0)
+_XSX_STORAGE = StorageSpec(capacity_bytes=1024 * GB, read_gbps=2.4,
+                           compressed_read_gbps=4.8)
+_XSS_STORAGE = StorageSpec(capacity_bytes=512 * GB, read_gbps=2.4,
+                           compressed_read_gbps=4.8)
+
+#: PS5 keeps ~3.5 GB of its 16 GB for the OS on the pre-Pro boards (UNVERIFIED:
+#: Sony never published the split; 13.5 GB game-available is the widely
+#: reproduced figure and is what we budget).
+_PS5_OS_RESERVE = 16 * GB - 13 * GB
+
+PS5 = ConsoleSKU(
+    sku="ps5",
+    family="playstation",
+    marketing_name="PlayStation 5 (CFI-10xx/11xx/12xx)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.5,
+    cu_physical=40, cu_enabled=36, gpu_ghz=2.23, gpu_tflops_fp32=10.28,
+    tiers=(MemoryTier("gddr6", 16 * GB, 448.0, _PS5_OS_RESERVE),),
+    storage=_PS5_STORAGE,
+    backends=(ComputeBackend.VULKAN, ComputeBackend.ROCM,
+              ComputeBackend.CPU_AVX2),
+    board_revisions=("CFI-1000A", "CFI-1000B", "CFI-1100A", "CFI-1100B",
+                     "CFI-1200A", "CFI-1200B"),
+    notes="Oberon; 4 of 40 CUs fused off for yield. B boards are the digital "
+          "edition: identical SoC, no Blu-ray drive.",
+)
+
+PS5_SLIM = replace(
+    PS5, sku="ps5-slim",
+    marketing_name="PlayStation 5 Slim (CFI-20xx)",
+    storage=_PS5_SLIM_STORAGE,
+    board_revisions=("CFI-2000A", "CFI-2000B", "CFI-2100A", "CFI-2100B"),
+    notes="Oberon Plus (6 nm shrink); same 36-of-40 CU configuration and same "
+          "448 GB/s. B boards are digital: same SoC, no drive.",
+)
+
+PS5_PRO = ConsoleSKU(
+    sku="ps5-pro",
+    family="playstation",
+    marketing_name="PlayStation 5 Pro (CFI-70xx)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.85,
+    # 60 enabled CUs / 30 WGPs. Physical count on the Trinity die is not
+    # disclosed; assume the same 4-CU harvest as Oberon (UNVERIFIED).
+    cu_physical=64, cu_enabled=60, gpu_ghz=2.17, gpu_tflops_fp32=16.7,
+    tiers=(MemoryTier("gddr6", 16 * GB, 576.0, 0),
+           MemoryTier("ddr5-os", 2 * GB, 0.0, 2 * GB,
+                      usable_for_weights=False)),
+    storage=_PS5_PRO_STORAGE,
+    backends=(ComputeBackend.VULKAN, ComputeBackend.ROCM,
+              ComputeBackend.CPU_AVX2),
+    board_revisions=("CFI-7000", "CFI-7020"),
+    notes="A separate 2 GB DDR5 die holds the OS, so the whole 16 GB GDDR6 is "
+          "application-available. No public ps5-linux support for this board "
+          "yet (UNVERIFIED): treat Pro units as CPU-only until proven.",
+)
+
+XBOX_SERIES_X = ConsoleSKU(
+    sku="xbox-series-x",
+    family="xbox",
+    marketing_name="Xbox Series X (1 TB)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.8,
+    cu_physical=56, cu_enabled=52, gpu_ghz=1.825, gpu_tflops_fp32=12.15,
+    # The published split: 10 GB "GPU optimal" at 560 GB/s and 6 GB at
+    # 336 GB/s, of which 2.5 GB is the system reservation.
+    tiers=(MemoryTier("gddr6-fast", 10 * GB, 560.0, 0),
+           MemoryTier("gddr6-slow", 6 * GB, 336.0, 2560 * MB)),
+    storage=_XSX_STORAGE,
+    backends=(ComputeBackend.D3D12, ComputeBackend.CPU_AVX2),
+    board_revisions=("1882", "1883-digital-1tb"),
+    notes="Scarlett; 4 of 56 CUs fused off for yield. The 2024 all-digital "
+          "1 TB board is the same compute part without the drive.",
+)
+
+XBOX_SERIES_S = ConsoleSKU(
+    sku="xbox-series-s",
+    family="xbox",
+    marketing_name="Xbox Series S (512 GB / 1 TB)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.6,
+    cu_physical=24, cu_enabled=20, gpu_ghz=1.565, gpu_tflops_fp32=4.0,
+    tiers=(MemoryTier("gddr6-fast", 8 * GB, 224.0, 0),
+           MemoryTier("gddr6-slow", 2 * GB, 56.0, 2 * GB)),
+    storage=_XSS_STORAGE,
+    backends=(ComputeBackend.D3D12, ComputeBackend.CPU_AVX2),
+    board_revisions=("1901", "1901-1tb-carbon"),
+    notes="Lockhart; 20 of 24 CUs enabled. The 2 GB slow tier is entirely the "
+          "system reservation, so only the 8 GB tier can hold weights.",
+)
+
+# -- salvage silicon: the same SoCs sold as cheap boards, harvested harder ----
+
+AMD_4700S = ConsoleSKU(
+    sku="amd-4700s",
+    family="salvage",
+    marketing_name="AMD 4700S Desktop Kit (Series X SoC, GPU fused off)",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=4.0,
+    cu_physical=56, cu_enabled=0, gpu_ghz=0.0, gpu_tflops_fp32=0.0,
+    # 16 GB GDDR6 soldered to the board and used as system memory. The DRAM is
+    # the console's, but the CPU reaches it through a fabric never meant to be
+    # the only client: measured desktop throughput and latency are far short of
+    # the console's 560 GB/s figure (UNVERIFIED; budgeted at a fifth of it,
+    # which is still several times a DDR4 desktop).
+    tiers=(MemoryTier("gddr6", 16 * GB, 112.0, 1 * GB),),
+    storage=StorageSpec(capacity_bytes=512 * GB, read_gbps=3.5),
+    backends=(ComputeBackend.CPU_AVX2,),
+    board_revisions=("4700s-itx",),
+    notes="GPU permanently disabled, so this is a pure CPU node with an unusual "
+          "amount of bandwidth-rich memory: the natural host for cold routed "
+          "experts. A PCIe x16 slot exists but no discrete GPU is assumed.",
+)
+
+AMD_4800S = replace(
+    AMD_4700S, sku="amd-4800s",
+    marketing_name="AMD 4800S Desktop Kit (Series X SoC, GPU fused off)",
+    board_revisions=("4800s-matx",),
+    notes="Later mATX revision of the same harvest, sold through OEMs. Same "
+          "CPU-only capability model as the 4700S.",
+)
+
+BC_250 = ConsoleSKU(
+    sku="bc-250",
+    family="salvage",
+    marketing_name="AMD BC-250 blade (PS5 Oberon / Cyan Skillfish, gfx1013)",
+    # 6 of 8 Zen 2 cores and 24 of the die's 40 CUs enabled by the driver
+    # baseline; the 40-CU unlock is community reverse-engineering, opted into
+    # per unit via ``ConsoleUnit.cu_enabled_override``.
+    cpu_cores=6, cpu_threads=12, cpu_ghz=3.5,
+    cu_physical=40, cu_enabled=24, gpu_ghz=2.0, gpu_tflops_fp32=6.8,
+    # 16 GB unified GDDR6, but what a compute job can actually map is bounded by
+    # the GTT cap rather than by capacity: ~13 GiB is the figure the community
+    # reaches after raising the kernel's TTM limits.
+    tiers=(MemoryTier("gddr6", 16 * GB, 360.0, 3 * GB),),
+    storage=StorageSpec(capacity_bytes=256 * GB, read_gbps=3.5),
+    backends=(ComputeBackend.VULKAN, ComputeBackend.ROCM,
+              ComputeBackend.CPU_AVX2),
+    board_revisions=("bc-250", "bc250"),
+    notes="Ex-mining blade, Linux-only, and the best-exercised GPU compute path "
+          "in this family: Vulkan/RADV works, while ROCm's userspace does not "
+          "ship gfx1013. Bandwidth is the measured ~360 GB/s, not the PS5's "
+          "448 GB/s figure.",
+)
+
+HOST_SIM_SKU = ConsoleSKU(
+    sku="host-sim",
+    family="host",
+    marketing_name="x86-64 host standing in for a console",
+    cpu_cores=8, cpu_threads=16, cpu_ghz=3.0,
+    cu_physical=0, cu_enabled=0, gpu_ghz=0.0, gpu_tflops_fp32=0.0,
+    tiers=(MemoryTier("host-ram", 8 * GB, 50.0, 0),),
+    storage=StorageSpec(capacity_bytes=64 * GB, read_gbps=1.0),
+    backends=(ComputeBackend.CPU_AVX2,),
+    notes="Bring-up and CI only; never part of a capability claim.",
+)
+
+SKUS: Dict[str, ConsoleSKU] = {
+    s.sku: s for s in (PS5, PS5_SLIM, PS5_PRO, XBOX_SERIES_X, XBOX_SERIES_S,
+                       AMD_4700S, AMD_4800S, BC_250, HOST_SIM_SKU)
+}
+
+#: Board revision string -> SKU, so an inventory may name the board it has.
+BOARD_TO_SKU: Dict[str, str] = {
+    rev: sku.sku for sku in SKUS.values() for rev in sku.board_revisions
+}
+
+
+def sku_for(name: str) -> ConsoleSKU:
+    """Look a SKU up by SKU id or by board revision."""
+    if name in SKUS:
+        return SKUS[name]
+    if name in BOARD_TO_SKU:
+        return SKUS[BOARD_TO_SKU[name]]
+    raise KeyError(f"unknown console SKU or board revision {name!r}; known: "
+                   f"{sorted(SKUS)} / {sorted(BOARD_TO_SKU)}")
+
+
+# --------------------------------------------------------------------------
+# Runtime sandboxes
+# --------------------------------------------------------------------------
+# A runtime is itself a downbin: it takes memory and cores away from an
+# otherwise healthy console. Modelling it this way means a Dev Mode Xbox and a
+# console with a dead memory package flow through exactly the same arithmetic.
+
+#: Retail Dev Mode hands a UWP *app* ~1 GB and a Creators-program *game* ~5 GB,
+#: with 4 exclusive + 2 shared CPU cores for games. We plan for the game budget
+#: and take the CPU reduction; there is no compute path worth planning around.
+XBOX_DEVMODE_GAME_BUDGET = 5 * GB
+XBOX_DEVMODE_APP_BUDGET = 1 * GB
+
+
+def runtime_downbin(runtime: Runtime, *, sku: ConsoleSKU,
+                    devmode_app: bool = False) -> Downbin:
+    """The reduction a runtime imposes on an otherwise pristine console."""
+    if runtime is Runtime.XBOX_DEVMODE:
+        budget = (XBOX_DEVMODE_APP_BUDGET if devmode_app
+                  else XBOX_DEVMODE_GAME_BUDGET)
+        return Downbin(
+            cpu_cores_disabled=2,
+            memory_budget_bytes=budget,
+            reasons=(f"retail Dev Mode sandbox: "
+                     f"{budget // MB} MB process budget, 6 of 8 CPU cores, no "
+                     f"dependable compute-shader path",),
+        )
+    if runtime is Runtime.PS5_HEN:
+        # Homebrew under HEN runs in a userland process with the GPU owned by
+        # the system; no compute path, and the allocator is well short of the
+        # game budget (UNVERIFIED: conservative).
+        return Downbin(
+            memory_budget_bytes=8 * GB,
+            reasons=("PS5 HEN homebrew: CPU only, conservative 8 GB allocator "
+                     "budget",),
+        )
+    if runtime is Runtime.PS5_LINUX:
+        # A real Linux userland, so the kernel and page cache cost something.
+        return Downbin(
+            tier_losses={sku.fast_tier.name: 1 * GB},
+            reasons=("ps5-linux kernel/userland reservation",),
+        )
+    if runtime is Runtime.SALVAGE_LINUX:
+        return Downbin(
+            tier_losses={sku.fast_tier.name: 1 * GB},
+            reasons=("Linux kernel/userland reservation on a salvage board",),
+        )
+    return Downbin()
+
+
+def pick_backend(sku: ConsoleSKU, runtime: Runtime,
+                 requested: Optional[ComputeBackend] = None
+                 ) -> Tuple[ComputeBackend, Tuple[str, ...]]:
+    """Choose a compute backend for a unit, with the reasons it was not better.
+
+    ``requested`` is honoured when the SKU can reach it and the runtime allows
+    it; otherwise the best allowed backend is returned along with a warning
+    naming what was refused. GPU compute is only offered where the runtime
+    actually exposes it: ``ps5-linux`` (amdgpu/GFX1013) and an Xbox GDK title.
+    """
+    warnings: List[str] = []
+    allowed: Tuple[ComputeBackend, ...]
+    if runtime is Runtime.SALVAGE_LINUX:
+        allowed = tuple(b for b in sku.backends
+                        if b is not ComputeBackend.D3D12)
+    elif runtime in (Runtime.XBOX_DEVMODE, Runtime.PS5_HEN, Runtime.HOST_SIM):
+        allowed = (ComputeBackend.CPU_AVX2,)
+        if requested is not None and requested.is_gpu:
+            warnings.append(
+                f"{requested.value} refused under {runtime.value}: no usable "
+                f"compute path, falling back to CPU")
+    else:
+        allowed = tuple(b for b in sku.backends
+                        if b is not ComputeBackend.D3D12
+                        or runtime is Runtime.XBOX_GDK)
+    if not allowed:
+        allowed = (ComputeBackend.CPU_AVX2,)
+        warnings.append(f"{sku.sku} exposes no compute backend under "
+                        f"{runtime.value}; using the CPU path")
+    if requested is not None and requested in allowed:
+        chosen = requested
+    else:
+        if requested is not None and requested not in allowed:
+            warnings.append(
+                f"{requested.value} not available on {sku.sku} under "
+                f"{runtime.value}; using {allowed[0].value}")
+        chosen = allowed[0]
+    if chosen is ComputeBackend.ROCM:
+        warnings.append(
+            "ROCm on a console GPU (gfx1013) is only partially supported: some "
+            "libraries do not ship the target and others fall back to a lower "
+            "capability level, so throughput must come from "
+            "measured_gemv_gflops rather than the datasheet")
+    return chosen, tuple(warnings)
+
+
+# --------------------------------------------------------------------------
+# Throughput model
+# --------------------------------------------------------------------------
+# MoE decode is memory-bound, not FLOP-bound: one token reads each active
+# expert's weights once and does two passes of arithmetic over them. So the
+# figure the planner needs is not peak TFLOPS but "how fast can this unit stream
+# weights through its ALUs", which is why the estimate is anchored on bandwidth
+# and only clipped by a fraction of peak compute.
+
+#: Fraction of a tier's peak bandwidth a well-written GEMV kernel sustains.
+#: Conservative; console GPUs are easier to feed than discrete ones because
+#: there is no PCIe hop, but a strided FP8 read with per-block scales is not a
+#: pure streaming load.
+BANDWIDTH_EFFICIENCY = {
+    ComputeBackend.CPU_AVX2: 0.35,
+    ComputeBackend.VULKAN: 0.70,
+    ComputeBackend.ROCM: 0.70,
+    ComputeBackend.D3D12: 0.70,
+}
+
+#: Fraction of peak FP32 a GEMV (arithmetic intensity ~2 flop/byte) can reach.
+COMPUTE_EFFICIENCY = 0.25
+
+
+def _cpu_gflops(cores: int, ghz: float) -> float:
+    """Zen 2 AVX2 peak: 2 FMA units x 8 fp32 lanes x 2 flop, per core."""
+    return cores * ghz * 2 * 8 * 2
+
+
+def estimate_gemv_gflops(backend: ComputeBackend, *, cu_active: int,
+                         gpu_ghz: float, cpu_cores: int, cpu_ghz: float,
+                         bandwidth_gbps: float) -> float:
+    """Sustainable GEMV rate for a unit, in GFLOP/s.
+
+    Memory-bound: bandwidth x 2 flop/byte, clipped by a fraction of peak
+    arithmetic so a hypothetical unit with enormous bandwidth and four CUs is
+    not credited with the bandwidth.
+    """
+    if backend is ComputeBackend.CPU_AVX2:
+        peak = _cpu_gflops(cpu_cores, cpu_ghz)
+    else:
+        # RDNA2: 64 lanes/CU x 2 flop x clock.
+        peak = cu_active * 64 * 2 * gpu_ghz
+    memory_bound = bandwidth_gbps * BANDWIDTH_EFFICIENCY[backend] * 2.0
+    return min(memory_bound, peak * COMPUTE_EFFICIENCY)
+
+
+@dataclass
+class ConsoleUnit:
+    """One physical console in the fleet.
+
+    The inventory describes units, not models: ``sku`` says what it was born as,
+    ``downbin`` says what it is now, and ``measured_gemv_gflops`` lets an
+    operator who has actually benchmarked the box override the estimate (the
+    only honest option for a ROCm node).
+    """
+
+    unit_id: str
+    sku: str
+    runtime: Runtime = Runtime.HOST_SIM
+    backend: Optional[ComputeBackend] = None
+    downbin: Downbin = field(default_factory=Downbin)
+    measured_gemv_gflops: Optional[float] = None
+    devmode_app: bool = False
+    #: Compute units enabled beyond the SKU's driver baseline. The BC-250's
+    #: 40-CU unlock is the only case: the die has 40, the driver lights 24, and
+    #: a community tool raises it at runtime. Capped at ``cu_physical``.
+    cu_enabled_override: Optional[int] = None
+    #: Free-form: rack position, MAC, serial. Carried into the plan untouched.
+    labels: Dict[str, str] = field(default_factory=dict)
+
+    def spec(self) -> ConsoleSKU:
+        return sku_for(self.sku)
+
+    def effective(self) -> EffectiveCapability:
+        """Fold SKU, runtime sandbox, and per-unit losses into one capability."""
+        spec = self.spec()
+        total = runtime_downbin(self.runtime, sku=spec,
+                                devmode_app=self.devmode_app).merge(self.downbin)
+        backend, warnings = pick_backend(spec, self.runtime, self.backend)
+
+        baseline = spec.cu_enabled
+        if self.cu_enabled_override is not None:
+            baseline = min(int(self.cu_enabled_override), spec.cu_physical)
+        cu_active = max(0, baseline - total.cu_disabled)
+        cores = max(1, spec.cpu_cores - total.cpu_cores_disabled)
+        cpu_ghz = min(spec.cpu_ghz, total.cpu_ghz_cap or spec.cpu_ghz)
+        gpu_ghz = min(spec.gpu_ghz, total.gpu_ghz_cap or spec.gpu_ghz)
+        if backend.is_gpu and cu_active == 0:
+            backend = ComputeBackend.CPU_AVX2
+            warnings = warnings + (
+                "every compute unit is disabled on this unit; forced to the CPU "
+                "backend",)
+
+        coffers = _apply_memory_downbin(spec, total)
+        if not coffers:
+            warnings = warnings + (
+                "no memory tier survives this unit's reductions; the planner "
+                "will place nothing here",)
+
+        bandwidth = coffers[0].bandwidth_gbps if coffers else 0.0
+        estimated = estimate_gemv_gflops(
+            backend, cu_active=cu_active, gpu_ghz=gpu_ghz, cpu_cores=cores,
+            cpu_ghz=cpu_ghz, bandwidth_gbps=bandwidth)
+        if self.measured_gemv_gflops is not None:
+            gflops = float(self.measured_gemv_gflops)
+            measured = True
+        else:
+            gflops = estimated
+            measured = False
+            if backend.throughput_is_assumed:
+                warnings = warnings + (
+                    f"{backend.value} throughput is an estimate "
+                    f"({estimated:.0f} GFLOP/s) on a target with incomplete "
+                    f"library support; measure it and set "
+                    f"measured_gemv_gflops",)
+        if (self.cu_enabled_override is not None
+                and self.cu_enabled_override > spec.cu_enabled):
+            warnings = warnings + (
+                f"{cu_active} CUs active via an unlock above the {spec.cu_enabled}"
+                f"-CU driver baseline; this is community reverse-engineering, "
+                f"so verify stability and set measured_gemv_gflops",)
+        for reason in total.reasons:
+            warnings = warnings + (reason,)
+        return EffectiveCapability(
+            unit_id=self.unit_id, sku=spec.sku, runtime=self.runtime,
+            backend=backend, cu_active=cu_active, cpu_cores_active=cores,
+            cpu_ghz=cpu_ghz, gpu_ghz=gpu_ghz, gemv_gflops=gflops,
+            coffers=coffers, storage=spec.storage,
+            throughput_measured=measured, warnings=warnings)
+
+
+def _apply_memory_downbin(spec: ConsoleSKU,
+                          down: Downbin) -> Tuple[MemoryTier, ...]:
+    """Tiers left after OS reservation, per-tier loss, and any sandbox cap.
+
+    Per-tier losses are named explicitly when the operator knows which package
+    or channel died. A sandbox ceiling is different in kind: it does not remove
+    a tier, it caps the sum, so it is applied fastest-tier-first — a Dev Mode
+    process gets its 5 GB out of the 560 GB/s pool before the 336 GB/s one.
+    """
+    tiers: List[MemoryTier] = []
+    for tier in spec.tiers:
+        lost = down.tier_losses.get(tier.name, 0)
+        scale = down.tier_bandwidth_scale.get(tier.name, 1.0)
+        total = max(0, tier.total_bytes - lost)
+        tiers.append(MemoryTier(tier.name, total,
+                                tier.bandwidth_gbps * scale,
+                                min(tier.os_reserved_bytes, total),
+                                tier.usable_for_weights))
+    tiers.sort(key=lambda t: t.bandwidth_gbps, reverse=True)
+
+    if down.memory_budget_bytes is not None:
+        budget = down.memory_budget_bytes
+        capped: List[MemoryTier] = []
+        for tier in tiers:
+            if budget <= 0:
+                break
+            take = min(tier.usable_bytes, budget)
+            budget -= take
+            if take > 0:
+                capped.append(MemoryTier(tier.name, take, tier.bandwidth_gbps,
+                                         0, tier.usable_for_weights))
+        tiers = capped
+    return tuple(t for t in tiers if t.usable_bytes > 0)
+
+
+@dataclass(frozen=True)
+class FleetSummary:
+    """What a fleet adds up to, once every unit's downbin is applied.
+
+    A dataclass rather than a dict because callers ask it arithmetic questions
+    and a typo in a string key should not silently become a KeyError three
+    layers down in a CLI.
+    """
+
+    units: int
+    by_sku: Dict[str, int]
+    weight_bytes: int
+    fast_bytes: int
+    gemv_gflops: float
+    #: Units carrying at least one recorded per-unit loss.
+    downbinned_units: int
+    #: Units whose throughput is a nominal figure rather than a measurement.
+    #: On a ROCm fleet this number being large is the thing to fix first.
+    estimated_throughput_units: int
+    warnings: List[str]
+
+
+def fleet_summary(units: Sequence[ConsoleUnit]) -> FleetSummary:
+    """Aggregate a fleet's effective capability."""
+    caps = [u.effective() for u in units]
+    by_sku: Dict[str, int] = {}
+    for cap in caps:
+        by_sku[cap.sku] = by_sku.get(cap.sku, 0) + 1
+    return FleetSummary(
+        units=len(caps),
+        by_sku=by_sku,
+        weight_bytes=sum(c.weight_bytes for c in caps),
+        fast_bytes=sum(c.fast_bytes for c in caps),
+        gemv_gflops=sum(c.gemv_gflops for c in caps),
+        downbinned_units=sum(1 for u in units if not u.downbin.is_pristine),
+        estimated_throughput_units=sum(1 for c in caps
+                                       if not c.throughput_measured),
+        warnings=sorted({w for c in caps for w in c.warnings}))

--- a/gen9-cluster/gen9_cluster/inventory.py
+++ b/gen9-cluster/gen9_cluster/inventory.py
@@ -1,0 +1,240 @@
+"""Fleet inventory: describing consoles that are not what their labels say.
+
+An inventory file is the operator's description of the hardware they actually
+have. It is JSON because it gets edited by hand at three in the morning next to
+a shelf of consoles, and every field beyond ``unit_id`` and ``sku`` is optional
+with a sane default.
+
+.. code-block:: json
+
+    {
+      "fleet": [
+        {"unit_id": "ps5-01", "sku": "ps5", "runtime": "ps5-linux",
+         "host": "10.0.0.11"},
+
+        {"unit_id": "ps5-02", "sku": "ps5", "runtime": "ps5-linux",
+         "host": "10.0.0.12",
+         "downbin": {"cu_disabled": 4, "gpu_ghz_cap": 1.8,
+                     "reasons": ["dead shader array", "fan replaced, clocked down"]}},
+
+        {"unit_id": "xsx-01", "sku": "xbox-series-x", "runtime": "xbox-devmode",
+         "host": "10.0.0.21", "devmode_app": false},
+
+        {"unit_id": "bc-01", "sku": "bc-250", "runtime": "salvage-linux",
+         "host": "10.0.0.31", "cu_enabled_override": 40,
+         "backend": "rocm", "measured_gemv_gflops": 940.0},
+
+        {"unit_id": "kit-01", "sku": "amd-4700s", "runtime": "salvage-linux",
+         "host": "10.0.0.41",
+         "downbin": {"tier_losses": {"gddr6": 2147483648},
+                     "reasons": ["one GDDR6 package failed memtest"]}}
+      ]
+    }
+
+The ``downbin`` block is the important one and the reason this file exists: it
+is where a unit's *individual* damage goes. Nothing about a second-hand console
+can be inferred from its model name, so anything that makes this unit different
+from a catalogue one — fused-off CUs, a dead memory package, a clock cap, a
+sandbox budget — is recorded per unit, with a human-readable reason that shows
+up in the plan.
+
+``measured_gemv_gflops`` is the other one. Any node whose throughput the planner
+cannot predict — every ROCm node, and anything unusual — should carry a measured
+figure from ``g9-probe``. Without it the planner falls back to an estimate and
+says so.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from .dispatch import NodeAddress
+from .hardware import ComputeBackend, ConsoleUnit, Downbin, Runtime
+
+DEFAULT_PORT = 9713
+
+
+@dataclass
+class FleetEntry:
+    """One console in an inventory file: what it is, and where it is."""
+
+    unit: ConsoleUnit
+    host: str = "127.0.0.1"
+    port: int = DEFAULT_PORT
+
+    @property
+    def address(self) -> NodeAddress:
+        return NodeAddress(self.unit.unit_id, self.host, self.port)
+
+
+def _downbin_from_dict(raw: Dict) -> Downbin:
+    return Downbin(
+        cu_disabled=int(raw.get("cu_disabled", 0)),
+        cpu_cores_disabled=int(raw.get("cpu_cores_disabled", 0)),
+        cpu_ghz_cap=raw.get("cpu_ghz_cap"),
+        gpu_ghz_cap=raw.get("gpu_ghz_cap"),
+        tier_losses={str(k): int(v)
+                     for k, v in (raw.get("tier_losses") or {}).items()},
+        tier_bandwidth_scale={str(k): float(v) for k, v in
+                              (raw.get("tier_bandwidth_scale") or {}).items()},
+        memory_budget_bytes=raw.get("memory_budget_bytes"),
+        reasons=tuple(raw.get("reasons") or ()),
+    )
+
+
+def _downbin_to_dict(downbin: Downbin) -> Dict:
+    out: Dict[str, object] = {}
+    if downbin.cu_disabled:
+        out["cu_disabled"] = downbin.cu_disabled
+    if downbin.cpu_cores_disabled:
+        out["cpu_cores_disabled"] = downbin.cpu_cores_disabled
+    if downbin.cpu_ghz_cap is not None:
+        out["cpu_ghz_cap"] = downbin.cpu_ghz_cap
+    if downbin.gpu_ghz_cap is not None:
+        out["gpu_ghz_cap"] = downbin.gpu_ghz_cap
+    if downbin.tier_losses:
+        out["tier_losses"] = dict(downbin.tier_losses)
+    if downbin.tier_bandwidth_scale:
+        out["tier_bandwidth_scale"] = dict(downbin.tier_bandwidth_scale)
+    if downbin.memory_budget_bytes is not None:
+        out["memory_budget_bytes"] = downbin.memory_budget_bytes
+    if downbin.reasons:
+        out["reasons"] = list(downbin.reasons)
+    return out
+
+
+def entry_from_dict(raw: Dict) -> FleetEntry:
+    try:
+        unit_id = raw["unit_id"]
+        sku = raw["sku"]
+    except KeyError as exc:
+        raise ValueError(f"fleet entry is missing {exc}") from exc
+    backend = raw.get("backend")
+    unit = ConsoleUnit(
+        unit_id=str(unit_id),
+        sku=str(sku),
+        runtime=Runtime(raw.get("runtime", "host-sim")),
+        backend=ComputeBackend(backend) if backend else None,
+        downbin=_downbin_from_dict(raw.get("downbin") or {}),
+        measured_gemv_gflops=raw.get("measured_gemv_gflops"),
+        devmode_app=bool(raw.get("devmode_app", False)),
+        cu_enabled_override=raw.get("cu_enabled_override"),
+        labels={str(k): str(v) for k, v in (raw.get("labels") or {}).items()},
+    )
+    return FleetEntry(unit=unit, host=str(raw.get("host", "127.0.0.1")),
+                      port=int(raw.get("port", DEFAULT_PORT)))
+
+
+def entry_to_dict(entry: FleetEntry) -> Dict:
+    unit = entry.unit
+    out: Dict[str, object] = {"unit_id": unit.unit_id, "sku": unit.sku,
+                              "runtime": unit.runtime.value,
+                              "host": entry.host, "port": entry.port}
+    if unit.backend is not None:
+        out["backend"] = unit.backend.value
+    if unit.measured_gemv_gflops is not None:
+        out["measured_gemv_gflops"] = unit.measured_gemv_gflops
+    if unit.devmode_app:
+        out["devmode_app"] = True
+    if unit.cu_enabled_override is not None:
+        out["cu_enabled_override"] = unit.cu_enabled_override
+    downbin = _downbin_to_dict(unit.downbin)
+    if downbin:
+        out["downbin"] = downbin
+    if unit.labels:
+        out["labels"] = dict(unit.labels)
+    return out
+
+
+def load_fleet(path: Path) -> List[FleetEntry]:
+    """Read an inventory file."""
+    raw = json.loads(Path(path).read_text())
+    entries = raw["fleet"] if isinstance(raw, dict) else raw
+    fleet = [entry_from_dict(item) for item in entries]
+    seen = set()
+    for entry in fleet:
+        if entry.unit.unit_id in seen:
+            raise ValueError(f"duplicate unit_id {entry.unit.unit_id!r} in "
+                             f"{path}")
+        seen.add(entry.unit.unit_id)
+    return fleet
+
+
+def save_fleet(path: Path, fleet: Sequence[FleetEntry]) -> None:
+    payload = {"fleet": [entry_to_dict(e) for e in fleet]}
+    Path(path).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def units(fleet: Sequence[FleetEntry]) -> List[ConsoleUnit]:
+    return [entry.unit for entry in fleet]
+
+
+def addresses(fleet: Sequence[FleetEntry]) -> Dict[str, NodeAddress]:
+    return {entry.unit.unit_id: entry.address for entry in fleet}
+
+
+def synthetic_fleet(counts: Dict[str, int], *,
+                    runtime: Optional[Dict[str, str]] = None,
+                    base_port: int = DEFAULT_PORT) -> List[FleetEntry]:
+    """Build a fleet of nominal consoles, for sizing exercises and tests.
+
+    Useful for the question operators actually ask first — "how many consoles
+    would I need?" — before anyone has bought anything.
+    """
+    defaults = {"ps5": "ps5-linux", "ps5-slim": "ps5-linux",
+                "ps5-pro": "ps5-linux", "xbox-series-x": "xbox-gdk",
+                "xbox-series-s": "xbox-gdk", "amd-4700s": "salvage-linux",
+                "amd-4800s": "salvage-linux", "bc-250": "salvage-linux",
+                "host-sim": "host-sim"}
+    defaults.update(runtime or {})
+    fleet: List[FleetEntry] = []
+    port = base_port
+    for sku, count in counts.items():
+        for index in range(count):
+            unit = ConsoleUnit(unit_id=f"{sku}-{index:03d}", sku=sku,
+                               runtime=Runtime(defaults.get(sku, "host-sim")))
+            fleet.append(FleetEntry(unit=unit, host="127.0.0.1", port=port))
+            port += 1
+    return fleet
+
+
+def deployment_config(plan, fleet: Sequence[FleetEntry]) -> Dict:
+    """Turn a plan plus an inventory into what each console must be told.
+
+    One section per console: the shards to load, whether it hosts hot blocks,
+    and which coffer each shard belongs in. This is the artefact that gets
+    copied to the consoles, and it is deliberately a plain dict so it can be
+    diffed between plans — the usual question after a console dies is "what
+    changed", and that should be answerable with ``diff``.
+    """
+    by_id = {entry.unit.unit_id: entry for entry in fleet}
+    config: Dict[str, object] = {
+        "model": plan.model,
+        "model_assumed": plan.model_assumed,
+        "context_tokens": plan.context_tokens,
+        "estimated_tokens_per_second": round(plan.tokens_per_second, 3),
+        "shelves": [stage.to_dict() for stage in plan.stages],
+        "nodes": {},
+    }
+    nodes: Dict[str, object] = {}
+    for unit_id, unit_plan in sorted(plan.units.items()):
+        entry = by_id.get(unit_id)
+        nodes[unit_id] = {
+            "host": entry.host if entry else None,
+            "port": entry.port if entry else None,
+            "sku": unit_plan.sku,
+            "backend": unit_plan.backend,
+            "hot_layers": unit_plan.hot_layers,
+            "dense_layers": unit_plan.dense_layers,
+            "io_pieces": unit_plan.io_pieces,
+            "resident_bytes": unit_plan.resident_bytes,
+            "capacity_bytes": unit_plan.capacity_bytes,
+            "ssd_expert_bytes": unit_plan.ssd_expert_bytes,
+            "shards": [shard.to_dict() for shard in unit_plan.shards],
+            "warnings": unit_plan.warnings,
+        }
+    config["nodes"] = nodes
+    return config

--- a/gen9-cluster/gen9_cluster/model.py
+++ b/gen9-cluster/gen9_cluster/model.py
@@ -1,0 +1,364 @@
+"""DeepSeek model profiles: what the planner needs to know about a checkpoint.
+
+DeepSeek's V3-family decoder has three properties that decide how it splits
+across consoles, and they pull in different directions:
+
+1. **MLA** (multi-head latent attention) compresses the KV cache to a single
+   ``kv_lora_rank``-wide latent plus a small RoPE key per token, so the cache is
+   ~1/10 the size of an equivalent GQA model's. That is what makes a 16 GB
+   console a plausible attention host at all, but the attention block's own
+   weights are read for *every* token, so they must live in a fast coffer.
+2. **DeepSeekMoE** puts many narrow routed experts plus one always-on shared
+   expert in each MoE layer. Only ``top_k`` of the routed experts run per token,
+   so the routed weights are enormous but cold — exactly what a bandwidth-tiered
+   coffer hierarchy and a 5.5 GB/s NVMe are for.
+3. **FP8 blockwise weights**: the checkpoint is natively FP8 (E4M3) with a scale
+   per 128-element block, so a console holds weights in the format it received
+   them and dequantises per block inside the kernel. No requantisation pass, and
+   the packed size is what the planner reasons about.
+
+Sizes here are computed from the architecture, not read off a file listing, so a
+profile can be edited (or a new one declared) and every derived number follows.
+
+**Honesty about V4 Pro.** No DeepSeek V4 Pro configuration is public at the time
+of writing. :data:`DEEPSEEK_V4_PRO` is therefore an *assumed* profile: it keeps
+the V3 shape that is known to work and scales the dimensions that DeepSeek has
+historically scaled between generations. It is marked ``assumed=True``, every
+tool that prints a plan prints that flag, and the field values are the only thing
+that needs editing when the real config appears. :data:`DEEPSEEK_V3` is the
+verified profile and is what the tests pin numerically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional
+
+#: Bytes per parameter for the formats a console can hold.
+DTYPE_BYTES = {"fp8": 1.0, "bf16": 2.0, "fp16": 2.0, "fp32": 4.0, "mxfp4": 0.5625}
+
+
+@dataclass(frozen=True)
+class MLAConfig:
+    """Multi-head latent attention shape."""
+
+    n_heads: int
+    kv_lora_rank: int
+    q_lora_rank: Optional[int]
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+
+    @property
+    def qk_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+    def kv_cache_bytes_per_token(self, dtype: str = "bf16") -> int:
+        """One layer's KV cache cost for one token.
+
+        MLA stores the compressed latent (``kv_lora_rank``) plus the decoupled
+        RoPE key (``qk_rope_head_dim``), shared across heads — the whole point of
+        the architecture, and the reason a console can hold a long context.
+        """
+        width = self.kv_lora_rank + self.qk_rope_head_dim
+        return int(round(width * DTYPE_BYTES[dtype]))
+
+    def weight_params(self, hidden_size: int) -> int:
+        """Parameters in one MLA block."""
+        q_out = self.n_heads * self.qk_head_dim
+        if self.q_lora_rank is None:
+            q = hidden_size * q_out
+        else:
+            q = (hidden_size * self.q_lora_rank
+                 + self.q_lora_rank * q_out)
+        # Joint KV down-projection (latent + decoupled RoPE key), then up.
+        kv_down = hidden_size * (self.kv_lora_rank + self.qk_rope_head_dim)
+        kv_up = (self.kv_lora_rank * self.n_heads
+                 * (self.qk_nope_head_dim + self.v_head_dim))
+        out = self.n_heads * self.v_head_dim * hidden_size
+        return q + kv_down + kv_up + out
+
+
+@dataclass(frozen=True)
+class MoEConfig:
+    """DeepSeekMoE shape: many narrow routed experts plus shared experts."""
+
+    n_routed_experts: int
+    n_shared_experts: int
+    top_k: int
+    moe_intermediate_size: int
+    #: Leading layers that use a dense MLP instead of MoE.
+    n_dense_layers: int
+    dense_intermediate_size: int
+    #: Experts are grouped for device-limited routing; a token's top-k is drawn
+    #: from at most ``topk_group`` of ``n_group`` groups. The planner uses this
+    #: to bound how many consoles a single token can touch.
+    n_group: int = 1
+    topk_group: int = 1
+
+    def expert_params(self) -> int:
+        """One routed expert: gate, up, down."""
+        return 3 * self.moe_intermediate_size
+
+    def dense_mlp_params(self, hidden_size: int) -> int:
+        return 3 * hidden_size * self.dense_intermediate_size
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    """Everything the planner needs about a DeepSeek checkpoint."""
+
+    name: str
+    n_layers: int
+    hidden_size: int
+    vocab_size: int
+    mla: MLAConfig
+    moe: MoEConfig
+    dtype: str = "fp8"
+    #: Multi-token-prediction heads (V3 ships one). Each is a whole extra
+    #: decoder block plus a head, so it is placed like a layer, not folded in.
+    n_mtp_heads: int = 1
+    #: True when the configuration is extrapolated rather than published.
+    assumed: bool = False
+    assumptions: tuple = ()
+
+    # -- per-piece sizes ---------------------------------------------------
+    @property
+    def bytes_per_param(self) -> float:
+        return DTYPE_BYTES[self.dtype]
+
+    @property
+    def n_moe_layers(self) -> int:
+        return max(0, self.n_layers - self.moe.n_dense_layers)
+
+    @property
+    def planning_layers(self) -> int:
+        """Blocks the planner has to place.
+
+        An MTP head is a whole decoder block plus a projection, not a small
+        appendage, so it is placed exactly like a layer rather than treated as
+        one indivisible lump that no console can hold.
+        """
+        return self.n_layers + self.n_mtp_heads
+
+    def expert_bytes(self) -> int:
+        """One routed expert, packed.
+
+        FP8 blockwise weights carry one fp32 scale per 128-element block, which
+        is a ~3% overhead that is small but not nothing when it decides whether a
+        layer's experts fit a 10 GB coffer.
+        """
+        params = self.moe.expert_params() * self.hidden_size
+        raw = params * self.bytes_per_param
+        return int(round(raw * (1.0 + self._scale_overhead())))
+
+    def _scale_overhead(self) -> float:
+        return 4.0 / 128.0 if self.dtype == "fp8" else 0.0
+
+    def shared_expert_bytes(self) -> int:
+        return self.expert_bytes() * self.moe.n_shared_experts
+
+    def attention_bytes(self) -> int:
+        raw = self.mla.weight_params(self.hidden_size) * self.bytes_per_param
+        return int(round(raw * (1.0 + self._scale_overhead())))
+
+    def router_bytes(self) -> int:
+        """Router matrix plus its bias; tiny, but read for every token."""
+        raw = (self.hidden_size * self.moe.n_routed_experts
+               + self.moe.n_routed_experts) * self.bytes_per_param
+        return int(round(raw))
+
+    def dense_mlp_bytes(self) -> int:
+        raw = self.moe.dense_mlp_params(self.hidden_size) * self.bytes_per_param
+        return int(round(raw * (1.0 + self._scale_overhead())))
+
+    def hot_bytes_per_moe_layer(self) -> int:
+        """Weights an MoE layer reads for *every* token.
+
+        Attention + router + shared expert + norms. This is the quantity that
+        must land in a fast coffer; the routed experts are the cold remainder.
+        """
+        norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
+        return (self.attention_bytes() + self.router_bytes()
+                + self.shared_expert_bytes() + norms)
+
+    def cold_bytes_per_moe_layer(self) -> int:
+        return self.expert_bytes() * self.moe.n_routed_experts
+
+    def dense_layer_bytes(self) -> int:
+        norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
+        return self.attention_bytes() + self.dense_mlp_bytes() + norms
+
+    def embedding_bytes(self) -> int:
+        return int(round(self.vocab_size * self.hidden_size
+                         * DTYPE_BYTES["bf16"]))
+
+    def lm_head_bytes(self) -> int:
+        return self.embedding_bytes()
+
+    def mtp_projection_bytes(self) -> int:
+        """The extra projection an MTP head carries on top of a decoder block."""
+        return int(round(2 * self.hidden_size * self.hidden_size
+                         * self.bytes_per_param))
+
+    def mtp_hot_bytes(self) -> int:
+        """Per-token weights of one MTP head: its hot block plus projection."""
+        return self.hot_bytes_per_moe_layer() + self.mtp_projection_bytes()
+
+    def mtp_bytes(self) -> int:
+        """All MTP heads, weights in full."""
+        if self.n_mtp_heads == 0:
+            return 0
+        return self.n_mtp_heads * (self.mtp_hot_bytes()
+                                   + self.cold_bytes_per_moe_layer())
+
+    def total_bytes(self) -> int:
+        return (self.moe.n_dense_layers * self.dense_layer_bytes()
+                + self.n_moe_layers * (self.hot_bytes_per_moe_layer()
+                                       + self.cold_bytes_per_moe_layer())
+                + self.embedding_bytes() + self.lm_head_bytes()
+                + self.mtp_bytes())
+
+    def total_params(self) -> int:
+        """Parameter count, for sanity-checking a profile against a model card."""
+        per_expert = self.moe.expert_params() * self.hidden_size
+        attn = self.mla.weight_params(self.hidden_size)
+        return int(
+            self.moe.n_dense_layers * (attn + self.moe.dense_mlp_params(
+                self.hidden_size))
+            + self.n_moe_layers * (
+                attn + self.hidden_size * self.moe.n_routed_experts
+                + per_expert * (self.moe.n_routed_experts
+                                + self.moe.n_shared_experts))
+            + 2 * self.vocab_size * self.hidden_size)
+
+    def activated_params(self) -> int:
+        """Parameters a single token actually multiplies against."""
+        per_expert = self.moe.expert_params() * self.hidden_size
+        attn = self.mla.weight_params(self.hidden_size)
+        return int(
+            self.moe.n_dense_layers * (attn + self.moe.dense_mlp_params(
+                self.hidden_size))
+            + self.n_moe_layers * (
+                attn + per_expert * (self.moe.top_k
+                                     + self.moe.n_shared_experts))
+            + self.vocab_size * self.hidden_size)
+
+    def kv_cache_bytes(self, context_tokens: int, dtype: str = "bf16") -> int:
+        return (self.n_layers * context_tokens
+                * self.mla.kv_cache_bytes_per_token(dtype))
+
+    def activation_bytes(self, dtype: str = "bf16") -> int:
+        """One token's hidden state on the wire between pipeline stages."""
+        return int(round(self.hidden_size * DTYPE_BYTES[dtype]))
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+# --------------------------------------------------------------------------
+# Profiles
+# --------------------------------------------------------------------------
+
+#: DeepSeek-V3 / R1, from the published config: 671 B total / 37 B activated,
+#: 61 layers, hidden 7168, 256 routed + 1 shared expert per MoE layer, top-8
+#: within 4 of 8 groups, first 3 layers dense, MLA with a 512-wide latent, one
+#: MTP head, native FP8. Used as the verified reference the tests pin.
+DEEPSEEK_V3 = ModelProfile(
+    name="deepseek-v3",
+    n_layers=61,
+    hidden_size=7168,
+    vocab_size=129280,
+    mla=MLAConfig(n_heads=128, kv_lora_rank=512, q_lora_rank=1536,
+                  qk_nope_head_dim=128, qk_rope_head_dim=64, v_head_dim=128),
+    moe=MoEConfig(n_routed_experts=256, n_shared_experts=1, top_k=8,
+                  moe_intermediate_size=2048, n_dense_layers=3,
+                  dense_intermediate_size=18432, n_group=8, topk_group=4),
+    dtype="fp8",
+    n_mtp_heads=1,
+)
+
+#: DeepSeek V4 Pro — **assumed**. No configuration has been published; this keeps
+#: the V3 decoder shape (the part that is architecture, not scale) and scales the
+#: dimensions DeepSeek has scaled before. Every consumer of this profile prints
+#: the ``assumed`` flag; replace the numbers, not the code, when the real config
+#: lands.
+DEEPSEEK_V4_PRO = ModelProfile(
+    name="deepseek-v4-pro",
+    n_layers=72,
+    hidden_size=8192,
+    vocab_size=131072,
+    mla=MLAConfig(n_heads=160, kv_lora_rank=512, q_lora_rank=1536,
+                  qk_nope_head_dim=128, qk_rope_head_dim=64, v_head_dim=128),
+    moe=MoEConfig(n_routed_experts=384, n_shared_experts=1, top_k=8,
+                  moe_intermediate_size=2048, n_dense_layers=3,
+                  dense_intermediate_size=20480, n_group=12, topk_group=4),
+    dtype="fp8",
+    n_mtp_heads=2,
+    assumed=True,
+    assumptions=(
+        "no DeepSeek V4 Pro configuration is public; the decoder shape is V3's",
+        "layer count, hidden size, head count, routed-expert count and MTP "
+        "depth are extrapolated from the V2 -> V3 progression",
+        "expert width (moe_intermediate_size) is held at V3's 2048, which is "
+        "what keeps one expert small enough to be a unit of placement",
+        "weights are assumed natively FP8 E4M3 with 128-element block scales, "
+        "as in V3",
+    ),
+)
+
+#: A small MoE with the same architecture, for a fleet of two or three consoles
+#: and for CI. Not a real checkpoint; a shape.
+DEEPSEEK_TINY = ModelProfile(
+    name="deepseek-tiny",
+    n_layers=8,
+    hidden_size=1024,
+    vocab_size=32768,
+    mla=MLAConfig(n_heads=16, kv_lora_rank=128, q_lora_rank=None,
+                  qk_nope_head_dim=64, qk_rope_head_dim=32, v_head_dim=64),
+    moe=MoEConfig(n_routed_experts=32, n_shared_experts=1, top_k=4,
+                  moe_intermediate_size=512, n_dense_layers=1,
+                  dense_intermediate_size=2048, n_group=4, topk_group=2),
+    dtype="fp8",
+    n_mtp_heads=0,
+)
+
+PROFILES: Dict[str, ModelProfile] = {
+    p.name: p for p in (DEEPSEEK_V3, DEEPSEEK_V4_PRO, DEEPSEEK_TINY)
+}
+
+
+def profile_for(name: str) -> ModelProfile:
+    if name not in PROFILES:
+        raise KeyError(f"unknown model profile {name!r}; known: {sorted(PROFILES)}")
+    return PROFILES[name]
+
+
+def describe(profile: ModelProfile) -> List[str]:
+    """Human-readable size breakdown, shared by the CLIs."""
+    gib = 1024 ** 3
+    mib = 1024 ** 2
+    lines = [
+        f"{profile.name}  ({profile.dtype}"
+        + (", ASSUMED CONFIGURATION" if profile.assumed else "") + ")",
+        f"  layers                {profile.n_layers} "
+        f"({profile.moe.n_dense_layers} dense, {profile.n_moe_layers} MoE)",
+        f"  hidden                {profile.hidden_size}",
+        f"  routed experts/layer  {profile.moe.n_routed_experts} "
+        f"(top-{profile.moe.top_k} of {profile.moe.topk_group}/"
+        f"{profile.moe.n_group} groups)",
+        f"  params total          {profile.total_params() / 1e9:.1f} B",
+        f"  params activated      {profile.activated_params() / 1e9:.1f} B",
+        f"  weights total         {profile.total_bytes() / gib:.1f} GiB",
+        f"  one routed expert     {profile.expert_bytes() / mib:.2f} MiB",
+        f"  hot per MoE layer     "
+        f"{profile.hot_bytes_per_moe_layer() / mib:.1f} MiB",
+        f"  cold per MoE layer    "
+        f"{profile.cold_bytes_per_moe_layer() / gib:.2f} GiB",
+        f"  KV cache @ 8k ctx     "
+        f"{profile.kv_cache_bytes(8192) / mib:.0f} MiB",
+    ]
+    if profile.assumed:
+        lines.append("  assumptions:")
+        lines.extend(f"    - {a}" for a in profile.assumptions)
+    return lines

--- a/gen9-cluster/gen9_cluster/model.py
+++ b/gen9-cluster/gen9_cluster/model.py
@@ -130,7 +130,7 @@ class MLAConfig(AttentionConfig):
     def kind(self, layer: int = 0) -> str:
         return "mla"
 
-    def kv_cache_bytes_per_token(self, dtype: str = "bf16",
+    def kv_cache_bytes_per_token(self, dtype: str = "fp8",
                                  layer: int = 0) -> int:
         """One layer's KV cache cost for one token.
 
@@ -138,8 +138,8 @@ class MLAConfig(AttentionConfig):
         RoPE key (``qk_rope_head_dim``), shared across heads — the whole point of
         the architecture, and the reason a console can hold a long context.
         """
-        width = self.kv_lora_rank + self.qk_rope_head_dim
-        return int(round(width * DTYPE_BYTES[dtype]))
+        return int(round(self.kv_lora_rank * DTYPE_BYTES[dtype]
+                         + self.qk_rope_head_dim * DTYPE_BYTES["bf16"]))
 
     def weight_params(self, hidden_size: int, layer: int = 0) -> int:
         """Parameters in one MLA block."""
@@ -220,67 +220,80 @@ class HybridAttentionConfig(AttentionConfig):
 
     def weight_params(self, hidden_size: int, layer: int = 0) -> int:
         d, c, nh = hidden_size, self.head_dim, self.n_heads
-        kind = self.kind(layer)
+        ratio = self.ratio(layer)
         # Queries: down to d_c, then up to one c-wide query per head.
         q = d * self.q_lora_rank + self.q_lora_rank * nh * c
+        # Base KV projection: the sliding-window branch exists on every layer,
+        # including ones that also carry a compressed branch.
+        kv_base = d * c
         # Grouped output: heads within a group share an intermediate of width
         # d_g, and each group projects back to d.
         out = nh * c * self.o_group_dim + self.o_groups * self.o_group_dim * d
-        if kind == "csa":
-            # Two overlapping KV series and their compression weights, plus the
-            # learnable positional bias each compression window carries.
-            kv = 4 * d * c + 2 * self.csa_ratio * c
-            indexer = (d * self.index_n_heads * self.index_head_dim
-                       + d * self.index_head_dim + self.index_n_heads)
-        elif kind == "hca":
-            kv = 2 * d * c + self.hca_ratio * c
-            indexer = 0
-        else:
-            # No compression: one shared KV entry straight off the hidden state.
-            kv = d * c
-            indexer = 0
-        return q + kv + out + indexer
+        params = q + kv_base + out + self.q_lora_rank + c + nh
+        if ratio <= 1:
+            # Pure sliding-window attention: one KV entry, no compression.
+            return params
+        # Heavily or sparsely compressed KV: two gating projections plus a
+        # per-compression-window positional bias.  CSA uses overlapping windows.
+        coff = 2 if ratio == self.csa_ratio else 1
+        kv_compress = coff * d * c + coff * d * c + ratio * coff * c + c
+        params += kv_compress
+        if ratio == self.csa_ratio:
+            # Lightning indexer: queries from the q-lora bottleneck, per-head
+            # weights from the hidden state, and its own overlapping compressor.
+            idx_c = self.index_head_dim
+            idx_coff = 2
+            params += (self.q_lora_rank * self.index_n_heads * idx_c
+                       + d * self.index_n_heads
+                       + idx_coff * d * idx_c
+                       + idx_coff * d * idx_c
+                       + ratio * idx_coff * idx_c
+                       + idx_c)
+        return params
 
-    def kv_cache_bytes_per_token(self, dtype: str = "bf16",
+    def kv_entry_bytes(self, dtype: str = "fp8") -> float:
+        """Bytes of one cached KV entry: FP8 for the non-RoPE part, BF16 for
+        the RoPE part, matching the V4 checkpoint format."""
+        nope = self.head_dim - self.qk_rope_head_dim
+        return nope * DTYPE_BYTES[dtype] + self.qk_rope_head_dim * DTYPE_BYTES["bf16"]
+
+    def kv_cache_bytes_per_token(self, dtype: str = "fp8",
                                  layer: int = 0) -> int:
         kind = self.kind(layer)
         if kind == "swa":
             return 0  # the window is a fixed-size state, see state_bytes
-        ratio = self.csa_ratio if kind == "csa" else self.hca_ratio
-        entry = self.head_dim * DTYPE_BYTES[dtype] / ratio
+        ratio = self.ratio(layer)
+        entry = self.kv_entry_bytes(dtype) / ratio
         if kind == "csa":
             entry += (self.index_head_dim
                       * self.index_quant.bytes_per_param / ratio)
         return int(round(entry))
 
-    def state_bytes(self, dtype: str = "bf16", layer: int = 0) -> int:
+    def state_bytes(self, dtype: str = "fp8", layer: int = 0) -> int:
         """The sliding-window branch, which every layer carries.
 
         Uncompressed tail tokens live here too; both are bounded, which is why
         DeepSeek's own serving stack treats them as a fixed pool rather than as
         part of the growing cache.
         """
-        return int(round(self.sliding_window * self.head_dim
-                         * DTYPE_BYTES[dtype]))
+        return int(round(self.sliding_window * self.kv_entry_bytes(dtype)))
 
-    def kv_read_bytes(self, context_tokens: int, dtype: str = "bf16",
+    def kv_read_bytes(self, context_tokens: int, dtype: str = "fp8",
                       layer: int = 0) -> int:
         kind = self.kind(layer)
         state = self.state_bytes(dtype, layer)
         if kind == "swa":
             return state
+        ratio = self.ratio(layer)
+        entries = context_tokens / ratio
         if kind == "hca":
-            entries = context_tokens / self.hca_ratio
-            return int(round(entries * self.head_dim * DTYPE_BYTES[dtype])
-                       + state)
+            return int(round(entries * self.kv_entry_bytes(dtype) + state))
         # CSA scans every compressed entry with the FP4 indexer, then reads only
         # the top-k it selected.
-        entries = context_tokens / self.csa_ratio
         scan = (entries * self.index_head_dim
                 * self.index_quant.bytes_per_param)
         selected = min(entries, float(self.index_topk))
-        return int(round(scan + selected * self.head_dim * DTYPE_BYTES[dtype])
-                   + state)
+        return int(round(scan + selected * self.kv_entry_bytes(dtype) + state))
 
 
 @dataclass(frozen=True)
@@ -383,11 +396,49 @@ class ModelProfile:
         params = self.attention.weight_params(self.hidden_size, layer)
         return int(round(params * self.bytes_per_param))
 
+    def _hc_dim(self) -> int:
+        return self.hc_mult * self.hidden_size
+
+    def _mix_hc(self) -> int:
+        return (2 + self.hc_mult) * self.hc_mult
+
+    def _hc_params(self) -> int:
+        """Float parameters in one block's two hyper-connection mappings."""
+        return 2 * (self._mix_hc() * self._hc_dim() + self._mix_hc() + 3)
+
+    def _hc_bytes(self) -> int:
+        return int(round(self._hc_params() * self.bytes_per_param))
+
+    def _final_head_params(self) -> int:
+        params = self.hidden_size
+        if self.hc_mult > 1:
+            params += self.hc_mult * self._hc_dim() + self.hc_mult + 1
+        return params
+
+    def _final_head_bytes(self) -> int:
+        hc_params = 0
+        if self.hc_mult > 1:
+            hc_params = self.hc_mult * self._hc_dim() + self.hc_mult + 1
+        return int(round(self.hidden_size * DTYPE_BYTES["bf16"]
+                         + hc_params * self.bytes_per_param))
+
+    def _mtp_extra_params(self) -> int:
+        params = 3 * self.hidden_size
+        if self.hc_mult > 1:
+            params += self.hc_mult * self._hc_dim() + self.hc_mult + 1
+        return params
+
+    def _mtp_extra_bytes(self) -> int:
+        hc_params = 0
+        if self.hc_mult > 1:
+            hc_params = self.hc_mult * self._hc_dim() + self.hc_mult + 1
+        return int(round(3 * self.hidden_size * DTYPE_BYTES["bf16"]
+                         + hc_params * self.bytes_per_param))
+
     def router_bytes(self) -> int:
-        """Router matrix plus its bias; tiny, but read for every token."""
-        raw = (self.hidden_size * self.moe.n_routed_experts
-               + self.moe.n_routed_experts) * self.bytes_per_param
-        return int(round(raw))
+        """Router matrix; the bias/hash table is added per-layer."""
+        return int(round(self.hidden_size * self.moe.n_routed_experts
+                         * self.bytes_per_param))
 
     def dense_mlp_bytes(self) -> int:
         raw = self.moe.dense_mlp_params(self.hidden_size) * self.bytes_per_param
@@ -396,22 +447,31 @@ class ModelProfile:
     def hot_bytes_per_moe_layer(self, layer: int = 0) -> int:
         """Weights an MoE layer reads for *every* token.
 
-        Attention + router + shared expert + norms. This is the quantity that
-        must land in a fast coffer; the routed experts are the cold remainder.
-        The hyper-connection mappings are generated from the hidden state and
-        come to well under a tenth of a percent of this, so they are left out
-        rather than guessed at.
+        Attention + router + shared expert + input/post norms +
+        hyper-connections + the gate's hash table or bias. This is the quantity
+        that must land in a fast coffer; the routed experts are the cold
+        remainder.
         """
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
+        gate_extras = 0
+        if layer >= self.moe.n_dense_layers:
+            if layer < self.moe.n_hash_layers:
+                gate_extras = int(round(self.vocab_size * self.moe.top_k * 4))
+            else:
+                gate_extras = int(round(self.moe.n_routed_experts
+                                        * self.bytes_per_param))
+        hc = self._hc_bytes() if self.hc_mult > 1 else 0
         return (self.attention_bytes(layer) + self.router_bytes()
-                + self.shared_expert_bytes() + norms)
+                + gate_extras + self.shared_expert_bytes()
+                + norms + hc)
 
     def cold_bytes_per_moe_layer(self) -> int:
         return self.expert_bytes() * self.moe.n_routed_experts
 
     def dense_layer_bytes(self, layer: int = 0) -> int:
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
-        return self.attention_bytes(layer) + self.dense_mlp_bytes() + norms
+        hc = self._hc_bytes() if self.hc_mult > 1 else 0
+        return self.attention_bytes(layer) + self.dense_mlp_bytes() + norms + hc
 
     def embedding_bytes(self) -> int:
         return int(round(self.vocab_size * self.hidden_size
@@ -428,7 +488,7 @@ class ModelProfile:
     def mtp_hot_bytes(self, head: int = 0) -> int:
         """Per-token weights of one MTP head: its hot block plus projection."""
         return (self.hot_bytes_per_moe_layer(self.n_layers + head)
-                + self.mtp_projection_bytes())
+                + self.mtp_projection_bytes() + self._mtp_extra_bytes())
 
     def mtp_bytes(self) -> int:
         """All MTP heads, weights in full."""
@@ -446,7 +506,8 @@ class ModelProfile:
         return self.mtp_hot_bytes(index - self.n_layers)
 
     def total_bytes(self) -> int:
-        weights = self.embedding_bytes() + self.lm_head_bytes() + self.mtp_bytes()
+        weights = (self.embedding_bytes() + self.lm_head_bytes()
+                   + self._final_head_bytes() + self.mtp_bytes())
         for index in range(self.n_layers):
             if index < self.moe.n_dense_layers:
                 weights += self.dense_layer_bytes(index)
@@ -464,17 +525,28 @@ class ModelProfile:
         """
         per_expert = self.moe.expert_params() * self.hidden_size
         params = 2 * self.vocab_size * self.hidden_size
+        params += self._final_head_params()
         blocks = self.planning_layers if include_mtp else self.n_layers
         for index in range(blocks):
             attn = self.attention.weight_params(self.hidden_size, index)
+            params += attn
+            # input and post-attention RMSNorms
+            params += 2 * self.hidden_size
+            if self.hc_mult > 1:
+                params += self._hc_params()
             if index < self.moe.n_dense_layers:
-                params += attn + self.moe.dense_mlp_params(self.hidden_size)
+                params += self.moe.dense_mlp_params(self.hidden_size)
                 continue
-            params += (attn + self.hidden_size * self.moe.n_routed_experts
-                       + per_expert * (self.moe.n_routed_experts
-                                       + self.moe.n_shared_experts))
+            params += self.hidden_size * self.moe.n_routed_experts
+            if index < self.moe.n_hash_layers:
+                params += self.vocab_size * self.moe.top_k
+            else:
+                params += self.moe.n_routed_experts
+            params += per_expert * (self.moe.n_routed_experts
+                                    + self.moe.n_shared_experts)
             if index >= self.n_layers:
                 params += 2 * self.hidden_size * self.hidden_size
+                params += self._mtp_extra_params()
         return int(params)
 
     def activated_params(self) -> int:
@@ -490,31 +562,32 @@ class ModelProfile:
             if index < self.moe.n_dense_layers:
                 params += attn + self.moe.dense_mlp_params(self.hidden_size)
                 continue
-            params += attn + per_expert * (self.moe.top_k
-                                           + self.moe.n_shared_experts)
+            params += (attn + self.hidden_size * self.moe.n_routed_experts
+                       + per_expert * (self.moe.top_k
+                                       + self.moe.n_shared_experts))
         return int(params)
 
     def kv_cache_bytes_for_layer(self, layer: int, context_tokens: int,
-                                 dtype: str = "bf16") -> int:
+                                 dtype: str = "fp8") -> int:
         """Cache one layer holds for one sequence at this context length."""
         per_token = self.attention.kv_cache_bytes_per_token(dtype, layer)
         return context_tokens * per_token + self.attention.state_bytes(dtype,
                                                                        layer)
 
     def kv_read_bytes_for_layer(self, layer: int, context_tokens: int,
-                                dtype: str = "bf16") -> int:
+                                dtype: str = "fp8") -> int:
         """Cache one layer *reads* to decode one token.
 
         Equal to what it holds under dense attention, and far less under CSA.
         """
         return self.attention.kv_read_bytes(context_tokens, dtype, layer)
 
-    def kv_cache_bytes(self, context_tokens: int, dtype: str = "bf16") -> int:
+    def kv_cache_bytes(self, context_tokens: int, dtype: str = "fp8") -> int:
         return sum(self.kv_cache_bytes_for_layer(layer, context_tokens, dtype)
                    for layer in range(self.n_layers))
 
     def block_kv_bytes(self, index: int, context_tokens: int,
-                       dtype: str = "bf16") -> int:
+                       dtype: str = "fp8") -> int:
         """Cache block ``index`` holds, MTP heads included.
 
         An MTP head runs its own attention and so keeps its own cache; it is
@@ -523,7 +596,7 @@ class ModelProfile:
         return self.kv_cache_bytes_for_layer(index, context_tokens, dtype)
 
     def block_kv_read_bytes(self, index: int, context_tokens: int,
-                            dtype: str = "bf16") -> int:
+                            dtype: str = "fp8") -> int:
         return self.kv_read_bytes_for_layer(index, context_tokens, dtype)
 
     def activation_bytes(self, dtype: str = "bf16") -> int:
@@ -578,11 +651,12 @@ _V4_PRO_RATIOS: Tuple[int, ...] = tuple(
 _V4_FLASH_RATIOS: Tuple[int, ...] = tuple(
     [0, 0] + [4, 128] * 20 + [4, 0])
 
-#: DeepSeek-V4-Pro, from the published config: 1.6 T total / 49 B activated, 61
-#: layers, hidden 7168, all-MoE with 384 routed + 1 shared expert, top-6, hash
-#: gating on the first three layers, hybrid CSA (m=4, top-1024) and HCA (m'=128)
-#: attention with 128 query heads of width 512, one MTP head, hyper-connection
-#: width 4. Expert weights are MXFP4 and everything else is FP8.
+#: DeepSeek-V4-Pro, from the published config: 1,599 B total
+#: (1,573 B excluding the MTP head) / 49 B activated, 61 layers, hidden 7168,
+#: all-MoE with 384 routed + 1 shared expert, top-6, hash gating on the first
+#: three layers, hybrid CSA (m=4, top-1024) and HCA (m'=128) attention with 128
+#: query heads of width 512, one MTP head, hyper-connection width 4. Expert
+#: weights are MXFP4 and everything else is FP8.
 DEEPSEEK_V4_PRO = ModelProfile(
     name="deepseek-v4-pro",
     n_layers=61,
@@ -604,8 +678,9 @@ DEEPSEEK_V4_PRO = ModelProfile(
     source="deepseek-ai/DeepSeek-V4-Pro config.json; arXiv:2606.19348 §4.2.1",
 )
 
-#: DeepSeek-V4-Flash, from the published config: 284 B total / 13 B activated,
-#: 43 layers, hidden 4096, 256 routed + 1 shared expert, top-6, the same hybrid
+#: DeepSeek-V4-Flash, from the published config: 291 B total
+#: (284 B excluding the MTP head) / 13 B activated, 43 layers, hidden 4096,
+#: 256 routed + 1 shared expert, top-6, the same hybrid
 #: attention with 64 query heads and a 512-entry indexer top-k, and pure
 #: sliding-window attention in the first two blocks. Same mixed FP4/FP8 weights
 #: as Pro, at a fifth of the size — which is the whole reason to care about it

--- a/gen9-cluster/gen9_cluster/model.py
+++ b/gen9-cluster/gen9_cluster/model.py
@@ -1,46 +1,120 @@
 """DeepSeek model profiles: what the planner needs to know about a checkpoint.
 
-DeepSeek's V3-family decoder has three properties that decide how it splits
-across consoles, and they pull in different directions:
+A DeepSeek decoder splits across consoles according to four properties, and they
+pull in different directions:
 
-1. **MLA** (multi-head latent attention) compresses the KV cache to a single
-   ``kv_lora_rank``-wide latent plus a small RoPE key per token, so the cache is
-   ~1/10 the size of an equivalent GQA model's. That is what makes a 16 GB
-   console a plausible attention host at all, but the attention block's own
-   weights are read for *every* token, so they must live in a fast coffer.
+1. **Compressed attention.** V3 uses MLA, which squeezes the KV cache into one
+   ``kv_lora_rank``-wide latent plus a decoupled RoPE key per token. V4 replaces
+   it with a *hybrid* of CSA and HCA (:class:`HybridAttentionConfig`), which
+   compresses along the sequence instead: every ``m`` tokens become one cache
+   entry. Either way the cache is small enough that a 16 GB console can host
+   attention, and either way the block's own weights are read for every token,
+   so they belong in a fast coffer.
 2. **DeepSeekMoE** puts many narrow routed experts plus one always-on shared
    expert in each MoE layer. Only ``top_k`` of the routed experts run per token,
    so the routed weights are enormous but cold — exactly what a bandwidth-tiered
-   coffer hierarchy and a 5.5 GB/s NVMe are for.
-3. **FP8 blockwise weights**: the checkpoint is natively FP8 (E4M3) with a scale
-   per 128-element block, so a console holds weights in the format it received
-   them and dequantises per block inside the kernel. No requantisation pass, and
-   the packed size is what the planner reasons about.
+   coffer hierarchy and an NVMe are for.
+3. **Mixed-precision weights.** V3 is FP8 (E4M3) throughout. V4 keeps FP8 for
+   everything read every token and drops the *expert* weights to MXFP4, which is
+   where nearly all the bytes are: it roughly halves what a fleet has to hold.
+   :class:`QuantSpec` carries the format and its block scales, so the packed
+   size — the thing the planner actually reasons about — follows from the
+   checkpoint's own quantisation config rather than from a guess.
+4. **Residual width.** V4's manifold-constrained hyper-connections widen the
+   residual stream to ``hc_mult`` × hidden while the layer input stays hidden-
+   wide. The layer does not get more expensive, but a *pipeline boundary* does:
+   what crosses between shelves is the whole residual state, so a shelf hop
+   carries ``hc_mult`` times the activation it would in V3.
 
 Sizes here are computed from the architecture, not read off a file listing, so a
 profile can be edited (or a new one declared) and every derived number follows.
-
-**Honesty about V4 Pro.** No DeepSeek V4 Pro configuration is public at the time
-of writing. :data:`DEEPSEEK_V4_PRO` is therefore an *assumed* profile: it keeps
-the V3 shape that is known to work and scales the dimensions that DeepSeek has
-historically scaled between generations. It is marked ``assumed=True``, every
-tool that prints a plan prints that flag, and the field values are the only thing
-that needs editing when the real config appears. :data:`DEEPSEEK_V3` is the
-verified profile and is what the tests pin numerically.
+Each profile's :meth:`ModelProfile.total_params` is checked against the published
+parameter count in the tests, which is what makes it safe to trust the derived
+byte counts.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
-#: Bytes per parameter for the formats a console can hold.
-DTYPE_BYTES = {"fp8": 1.0, "bf16": 2.0, "fp16": 2.0, "fp32": 4.0, "mxfp4": 0.5625}
+#: Bytes per parameter for the formats a console can hold, *before* block
+#: scales; :class:`QuantSpec` adds those.
+DTYPE_BYTES = {"fp8": 1.0, "fp4": 0.5, "mxfp4": 0.5,
+               "bf16": 2.0, "fp16": 2.0, "fp32": 4.0}
 
 
 @dataclass(frozen=True)
-class MLAConfig:
-    """Multi-head latent attention shape."""
+class QuantSpec:
+    """A weight format together with the block scales stored alongside it.
+
+    Quantised weights are never only their payload: a blockwise format keeps one
+    scale per block, and whether that rounds to nothing or to 6% depends
+    entirely on the block shape. FP8 with an fp32 scale per 128x128 tile is
+    0.02% overhead; MXFP4 with a one-byte exponent per 32 values is 6.25%, which
+    is the difference between an expert fitting a coffer and not.
+    """
+
+    dtype: str
+    #: Bytes per stored scale (4 for fp32, 1 for the ue8m0 / E8M0 exponents).
+    scale_bytes: float = 0.0
+    #: Elements sharing one scale; 0 means the format carries no scales.
+    scale_block: int = 0
+
+    @property
+    def bytes_per_param(self) -> float:
+        base = DTYPE_BYTES[self.dtype]
+        if self.scale_block:
+            base += self.scale_bytes / self.scale_block
+        return base
+
+
+#: FP8 E4M3 with an fp32 scale per 128x128 tile, as V3/R1 ship it.
+FP8_BLOCK128 = QuantSpec("fp8", scale_bytes=4.0, scale_block=128 * 128)
+#: FP8 E4M3 with a ue8m0 scale per 128x128 tile, as V4 ships it.
+FP8_UE8M0 = QuantSpec("fp8", scale_bytes=1.0, scale_block=128 * 128)
+#: OCP MXFP4: E2M1 values with one E8M0 scale per 32-element tile.
+MXFP4 = QuantSpec("mxfp4", scale_bytes=1.0, scale_block=32)
+
+
+class AttentionConfig:
+    """What the planner needs from an attention block, per layer.
+
+    Subclasses differ in how much cache a token leaves behind and how much of
+    that cache the *next* token has to read, which are not the same number once
+    attention is sparse. Everything is per layer, because V4 interleaves layer
+    kinds that differ by a factor of 32 in cache size.
+    """
+
+    n_heads: int
+
+    def kind(self, layer: int = 0) -> str:
+        """Short name of this layer's attention, for humans and for tests."""
+        raise NotImplementedError
+
+    def weight_params(self, hidden_size: int, layer: int = 0) -> int:
+        """Parameters in one attention block."""
+        raise NotImplementedError
+
+    def kv_cache_bytes_per_token(self, dtype: str = "bf16",
+                                 layer: int = 0) -> int:
+        """Cache one more token *adds* to this layer. May be zero."""
+        raise NotImplementedError
+
+    def state_bytes(self, dtype: str = "bf16", layer: int = 0) -> int:
+        """Cache this layer holds regardless of context length."""
+        return 0
+
+    def kv_read_bytes(self, context_tokens: int, dtype: str = "bf16",
+                      layer: int = 0) -> int:
+        """Cache one decoded token has to *read* — not what it stores."""
+        return (context_tokens * self.kv_cache_bytes_per_token(dtype, layer)
+                + self.state_bytes(dtype, layer))
+
+
+@dataclass(frozen=True)
+class MLAConfig(AttentionConfig):
+    """Multi-head latent attention (V2/V3) shape."""
 
     n_heads: int
     kv_lora_rank: int
@@ -53,7 +127,11 @@ class MLAConfig:
     def qk_head_dim(self) -> int:
         return self.qk_nope_head_dim + self.qk_rope_head_dim
 
-    def kv_cache_bytes_per_token(self, dtype: str = "bf16") -> int:
+    def kind(self, layer: int = 0) -> str:
+        return "mla"
+
+    def kv_cache_bytes_per_token(self, dtype: str = "bf16",
+                                 layer: int = 0) -> int:
         """One layer's KV cache cost for one token.
 
         MLA stores the compressed latent (``kv_lora_rank``) plus the decoupled
@@ -63,7 +141,7 @@ class MLAConfig:
         width = self.kv_lora_rank + self.qk_rope_head_dim
         return int(round(width * DTYPE_BYTES[dtype]))
 
-    def weight_params(self, hidden_size: int) -> int:
+    def weight_params(self, hidden_size: int, layer: int = 0) -> int:
         """Parameters in one MLA block."""
         q_out = self.n_heads * self.qk_head_dim
         if self.q_lora_rank is None:
@@ -77,6 +155,132 @@ class MLAConfig:
                  * (self.qk_nope_head_dim + self.v_head_dim))
         out = self.n_heads * self.v_head_dim * hidden_size
         return q + kv_down + kv_up + out
+
+
+@dataclass(frozen=True)
+class HybridAttentionConfig(AttentionConfig):
+    """V4's interleaved CSA / HCA attention, with a sliding-window branch.
+
+    Both halves compress the cache *along the sequence*: CSA folds every ``m``
+    tokens into one shared-KV entry and then attends sparsely to ``index_topk``
+    of those entries, chosen by a small FP4 indexer; HCA folds every ``m'``
+    (≫ ``m``) tokens into one entry and attends to all of them densely. A layer
+    is one or the other, given by :attr:`compress_ratios`; a ratio of 0 means the
+    layer has no compressed branch at all and runs pure sliding-window
+    attention.
+
+    The consequence the planner cares about is that *stored* and *read* cache
+    diverge. An HCA layer at a million tokens stores 16 KiB and reads all of it;
+    a CSA layer stores 512 KiB but reads only the selected entries plus one
+    indexer scan. Modelling them with a single number gets long-context decode
+    wrong by more than an order of magnitude.
+
+    ``compress_ratios`` carries one entry per *block*, which is one more than
+    ``n_layers`` when the checkpoint has an MTP head; the trailing entry is that
+    head's block.
+    """
+
+    n_heads: int
+    #: ``c``: width of a shared KV entry, and of each query head.
+    head_dim: int
+    #: ``d_c``: queries are produced through this low-rank bottleneck.
+    q_lora_rank: int
+    #: ``g`` and ``d_g``: the output projection is grouped, not one big matrix.
+    o_groups: int
+    o_group_dim: int
+    #: How many of ``head_dim``'s dimensions are rotated. Partial RoPE, so this
+    #: is a subset of the head, not extra width.
+    qk_rope_head_dim: int
+    #: CSA's indexer: query heads, head dim, and how many entries it selects.
+    index_n_heads: int
+    index_head_dim: int
+    index_topk: int
+    #: Sliding-window branch present on every layer.
+    sliding_window: int
+    #: ``m`` and ``m'``.
+    csa_ratio: int
+    hca_ratio: int
+    #: Per-block compression ratio: ``csa_ratio``, ``hca_ratio``, or 0 for a
+    #: layer that is pure sliding window.
+    compress_ratios: Tuple[int, ...] = ()
+    #: The indexer's keys are cached and multiplied in FP4.
+    index_quant: QuantSpec = MXFP4
+
+    def ratio(self, layer: int = 0) -> int:
+        if not self.compress_ratios:
+            return self.csa_ratio
+        index = min(layer, len(self.compress_ratios) - 1)
+        return self.compress_ratios[index]
+
+    def kind(self, layer: int = 0) -> str:
+        ratio = self.ratio(layer)
+        if ratio <= 1:
+            return "swa"
+        return "csa" if ratio == self.csa_ratio else "hca"
+
+    def weight_params(self, hidden_size: int, layer: int = 0) -> int:
+        d, c, nh = hidden_size, self.head_dim, self.n_heads
+        kind = self.kind(layer)
+        # Queries: down to d_c, then up to one c-wide query per head.
+        q = d * self.q_lora_rank + self.q_lora_rank * nh * c
+        # Grouped output: heads within a group share an intermediate of width
+        # d_g, and each group projects back to d.
+        out = nh * c * self.o_group_dim + self.o_groups * self.o_group_dim * d
+        if kind == "csa":
+            # Two overlapping KV series and their compression weights, plus the
+            # learnable positional bias each compression window carries.
+            kv = 4 * d * c + 2 * self.csa_ratio * c
+            indexer = (d * self.index_n_heads * self.index_head_dim
+                       + d * self.index_head_dim + self.index_n_heads)
+        elif kind == "hca":
+            kv = 2 * d * c + self.hca_ratio * c
+            indexer = 0
+        else:
+            # No compression: one shared KV entry straight off the hidden state.
+            kv = d * c
+            indexer = 0
+        return q + kv + out + indexer
+
+    def kv_cache_bytes_per_token(self, dtype: str = "bf16",
+                                 layer: int = 0) -> int:
+        kind = self.kind(layer)
+        if kind == "swa":
+            return 0  # the window is a fixed-size state, see state_bytes
+        ratio = self.csa_ratio if kind == "csa" else self.hca_ratio
+        entry = self.head_dim * DTYPE_BYTES[dtype] / ratio
+        if kind == "csa":
+            entry += (self.index_head_dim
+                      * self.index_quant.bytes_per_param / ratio)
+        return int(round(entry))
+
+    def state_bytes(self, dtype: str = "bf16", layer: int = 0) -> int:
+        """The sliding-window branch, which every layer carries.
+
+        Uncompressed tail tokens live here too; both are bounded, which is why
+        DeepSeek's own serving stack treats them as a fixed pool rather than as
+        part of the growing cache.
+        """
+        return int(round(self.sliding_window * self.head_dim
+                         * DTYPE_BYTES[dtype]))
+
+    def kv_read_bytes(self, context_tokens: int, dtype: str = "bf16",
+                      layer: int = 0) -> int:
+        kind = self.kind(layer)
+        state = self.state_bytes(dtype, layer)
+        if kind == "swa":
+            return state
+        if kind == "hca":
+            entries = context_tokens / self.hca_ratio
+            return int(round(entries * self.head_dim * DTYPE_BYTES[dtype])
+                       + state)
+        # CSA scans every compressed entry with the FP4 indexer, then reads only
+        # the top-k it selected.
+        entries = context_tokens / self.csa_ratio
+        scan = (entries * self.index_head_dim
+                * self.index_quant.bytes_per_param)
+        selected = min(entries, float(self.index_topk))
+        return int(round(scan + selected * self.head_dim * DTYPE_BYTES[dtype])
+                   + state)
 
 
 @dataclass(frozen=True)
@@ -95,6 +299,11 @@ class MoEConfig:
     #: to bound how many consoles a single token can touch.
     n_group: int = 1
     topk_group: int = 1
+    #: Leading MoE layers whose gate is a hash of the token rather than a
+    #: learned router. Same weights and same cost, but the expert choice is
+    #: known before the layer runs, so those layers can be prefetched exactly
+    #: instead of speculatively.
+    n_hash_layers: int = 0
 
     def expert_params(self) -> int:
         """One routed expert: gate, up, down."""
@@ -112,21 +321,42 @@ class ModelProfile:
     n_layers: int
     hidden_size: int
     vocab_size: int
-    mla: MLAConfig
+    attention: AttentionConfig
     moe: MoEConfig
-    dtype: str = "fp8"
+    #: Format of everything read for every token.
+    weights: QuantSpec = FP8_BLOCK128
+    #: Format of the routed and shared expert weights, when it differs.
+    expert_weights: Optional[QuantSpec] = None
     #: Multi-token-prediction heads (V3 ships one). Each is a whole extra
     #: decoder block plus a head, so it is placed like a layer, not folded in.
     n_mtp_heads: int = 1
+    #: Hyper-connection expansion: the residual stream is this many times
+    #: hidden-wide, which is what crosses a pipeline boundary.
+    hc_mult: int = 1
     #: True when the configuration is extrapolated rather than published.
     assumed: bool = False
     assumptions: tuple = ()
+    #: Where the configuration came from, printed next to the sizes.
+    source: str = ""
 
-    # -- per-piece sizes ---------------------------------------------------
+    # -- formats -----------------------------------------------------------
+    @property
+    def dtype(self) -> str:
+        return self.weights.dtype
+
+    @property
+    def expert_quant(self) -> QuantSpec:
+        return self.expert_weights or self.weights
+
     @property
     def bytes_per_param(self) -> float:
-        return DTYPE_BYTES[self.dtype]
+        return self.weights.bytes_per_param
 
+    @property
+    def mixed_precision(self) -> bool:
+        return self.expert_quant.dtype != self.weights.dtype
+
+    # -- per-piece sizes ---------------------------------------------------
     @property
     def n_moe_layers(self) -> int:
         return max(0, self.n_layers - self.moe.n_dense_layers)
@@ -142,25 +372,16 @@ class ModelProfile:
         return self.n_layers + self.n_mtp_heads
 
     def expert_bytes(self) -> int:
-        """One routed expert, packed.
-
-        FP8 blockwise weights carry one fp32 scale per 128-element block, which
-        is a ~3% overhead that is small but not nothing when it decides whether a
-        layer's experts fit a 10 GB coffer.
-        """
+        """One routed expert, packed, block scales included."""
         params = self.moe.expert_params() * self.hidden_size
-        raw = params * self.bytes_per_param
-        return int(round(raw * (1.0 + self._scale_overhead())))
-
-    def _scale_overhead(self) -> float:
-        return 4.0 / 128.0 if self.dtype == "fp8" else 0.0
+        return int(round(params * self.expert_quant.bytes_per_param))
 
     def shared_expert_bytes(self) -> int:
         return self.expert_bytes() * self.moe.n_shared_experts
 
-    def attention_bytes(self) -> int:
-        raw = self.mla.weight_params(self.hidden_size) * self.bytes_per_param
-        return int(round(raw * (1.0 + self._scale_overhead())))
+    def attention_bytes(self, layer: int = 0) -> int:
+        params = self.attention.weight_params(self.hidden_size, layer)
+        return int(round(params * self.bytes_per_param))
 
     def router_bytes(self) -> int:
         """Router matrix plus its bias; tiny, but read for every token."""
@@ -170,24 +391,27 @@ class ModelProfile:
 
     def dense_mlp_bytes(self) -> int:
         raw = self.moe.dense_mlp_params(self.hidden_size) * self.bytes_per_param
-        return int(round(raw * (1.0 + self._scale_overhead())))
+        return int(round(raw))
 
-    def hot_bytes_per_moe_layer(self) -> int:
+    def hot_bytes_per_moe_layer(self, layer: int = 0) -> int:
         """Weights an MoE layer reads for *every* token.
 
         Attention + router + shared expert + norms. This is the quantity that
         must land in a fast coffer; the routed experts are the cold remainder.
+        The hyper-connection mappings are generated from the hidden state and
+        come to well under a tenth of a percent of this, so they are left out
+        rather than guessed at.
         """
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
-        return (self.attention_bytes() + self.router_bytes()
+        return (self.attention_bytes(layer) + self.router_bytes()
                 + self.shared_expert_bytes() + norms)
 
     def cold_bytes_per_moe_layer(self) -> int:
         return self.expert_bytes() * self.moe.n_routed_experts
 
-    def dense_layer_bytes(self) -> int:
+    def dense_layer_bytes(self, layer: int = 0) -> int:
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
-        return self.attention_bytes() + self.dense_mlp_bytes() + norms
+        return self.attention_bytes(layer) + self.dense_mlp_bytes() + norms
 
     def embedding_bytes(self) -> int:
         return int(round(self.vocab_size * self.hidden_size
@@ -201,56 +425,119 @@ class ModelProfile:
         return int(round(2 * self.hidden_size * self.hidden_size
                          * self.bytes_per_param))
 
-    def mtp_hot_bytes(self) -> int:
+    def mtp_hot_bytes(self, head: int = 0) -> int:
         """Per-token weights of one MTP head: its hot block plus projection."""
-        return self.hot_bytes_per_moe_layer() + self.mtp_projection_bytes()
+        return (self.hot_bytes_per_moe_layer(self.n_layers + head)
+                + self.mtp_projection_bytes())
 
     def mtp_bytes(self) -> int:
         """All MTP heads, weights in full."""
         if self.n_mtp_heads == 0:
             return 0
-        return self.n_mtp_heads * (self.mtp_hot_bytes()
-                                   + self.cold_bytes_per_moe_layer())
+        return sum(self.mtp_hot_bytes(head) + self.cold_bytes_per_moe_layer()
+                   for head in range(self.n_mtp_heads))
+
+    def block_bytes(self, index: int) -> int:
+        """Per-token weights of block ``index``, MTP heads counted as blocks."""
+        if index < self.moe.n_dense_layers:
+            return self.dense_layer_bytes(index)
+        if index < self.n_layers:
+            return self.hot_bytes_per_moe_layer(index)
+        return self.mtp_hot_bytes(index - self.n_layers)
 
     def total_bytes(self) -> int:
-        return (self.moe.n_dense_layers * self.dense_layer_bytes()
-                + self.n_moe_layers * (self.hot_bytes_per_moe_layer()
-                                       + self.cold_bytes_per_moe_layer())
-                + self.embedding_bytes() + self.lm_head_bytes()
-                + self.mtp_bytes())
+        weights = self.embedding_bytes() + self.lm_head_bytes() + self.mtp_bytes()
+        for index in range(self.n_layers):
+            if index < self.moe.n_dense_layers:
+                weights += self.dense_layer_bytes(index)
+            else:
+                weights += (self.hot_bytes_per_moe_layer(index)
+                            + self.cold_bytes_per_moe_layer())
+        return weights
 
-    def total_params(self) -> int:
-        """Parameter count, for sanity-checking a profile against a model card."""
+    def total_params(self, include_mtp: bool = True) -> int:
+        """Parameter count, for checking a profile against a model card.
+
+        DeepSeek's published totals exclude the MTP head, so ``include_mtp``
+        has to be off to compare against a card and on to size a fleet, which
+        does have to store it.
+        """
         per_expert = self.moe.expert_params() * self.hidden_size
-        attn = self.mla.weight_params(self.hidden_size)
-        return int(
-            self.moe.n_dense_layers * (attn + self.moe.dense_mlp_params(
-                self.hidden_size))
-            + self.n_moe_layers * (
-                attn + self.hidden_size * self.moe.n_routed_experts
-                + per_expert * (self.moe.n_routed_experts
-                                + self.moe.n_shared_experts))
-            + 2 * self.vocab_size * self.hidden_size)
+        params = 2 * self.vocab_size * self.hidden_size
+        blocks = self.planning_layers if include_mtp else self.n_layers
+        for index in range(blocks):
+            attn = self.attention.weight_params(self.hidden_size, index)
+            if index < self.moe.n_dense_layers:
+                params += attn + self.moe.dense_mlp_params(self.hidden_size)
+                continue
+            params += (attn + self.hidden_size * self.moe.n_routed_experts
+                       + per_expert * (self.moe.n_routed_experts
+                                       + self.moe.n_shared_experts))
+            if index >= self.n_layers:
+                params += 2 * self.hidden_size * self.hidden_size
+        return int(params)
 
     def activated_params(self) -> int:
-        """Parameters a single token actually multiplies against."""
+        """Parameters a single token actually multiplies against.
+
+        MTP heads are not counted: they run only when speculative decoding is
+        on, which is what the published activated-parameter figures assume.
+        """
         per_expert = self.moe.expert_params() * self.hidden_size
-        attn = self.mla.weight_params(self.hidden_size)
-        return int(
-            self.moe.n_dense_layers * (attn + self.moe.dense_mlp_params(
-                self.hidden_size))
-            + self.n_moe_layers * (
-                attn + per_expert * (self.moe.top_k
-                                     + self.moe.n_shared_experts))
-            + self.vocab_size * self.hidden_size)
+        params = float(self.vocab_size * self.hidden_size)
+        for index in range(self.n_layers):
+            attn = self.attention.weight_params(self.hidden_size, index)
+            if index < self.moe.n_dense_layers:
+                params += attn + self.moe.dense_mlp_params(self.hidden_size)
+                continue
+            params += attn + per_expert * (self.moe.top_k
+                                           + self.moe.n_shared_experts)
+        return int(params)
+
+    def kv_cache_bytes_for_layer(self, layer: int, context_tokens: int,
+                                 dtype: str = "bf16") -> int:
+        """Cache one layer holds for one sequence at this context length."""
+        per_token = self.attention.kv_cache_bytes_per_token(dtype, layer)
+        return context_tokens * per_token + self.attention.state_bytes(dtype,
+                                                                       layer)
+
+    def kv_read_bytes_for_layer(self, layer: int, context_tokens: int,
+                                dtype: str = "bf16") -> int:
+        """Cache one layer *reads* to decode one token.
+
+        Equal to what it holds under dense attention, and far less under CSA.
+        """
+        return self.attention.kv_read_bytes(context_tokens, dtype, layer)
 
     def kv_cache_bytes(self, context_tokens: int, dtype: str = "bf16") -> int:
-        return (self.n_layers * context_tokens
-                * self.mla.kv_cache_bytes_per_token(dtype))
+        return sum(self.kv_cache_bytes_for_layer(layer, context_tokens, dtype)
+                   for layer in range(self.n_layers))
+
+    def block_kv_bytes(self, index: int, context_tokens: int,
+                       dtype: str = "bf16") -> int:
+        """Cache block ``index`` holds, MTP heads included.
+
+        An MTP head runs its own attention and so keeps its own cache; it is
+        one more block, sized like the layer whose position it occupies.
+        """
+        return self.kv_cache_bytes_for_layer(index, context_tokens, dtype)
+
+    def block_kv_read_bytes(self, index: int, context_tokens: int,
+                            dtype: str = "bf16") -> int:
+        return self.kv_read_bytes_for_layer(index, context_tokens, dtype)
 
     def activation_bytes(self, dtype: str = "bf16") -> int:
-        """One token's hidden state on the wire between pipeline stages."""
-        return int(round(self.hidden_size * DTYPE_BYTES[dtype]))
+        """One token's residual state on the wire between pipeline stages.
+
+        With hyper-connections this is the whole ``hc_mult``-wide stream, not
+        the hidden-wide layer input: the next block's residual mixing needs
+        every branch, so a shelf boundary cannot ship only the part the layer
+        consumes.
+        """
+        return int(round(self.hc_mult * self.hidden_size * DTYPE_BYTES[dtype]))
+
+    def layer_kinds(self) -> List[str]:
+        return [self.attention.kind(i) for i in range(self.planning_layers)]
 
     def to_dict(self) -> Dict[str, object]:
         return asdict(self)
@@ -263,48 +550,85 @@ class ModelProfile:
 #: DeepSeek-V3 / R1, from the published config: 671 B total / 37 B activated,
 #: 61 layers, hidden 7168, 256 routed + 1 shared expert per MoE layer, top-8
 #: within 4 of 8 groups, first 3 layers dense, MLA with a 512-wide latent, one
-#: MTP head, native FP8. Used as the verified reference the tests pin.
+#: MTP head, native FP8.
 DEEPSEEK_V3 = ModelProfile(
     name="deepseek-v3",
     n_layers=61,
     hidden_size=7168,
     vocab_size=129280,
-    mla=MLAConfig(n_heads=128, kv_lora_rank=512, q_lora_rank=1536,
-                  qk_nope_head_dim=128, qk_rope_head_dim=64, v_head_dim=128),
+    attention=MLAConfig(n_heads=128, kv_lora_rank=512, q_lora_rank=1536,
+                        qk_nope_head_dim=128, qk_rope_head_dim=64,
+                        v_head_dim=128),
     moe=MoEConfig(n_routed_experts=256, n_shared_experts=1, top_k=8,
                   moe_intermediate_size=2048, n_dense_layers=3,
                   dense_intermediate_size=18432, n_group=8, topk_group=4),
-    dtype="fp8",
+    weights=FP8_BLOCK128,
     n_mtp_heads=1,
+    source="deepseek-ai/DeepSeek-V3 config.json",
 )
 
-#: DeepSeek V4 Pro — **assumed**. No configuration has been published; this keeps
-#: the V3 decoder shape (the part that is architecture, not scale) and scales the
-#: dimensions DeepSeek has scaled before. Every consumer of this profile prints
-#: the ``assumed`` flag; replace the numbers, not the code, when the real config
-#: lands.
+#: Per-block attention schedule of DeepSeek-V4-Pro: HCA for the first two
+#: blocks, then CSA and HCA interleaved, with the trailing entry describing the
+#: MTP block. Taken verbatim from the checkpoint's ``compress_ratios``.
+_V4_PRO_RATIOS: Tuple[int, ...] = tuple(
+    [128, 128] + [4, 128] * 29 + [4, 0])
+
+#: Per-block attention schedule of DeepSeek-V4-Flash: two pure sliding-window
+#: blocks, then CSA and HCA interleaved, then the MTP block.
+_V4_FLASH_RATIOS: Tuple[int, ...] = tuple(
+    [0, 0] + [4, 128] * 20 + [4, 0])
+
+#: DeepSeek-V4-Pro, from the published config: 1.6 T total / 49 B activated, 61
+#: layers, hidden 7168, all-MoE with 384 routed + 1 shared expert, top-6, hash
+#: gating on the first three layers, hybrid CSA (m=4, top-1024) and HCA (m'=128)
+#: attention with 128 query heads of width 512, one MTP head, hyper-connection
+#: width 4. Expert weights are MXFP4 and everything else is FP8.
 DEEPSEEK_V4_PRO = ModelProfile(
     name="deepseek-v4-pro",
-    n_layers=72,
-    hidden_size=8192,
-    vocab_size=131072,
-    mla=MLAConfig(n_heads=160, kv_lora_rank=512, q_lora_rank=1536,
-                  qk_nope_head_dim=128, qk_rope_head_dim=64, v_head_dim=128),
-    moe=MoEConfig(n_routed_experts=384, n_shared_experts=1, top_k=8,
-                  moe_intermediate_size=2048, n_dense_layers=3,
-                  dense_intermediate_size=20480, n_group=12, topk_group=4),
-    dtype="fp8",
-    n_mtp_heads=2,
-    assumed=True,
-    assumptions=(
-        "no DeepSeek V4 Pro configuration is public; the decoder shape is V3's",
-        "layer count, hidden size, head count, routed-expert count and MTP "
-        "depth are extrapolated from the V2 -> V3 progression",
-        "expert width (moe_intermediate_size) is held at V3's 2048, which is "
-        "what keeps one expert small enough to be a unit of placement",
-        "weights are assumed natively FP8 E4M3 with 128-element block scales, "
-        "as in V3",
-    ),
+    n_layers=61,
+    hidden_size=7168,
+    vocab_size=129280,
+    attention=HybridAttentionConfig(
+        n_heads=128, head_dim=512, q_lora_rank=1536,
+        o_groups=16, o_group_dim=1024, qk_rope_head_dim=64,
+        index_n_heads=64, index_head_dim=128, index_topk=1024,
+        sliding_window=128, csa_ratio=4, hca_ratio=128,
+        compress_ratios=_V4_PRO_RATIOS),
+    moe=MoEConfig(n_routed_experts=384, n_shared_experts=1, top_k=6,
+                  moe_intermediate_size=3072, n_dense_layers=0,
+                  dense_intermediate_size=0, n_hash_layers=3),
+    weights=FP8_UE8M0,
+    expert_weights=MXFP4,
+    n_mtp_heads=1,
+    hc_mult=4,
+    source="deepseek-ai/DeepSeek-V4-Pro config.json; arXiv:2606.19348 §4.2.1",
+)
+
+#: DeepSeek-V4-Flash, from the published config: 284 B total / 13 B activated,
+#: 43 layers, hidden 4096, 256 routed + 1 shared expert, top-6, the same hybrid
+#: attention with 64 query heads and a 512-entry indexer top-k, and pure
+#: sliding-window attention in the first two blocks. Same mixed FP4/FP8 weights
+#: as Pro, at a fifth of the size — which is the whole reason to care about it
+#: here: it is the first member of the family a small fleet can hold.
+DEEPSEEK_V4_FLASH = ModelProfile(
+    name="deepseek-v4-flash",
+    n_layers=43,
+    hidden_size=4096,
+    vocab_size=129280,
+    attention=HybridAttentionConfig(
+        n_heads=64, head_dim=512, q_lora_rank=1024,
+        o_groups=8, o_group_dim=1024, qk_rope_head_dim=64,
+        index_n_heads=64, index_head_dim=128, index_topk=512,
+        sliding_window=128, csa_ratio=4, hca_ratio=128,
+        compress_ratios=_V4_FLASH_RATIOS),
+    moe=MoEConfig(n_routed_experts=256, n_shared_experts=1, top_k=6,
+                  moe_intermediate_size=2048, n_dense_layers=0,
+                  dense_intermediate_size=0, n_hash_layers=3),
+    weights=FP8_UE8M0,
+    expert_weights=MXFP4,
+    n_mtp_heads=1,
+    hc_mult=4,
+    source="deepseek-ai/DeepSeek-V4-Flash config.json; arXiv:2606.19348 §4.2.1",
 )
 
 #: A small MoE with the same architecture, for a fleet of two or three consoles
@@ -314,17 +638,19 @@ DEEPSEEK_TINY = ModelProfile(
     n_layers=8,
     hidden_size=1024,
     vocab_size=32768,
-    mla=MLAConfig(n_heads=16, kv_lora_rank=128, q_lora_rank=None,
-                  qk_nope_head_dim=64, qk_rope_head_dim=32, v_head_dim=64),
+    attention=MLAConfig(n_heads=16, kv_lora_rank=128, q_lora_rank=None,
+                        qk_nope_head_dim=64, qk_rope_head_dim=32,
+                        v_head_dim=64),
     moe=MoEConfig(n_routed_experts=32, n_shared_experts=1, top_k=4,
                   moe_intermediate_size=512, n_dense_layers=1,
                   dense_intermediate_size=2048, n_group=4, topk_group=2),
-    dtype="fp8",
+    weights=FP8_BLOCK128,
     n_mtp_heads=0,
 )
 
 PROFILES: Dict[str, ModelProfile] = {
-    p.name: p for p in (DEEPSEEK_V3, DEEPSEEK_V4_PRO, DEEPSEEK_TINY)
+    p.name: p for p in (DEEPSEEK_V3, DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH,
+                        DEEPSEEK_TINY)
 }
 
 
@@ -334,16 +660,31 @@ def profile_for(name: str) -> ModelProfile:
     return PROFILES[name]
 
 
+def _attention_summary(profile: ModelProfile) -> str:
+    kinds = profile.layer_kinds()
+    counts: Dict[str, int] = {}
+    for kind in kinds:
+        counts[kind] = counts.get(kind, 0) + 1
+    return ", ".join(f"{n} {kind.upper()}"
+                     for kind, n in sorted(counts.items(), key=lambda kv: -kv[1]))
+
+
 def describe(profile: ModelProfile) -> List[str]:
     """Human-readable size breakdown, shared by the CLIs."""
     gib = 1024 ** 3
     mib = 1024 ** 2
+    fmt = profile.weights.dtype
+    if profile.mixed_precision:
+        fmt = f"{profile.expert_quant.dtype} experts / {fmt} elsewhere"
     lines = [
-        f"{profile.name}  ({profile.dtype}"
+        f"{profile.name}  ({fmt}"
         + (", ASSUMED CONFIGURATION" if profile.assumed else "") + ")",
         f"  layers                {profile.n_layers} "
         f"({profile.moe.n_dense_layers} dense, {profile.n_moe_layers} MoE)",
-        f"  hidden                {profile.hidden_size}",
+        f"  attention             {_attention_summary(profile)}",
+        f"  hidden                {profile.hidden_size}"
+        + (f" (residual {profile.hc_mult}x wide)" if profile.hc_mult > 1
+           else ""),
         f"  routed experts/layer  {profile.moe.n_routed_experts} "
         f"(top-{profile.moe.top_k} of {profile.moe.topk_group}/"
         f"{profile.moe.n_group} groups)",
@@ -358,6 +699,8 @@ def describe(profile: ModelProfile) -> List[str]:
         f"  KV cache @ 8k ctx     "
         f"{profile.kv_cache_bytes(8192) / mib:.0f} MiB",
     ]
+    if profile.source:
+        lines.append(f"  source                {profile.source}")
     if profile.assumed:
         lines.append("  assumptions:")
         lines.extend(f"    - {a}" for a in profile.assumptions)

--- a/gen9-cluster/gen9_cluster/node.py
+++ b/gen9-cluster/gen9_cluster/node.py
@@ -18,7 +18,14 @@ pinning hot experts to the GPU, arrived at by letting the kernel do it.
 :class:`ExpertRunner` is the compute seam. The reference implementation is
 numpy, which is honest and slow; a console plugs in the AVX2, Vulkan or HIP
 kernel from ``kernels/`` by passing a different runner. Nothing else in the
-stack knows which backend is in use.
+stack knows which backend is in use. A runner implements
+:meth:`ExpertRunner.rows` — one weighted output per expert, no cross-expert
+addition — and the base class derives the collapsed sum from it, so no backend
+gets to choose its own reduction order.
+
+The node does not sum a batch unless it is asked to. Its reply is one row per
+expert, tagged, and the coordinator adds them in top-k order; see
+:mod:`gen9_cluster.protocol`. ``Flags.FAST`` opts into the collapsed sum.
 """
 
 from __future__ import annotations
@@ -33,10 +40,13 @@ from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple
 import numpy as np
 
 from . import fp8
+from .dedup import (DedupCache, DedupCapacityError, MismatchedBatchError,
+                    batch_fingerprint)
 from .errors import CapacityError, ShardMissing
-from .protocol import (HEADER_SIZE, DType, ExpertBatchPayload, Flags, Frame,
-                       HelloPayload, MsgType, ShardHeader, decode_vector,
-                       encode_error, encode_vector)
+from .protocol import (HEADER_SIZE, DType, ExpertBatchPayload,
+                       ExpertRowsPayload, Flags, Frame, HelloPayload, MsgType,
+                       ShardHeader, accumulate, decode_vector, encode_error,
+                       encode_vector)
 
 #: (layer, expert) -> the three matrices of a DeepSeek expert.
 ExpertKey = Tuple[int, int]
@@ -97,28 +107,43 @@ class ExpertWeights:
 
 
 class ExpertRunner:
-    """Runs a batch of experts on one activation. Replaceable per backend."""
+    """Runs a batch of experts on one activation. Replaceable per backend.
+
+    Backends override :meth:`rows`, never :meth:`__call__`. Returning the
+    experts separately and letting the caller decide whether and in what order
+    to add them is what keeps the answer independent of where the experts
+    happen to live: a backend that summed internally would bake this node's
+    particular shard assignment into the arithmetic.
+    """
 
     name = "numpy-reference"
 
-    def __call__(self, activation: np.ndarray,
-                 experts: Sequence[ExpertWeights],
-                 gates: Sequence[float]) -> np.ndarray:
-        """Gate-weighted sum of SwiGLU experts.
-
-        Summing on the node rather than returning each expert's output is the
-        difference between one reply and ``k`` replies; at eight experts and a
-        32 KiB hidden state that is 256 KiB saved per layer per token.
-        """
-        out = np.zeros_like(activation, dtype=np.float32)
-        for weights, gate in zip(experts, gates):
+    def rows(self, activation: np.ndarray,
+             experts: Sequence[ExpertWeights],
+             gates: Sequence[float]) -> np.ndarray:
+        """``gate_i * expert_i(activation)`` for each expert, as a 2-D array."""
+        out = np.empty((len(experts), activation.size), dtype=np.float32)
+        for index, (weights, gate) in enumerate(zip(experts, gates)):
             if weights.quantised:
                 weights = weights.dequantised()
             hidden = activation @ weights.gate.T
             hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))   # SiLU
             hidden = hidden * (activation @ weights.up.T)
-            out += float(gate) * (hidden @ weights.down.T)
+            out[index] = np.float32(gate) * (hidden @ weights.down.T)
         return out
+
+    def __call__(self, activation: np.ndarray,
+                 experts: Sequence[ExpertWeights],
+                 gates: Sequence[float]) -> np.ndarray:
+        """Gate-weighted sum of SwiGLU experts, folded left to right.
+
+        Only used for a ``FAST`` batch, and defined here rather than in each
+        backend so that every collapsed sum in the fleet folds in the same
+        order whatever kernel produced the rows.
+        """
+        if not experts:
+            return np.zeros_like(activation, dtype=np.float32)
+        return accumulate(list(self.rows(activation, experts, gates)))
 
 
 class ShardStore:
@@ -199,7 +224,8 @@ class NodeServer:
                  block_fn: Optional[Callable[[int, np.ndarray], np.ndarray]] = None,
                  sku: str = "unknown", backend: str = "cpu-avx2",
                  runtime: str = "host-sim", weight_bytes: int = 0,
-                 fast_bytes: int = 0, gemv_gflops: float = 0.0):
+                 fast_bytes: int = 0, gemv_gflops: float = 0.0,
+                 dedup: Optional[DedupCache] = None):
         self.store = store
         self.unit_id = unit_id
         self.host = host
@@ -210,6 +236,7 @@ class NodeServer:
                                   runtime=runtime, weight_bytes=weight_bytes,
                                   fast_bytes=fast_bytes,
                                   gemv_gflops=gemv_gflops)
+        self.dedup = dedup if dedup is not None else DedupCache()
         self.tokens_served = 0
         self.experts_run = 0
         self.storage_reads = 0
@@ -311,19 +338,57 @@ class NodeServer:
                      self.hello.encode())
 
     def _on_expert_batch(self, frame: Frame) -> Frame:
+        """Run a batch once, and answer with rows unless FAST was asked for.
+
+        The dedup cache wraps the *whole* reply including its flags, so a
+        replay is byte-identical to what the first attempt sent — apart from
+        ``REPLAYED``, which is set on the way out so the coordinator's stats
+        can tell a cheap retry from an expensive one.
+        """
         payload = ExpertBatchPayload.decode(frame.payload)
+        fast = bool(frame.flags & Flags.FAST)
+        fingerprint = batch_fingerprint(frame.layer, payload.expert_ids,
+                                        payload.gates, payload.activation,
+                                        fast)
+
+        def compute() -> bytes:
+            return self._run_batch(frame, payload, fast).encode()
+
+        try:
+            raw, replayed = self.dedup.run(payload.batch_id, fingerprint,
+                                           compute)
+        except MismatchedBatchError as exc:
+            return self._error(frame, str(exc))
+        except DedupCapacityError as exc:
+            reply = self._error(frame, str(exc))
+            reply.flags |= Flags.BACKPRESSURE
+            return reply
+        reply, _ = Frame.decode_header(raw[:HEADER_SIZE])
+        reply.payload = raw[HEADER_SIZE:]
+        reply.request_id = frame.request_id
+        if replayed:
+            reply.flags |= Flags.REPLAYED
+        return reply
+
+    def _run_batch(self, frame: Frame, payload: ExpertBatchPayload,
+                   fast: bool) -> Frame:
         weights = [self.store.get(frame.layer, eid)
                    for eid in payload.expert_ids]
-        out = self.runner(payload.activation, weights, payload.gates)
+        rows = self.runner.rows(payload.activation, weights, payload.gates)
         self.experts_run += len(weights)
         self.tokens_served += 1
-        flags = Flags.PARTIAL
+        flags = Flags.NONE
         if any(w.tier == "ssd" for w in weights):
             self.storage_reads += 1
             flags |= Flags.FROM_STORAGE
-        return Frame(MsgType.EXPERT_RESULT, frame.request_id,
-                     encode_vector(out), layer=frame.layer, token=frame.token,
-                     flags=flags)
+        if fast:
+            flags |= Flags.PARTIAL
+            body = encode_vector(accumulate(list(rows)))
+        else:
+            flags |= Flags.PER_EXPERT
+            body = ExpertRowsPayload(payload.expert_ids, rows).encode()
+        return Frame(MsgType.EXPERT_RESULT, frame.request_id, body,
+                     layer=frame.layer, token=frame.token, flags=flags)
 
     def _on_block(self, frame: Frame) -> Frame:
         if self.block_fn is None:

--- a/gen9-cluster/gen9_cluster/node.py
+++ b/gen9-cluster/gen9_cluster/node.py
@@ -1,0 +1,436 @@
+"""The console-side worker: holds shards, runs experts, answers G9XC.
+
+One of these runs on each console. It is deliberately simple — a threaded TCP
+server over :mod:`gen9_cluster.protocol` — because the interesting engineering
+is in *what it holds* and *where it holds it*, not in its concurrency model.
+
+Two things here are worth reading closely:
+
+:class:`ShardStore` is the coffer manager. It keeps a shard either in RAM or
+memory-mapped from NVMe, and the distinction is visible to the caller, because a
+routing hit on a memory-mapped expert costs a 2.4-5.5 GB/s read and the
+coordinator deserves to know that is why the layer was slow. Mapping rather than
+reading is what makes the NVMe tier usable at all: the page cache keeps the
+experts that actually get routed to, which converges on the popular ones without
+anybody having to profile them. That is the same effect KTransformers gets by
+pinning hot experts to the GPU, arrived at by letting the kernel do it.
+
+:class:`ExpertRunner` is the compute seam. The reference implementation is
+numpy, which is honest and slow; a console plugs in the AVX2, Vulkan or HIP
+kernel from ``kernels/`` by passing a different runner. Nothing else in the
+stack knows which backend is in use.
+"""
+
+from __future__ import annotations
+
+import socket
+import socketserver
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple
+
+import numpy as np
+
+from . import fp8
+from .errors import CapacityError, ShardMissing
+from .protocol import (HEADER_SIZE, DType, ExpertBatchPayload, Flags, Frame,
+                       HelloPayload, MsgType, ShardHeader, decode_vector,
+                       encode_error, encode_vector)
+
+#: (layer, expert) -> the three matrices of a DeepSeek expert.
+ExpertKey = Tuple[int, int]
+
+
+@dataclass
+class ExpertWeights:
+    """One routed expert: gate, up, down.
+
+    Stored as whatever numpy dtype the loader produced. FP8 shards arrive as
+    ``uint8`` plus a scale array and are dequantised by the kernel, so the
+    reference runner up-converts them once here rather than pretending numpy
+    speaks E4M3.
+    """
+
+    gate: np.ndarray
+    up: np.ndarray
+    down: np.ndarray
+    scales: Optional[np.ndarray] = None
+    #: "fast" | "slow" | "ssd" — which coffer this came out of.
+    tier: str = "fast"
+
+    @property
+    def nbytes(self) -> int:
+        total = self.gate.nbytes + self.up.nbytes + self.down.nbytes
+        return total + (self.scales.nbytes if self.scales is not None else 0)
+
+    @property
+    def quantised(self) -> bool:
+        return self.gate.dtype == np.uint8
+
+    def dequantised(self) -> "ExpertWeights":
+        """An fp32 copy, for runners that cannot read FP8 themselves.
+
+        This throws away the whole point of FP8 — the expert is four times its
+        stored size while it is being used — so it is done per call and
+        discarded, never cached. A console that does this for every token is
+        one whose compiled kernel failed to build, and its throughput will say
+        so loudly.
+        """
+        if not self.quantised:
+            return self
+        if self.scales is None:
+            raise ValueError("an FP8 expert without block scales cannot be "
+                             "decoded; the shard is incomplete")
+        sizes = [array.size for array in (self.gate, self.up, self.down)]
+        counts = [fp8.n_blocks(size) for size in sizes]
+        flat = np.asarray(self.scales, dtype=np.float32).reshape(-1)
+        if flat.size != sum(counts):
+            raise ValueError(f"expert needs {sum(counts)} block scales, "
+                             f"carries {flat.size}")
+        first, second = counts[0], counts[0] + counts[1]
+        return ExpertWeights(
+            gate=fp8.dequantize(self.gate, flat[:first]),
+            up=fp8.dequantize(self.up, flat[first:second]),
+            down=fp8.dequantize(self.down, flat[second:]),
+            tier=self.tier)
+
+
+class ExpertRunner:
+    """Runs a batch of experts on one activation. Replaceable per backend."""
+
+    name = "numpy-reference"
+
+    def __call__(self, activation: np.ndarray,
+                 experts: Sequence[ExpertWeights],
+                 gates: Sequence[float]) -> np.ndarray:
+        """Gate-weighted sum of SwiGLU experts.
+
+        Summing on the node rather than returning each expert's output is the
+        difference between one reply and ``k`` replies; at eight experts and a
+        32 KiB hidden state that is 256 KiB saved per layer per token.
+        """
+        out = np.zeros_like(activation, dtype=np.float32)
+        for weights, gate in zip(experts, gates):
+            if weights.quantised:
+                weights = weights.dequantised()
+            hidden = activation @ weights.gate.T
+            hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))   # SiLU
+            hidden = hidden * (activation @ weights.up.T)
+            out += float(gate) * (hidden @ weights.down.T)
+        return out
+
+
+class ShardStore:
+    """The node's residency: which experts it holds, and in which coffer."""
+
+    def __init__(self, *, capacity_bytes: int = 0,
+                 storage_dir: Optional[Path] = None):
+        self.capacity_bytes = capacity_bytes
+        self.storage_dir = Path(storage_dir) if storage_dir else None
+        self._experts: Dict[ExpertKey, ExpertWeights] = {}
+        self._lock = threading.RLock()
+        self.resident_bytes = 0
+
+    def put(self, layer: int, expert: int, weights: ExpertWeights) -> None:
+        with self._lock:
+            if (self.capacity_bytes and weights.tier != "ssd"
+                    and self.resident_bytes + weights.nbytes
+                    > self.capacity_bytes):
+                raise CapacityError(
+                    f"shard would take the node to "
+                    f"{(self.resident_bytes + weights.nbytes) / 2**30:.2f} GiB "
+                    f"against a {self.capacity_bytes / 2**30:.2f} GiB budget",
+                    layer=layer, expert=expert)
+            self._experts[(layer, expert)] = weights
+            if weights.tier != "ssd":
+                self.resident_bytes += weights.nbytes
+
+    def get(self, layer: int, expert: int) -> ExpertWeights:
+        try:
+            return self._experts[(layer, expert)]
+        except KeyError:
+            raise ShardMissing("shard not resident on this node", layer=layer,
+                               expert=expert) from None
+
+    def holds(self, layer: int, expert: int) -> bool:
+        return (layer, expert) in self._experts
+
+    def layers(self) -> Iterable[int]:
+        return sorted({layer for layer, _ in self._experts})
+
+    def __len__(self) -> int:
+        return len(self._experts)
+
+    def map_from_storage(self, layer: int, expert: int, path: Path, *,
+                         hidden: int, intermediate: int,
+                         dtype: str = "float32") -> ExpertWeights:
+        """Memory-map an expert from NVMe instead of loading it.
+
+        The OS page cache then decides which experts stay hot, which is both
+        free and better than a hand-written policy: a routing distribution is
+        exactly the access pattern an LRU is good at.
+        """
+        itemsize = np.dtype(dtype).itemsize
+        counts = intermediate * hidden
+        gate = np.memmap(path, dtype=dtype, mode="r", offset=0,
+                         shape=(intermediate, hidden))
+        up = np.memmap(path, dtype=dtype, mode="r", offset=counts * itemsize,
+                       shape=(intermediate, hidden))
+        down = np.memmap(path, dtype=dtype, mode="r",
+                         offset=2 * counts * itemsize,
+                         shape=(hidden, intermediate))
+        weights = ExpertWeights(gate=gate, up=up, down=down, tier="ssd")
+        self.put(layer, expert, weights)
+        return weights
+
+
+class NodeServer:
+    """Serves G9XC on a console.
+
+    ``block_fn`` is the hook for the hot block (attention + router + shared
+    expert) on the shelf's host console; nodes that only hold experts leave it
+    unset and reject BLOCK_FWD, which is a plan/deployment mismatch worth
+    hearing about loudly.
+    """
+
+    def __init__(self, store: ShardStore, *, unit_id: str, host: str = "0.0.0.0",
+                 port: int = 9713, runner: Optional[ExpertRunner] = None,
+                 block_fn: Optional[Callable[[int, np.ndarray], np.ndarray]] = None,
+                 sku: str = "unknown", backend: str = "cpu-avx2",
+                 runtime: str = "host-sim", weight_bytes: int = 0,
+                 fast_bytes: int = 0, gemv_gflops: float = 0.0):
+        self.store = store
+        self.unit_id = unit_id
+        self.host = host
+        self.port = port
+        self.runner = runner or ExpertRunner()
+        self.block_fn = block_fn
+        self.hello = HelloPayload(unit_id=unit_id, sku=sku, backend=backend,
+                                  runtime=runtime, weight_bytes=weight_bytes,
+                                  fast_bytes=fast_bytes,
+                                  gemv_gflops=gemv_gflops)
+        self.tokens_served = 0
+        self.experts_run = 0
+        self.storage_reads = 0
+        self._server: Optional[socketserver.ThreadingTCPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    # -- serving ----------------------------------------------------------
+    def serve_forever(self) -> None:
+        server = self._make_server()
+        server.serve_forever(poll_interval=0.2)
+
+    def start(self) -> int:
+        """Start in a background thread; returns the bound port."""
+        server = self._make_server()
+        self._thread = threading.Thread(target=server.serve_forever,
+                                        kwargs={"poll_interval": 0.05},
+                                        name=f"g9-node-{self.unit_id}",
+                                        daemon=True)
+        self._thread.start()
+        return server.server_address[1]
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def __enter__(self) -> "NodeServer":
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.stop()
+
+    def _make_server(self) -> socketserver.ThreadingTCPServer:
+        node = self
+
+        class Handler(socketserver.BaseRequestHandler):
+            def handle(self) -> None:
+                self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY,
+                                        1)
+                while True:
+                    head = _read_exactly(self.request, HEADER_SIZE)
+                    if head is None:
+                        return
+                    try:
+                        frame, length = Frame.decode_header(head)
+                    except ValueError:
+                        return          # framing is gone; the peer must reopen
+                    payload = b""
+                    if length:
+                        body = _read_exactly(self.request, length)
+                        if body is None:
+                            return
+                        payload = body
+                    frame.payload = payload
+                    reply = node.handle_frame(frame)
+                    if reply is None:
+                        return
+                    self.request.sendall(reply.encode())
+
+        class Server(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+
+        server = Server((self.host, self.port), Handler)
+        self._server = server
+        self.port = server.server_address[1]
+        return server
+
+    # -- message handling -------------------------------------------------
+    def handle_frame(self, frame: Frame) -> Optional[Frame]:
+        """Dispatch one frame. Returns the reply, or None to close."""
+        handler = {
+            MsgType.HELLO: self._on_hello,
+            MsgType.EXPERT_BATCH: self._on_expert_batch,
+            MsgType.BLOCK_FWD: self._on_block,
+            MsgType.LOAD_SHARD: self._on_load,
+            MsgType.PING: self._on_ping,
+            MsgType.STATUS: self._on_status,
+        }.get(frame.msg_type)
+        if frame.msg_type is MsgType.SHUTDOWN:
+            return None
+        if handler is None:
+            return self._error(frame, f"unsupported message "
+                                      f"{frame.msg_type.name}")
+        try:
+            return handler(frame)
+        except (ShardMissing, CapacityError) as exc:
+            return self._error(frame, str(exc))
+        except Exception as exc:                    # noqa: BLE001 - reported
+            return self._error(frame, f"{type(exc).__name__}: {exc}")
+
+    def _on_hello(self, frame: Frame) -> Frame:
+        return Frame(MsgType.HELLO_ACK, frame.request_id,
+                     self.hello.encode())
+
+    def _on_expert_batch(self, frame: Frame) -> Frame:
+        payload = ExpertBatchPayload.decode(frame.payload)
+        weights = [self.store.get(frame.layer, eid)
+                   for eid in payload.expert_ids]
+        out = self.runner(payload.activation, weights, payload.gates)
+        self.experts_run += len(weights)
+        self.tokens_served += 1
+        flags = Flags.PARTIAL
+        if any(w.tier == "ssd" for w in weights):
+            self.storage_reads += 1
+            flags |= Flags.FROM_STORAGE
+        return Frame(MsgType.EXPERT_RESULT, frame.request_id,
+                     encode_vector(out), layer=frame.layer, token=frame.token,
+                     flags=flags)
+
+    def _on_block(self, frame: Frame) -> Frame:
+        if self.block_fn is None:
+            return self._error(frame, "this node hosts no hot blocks; the plan "
+                                      "and the deployment disagree")
+        out = self.block_fn(frame.layer, decode_vector(frame.payload))
+        return Frame(MsgType.BLOCK_RESULT, frame.request_id, encode_vector(out),
+                     layer=frame.layer, token=frame.token)
+
+    def _on_load(self, frame: Frame) -> Frame:
+        header, offset = ShardHeader.decode(frame.payload)
+        body = frame.payload[offset:]
+        try:
+            if header.dtype is DType.FP8_E4M3_B128:
+                self._load_fp8(header, body)
+            else:
+                self._load_f32(header, body)
+        except ValueError as exc:
+            return self._error(frame, str(exc))
+        return Frame(MsgType.LOAD_ACK, frame.request_id, layer=header.layer,
+                     expert=header.first_expert, dtype=header.dtype)
+
+    def _load_f32(self, header: ShardHeader, body: bytes) -> None:
+        per_expert = 3 * header.hidden_size * header.intermediate_size
+        array = np.frombuffer(body, dtype="<f4")
+        expected = header.n_experts * per_expert
+        if array.size != expected:
+            raise ValueError(f"shard body has {array.size} floats, "
+                             f"expected {expected}")
+        for index in range(header.n_experts):
+            chunk = array[index * per_expert:(index + 1) * per_expert]
+            gate, up, down = np.split(chunk, 3)
+            self.store.put(
+                header.layer, header.first_expert + index,
+                ExpertWeights(
+                    gate=gate.reshape(header.intermediate_size,
+                                      header.hidden_size),
+                    up=up.reshape(header.intermediate_size,
+                                  header.hidden_size),
+                    down=down.reshape(header.hidden_size,
+                                      header.intermediate_size),
+                    tier=header.tier))
+
+    def _load_fp8(self, header: ShardHeader, body: bytes) -> None:
+        """An FP8 shard: all the codes, then all the block scales.
+
+        Codes and scales are separated rather than interleaved so the codes
+        land contiguous and page-aligned in the coffer; a GPU backend uploads
+        them as one buffer and a memory-mapped shard reads them without a
+        gather. The scales are three orders of magnitude smaller and can
+        afford to be a second, small transfer.
+        """
+        matrix = header.hidden_size * header.intermediate_size
+        per_expert = 3 * matrix
+        n_codes = header.n_experts * per_expert
+        blocks_per_expert = 3 * fp8.n_blocks(matrix)
+        n_scales = header.n_experts * blocks_per_expert
+        expected = n_codes + 4 * n_scales
+        if len(body) != expected:
+            raise ValueError(f"fp8 shard body is {len(body)} bytes, expected "
+                             f"{expected} ({n_codes} codes + {n_scales} "
+                             f"block scales)")
+        codes = np.frombuffer(body, dtype=np.uint8, count=n_codes)
+        scales = np.frombuffer(body, dtype="<f4", count=n_scales,
+                               offset=n_codes)
+        for index in range(header.n_experts):
+            chunk = codes[index * per_expert:(index + 1) * per_expert]
+            gate, up, down = np.split(chunk, 3)
+            self.store.put(
+                header.layer, header.first_expert + index,
+                ExpertWeights(
+                    gate=gate.reshape(header.intermediate_size,
+                                      header.hidden_size),
+                    up=up.reshape(header.intermediate_size,
+                                  header.hidden_size),
+                    down=down.reshape(header.hidden_size,
+                                      header.intermediate_size),
+                    scales=scales[index * blocks_per_expert:
+                                  (index + 1) * blocks_per_expert],
+                    tier=header.tier))
+
+    def _on_ping(self, frame: Frame) -> Frame:
+        return Frame(MsgType.PONG, frame.request_id, frame.payload)
+
+    def _on_status(self, frame: Frame) -> Frame:
+        text = (f"unit={self.unit_id} shards={len(self.store)} "
+                f"resident={self.store.resident_bytes} "
+                f"tokens={self.tokens_served} experts={self.experts_run} "
+                f"storage_reads={self.storage_reads} backend={self.runner.name}")
+        return Frame(MsgType.STATUS_REPLY, frame.request_id,
+                     text.encode("utf-8"))
+
+    def _error(self, frame: Frame, message: str) -> Frame:
+        return Frame(MsgType.ERROR, frame.request_id, encode_error(message),
+                     layer=frame.layer, expert=frame.expert)
+
+
+def _read_exactly(sock: socket.socket, count: int) -> Optional[bytes]:
+    chunks = []
+    remaining = count
+    while remaining:
+        try:
+            chunk = sock.recv(remaining)
+        except OSError:
+            return None
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -16,7 +16,7 @@ becomes "what belongs where". This module answers it along four axes at once:
 2. **Hot/cold, by coffer.** Everything an MoE layer reads for *every* token —
    attention, the router, the shared expert, the norms — is small
    (~330 MiB at V4-Pro width) and must sit in the fastest coffer the owning
-   console has. The routed experts are ~13 GiB per layer and are read a handful
+   console has. The routed experts are ~12.9 GiB per layer and are read a handful
    at a time, so they belong in slow coffers and on NVMe. This is the RAM
    Coffers thesis applied to a memory hierarchy the console vendors built for
    their own reasons: the Series X's 560/336 GB/s split is a hot/cold boundary

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -7,15 +7,16 @@ dozen routed experts, so the interesting question stops being "does it fit" and
 becomes "what belongs where". This module answers it along four axes at once:
 
 1. **Pipeline, by contiguous layer range.** A stage owns consecutive decoder
-   layers so a token crosses the network once per stage, carrying one
-   ``hidden_size`` activation (16 KiB at V4-Pro width in bf16) rather than
-   anything proportional to the weights. Gigabit ethernet is the fleet's
-   scarcest resource and this is the axis that respects it.
+   layers so a token crosses the network once per stage, carrying one residual
+   state (56 KiB at V4-Pro width in bf16, four times hidden because of its
+   hyper-connections) rather than anything proportional to the weights.
+   Gigabit ethernet is the fleet's scarcest resource and this is the axis that
+   respects it.
 
 2. **Hot/cold, by coffer.** Everything an MoE layer reads for *every* token —
-   MLA attention, the router, the shared expert, the norms — is small
-   (~300 MiB at V4-Pro width) and must sit in the fastest coffer the owning
-   console has. The routed experts are ~19 GiB per layer and are read a handful
+   attention, the router, the shared expert, the norms — is small
+   (~330 MiB at V4-Pro width) and must sit in the fastest coffer the owning
+   console has. The routed experts are ~13 GiB per layer and are read a handful
    at a time, so they belong in slow coffers and on NVMe. This is the RAM
    Coffers thesis applied to a memory hierarchy the console vendors built for
    their own reasons: the Series X's 560/336 GB/s split is a hot/cold boundary
@@ -223,11 +224,17 @@ class SplitPlan:
 
 def _block_bytes(profile: ModelProfile, index: int) -> int:
     """Per-token weights of block ``index``, counting MTP heads as blocks."""
-    if index < profile.moe.n_dense_layers:
-        return profile.dense_layer_bytes()
-    if index < profile.n_layers:
-        return profile.hot_bytes_per_moe_layer()
-    return profile.mtp_hot_bytes()
+    return profile.block_bytes(index)
+
+
+def _block_need(profile: ModelProfile, index: int, context_tokens: int) -> int:
+    """What a hot host has to hold for block ``index``: weights plus its cache.
+
+    V4 interleaves attention kinds whose caches differ by a factor of 32, so
+    this is per block rather than one figure reused for every layer.
+    """
+    return (_block_bytes(profile, index)
+            + profile.block_kv_bytes(index, context_tokens))
 
 
 def _has_routed_experts(profile: ModelProfile, index: int) -> bool:
@@ -369,7 +376,6 @@ def _assign_layer_ranges(profile: ModelProfile,
     number and overflowing to NVMe.
     """
     n_blocks = profile.planning_layers
-    kv_per_layer = context_tokens * profile.mla.kv_cache_bytes_per_token("bf16")
 
     total_capacity = sum(_shelf_capacity(s, units) for s in shelves)
     if total_capacity <= 0:
@@ -403,14 +409,14 @@ def _assign_layer_ranges(profile: ModelProfile,
                 f"it is too small to be worth a layer of this model")
             continue
         first = layer
-        block_need = sum(_block_bytes(profile, first + offset) + kv_per_layer
+        block_need = sum(_block_need(profile, first + offset, context_tokens)
                          for offset in range(count))
         host = _shelf_host(shelf, units, caps, block_need)
         if host is None:
             # No member can hold every hot block for this many layers. Shrink
             # the shelf's range until one can, and push the rest onward.
             count, host = _shrink_until_hosted(profile, shelf, units, caps,
-                                               first, count, kv_per_layer)
+                                               first, count, context_tokens)
             if host is None:
                 raise PlanningError(
                     f"shelf {shelf_index} has no member able to hold even one "
@@ -434,7 +440,7 @@ def _assign_layer_ranges(profile: ModelProfile,
             if index >= profile.n_layers:
                 plan.io_pieces.append(f"mtp-head-{index - profile.n_layers}")
             plan.hot_bytes += _block_bytes(profile, index)
-            plan.kv_bytes += kv_per_layer
+            plan.kv_bytes += profile.block_kv_bytes(index, context_tokens)
         stages.append(StagePlan(stage_id=f"st-{len(stages):04d}",
                                 first_layer=first, n_layers=count,
                                 host_unit=host, expert_units=list(shelf)))
@@ -446,8 +452,9 @@ def _assign_layer_ranges(profile: ModelProfile,
         raise PlanningError(
             f"only {layer} of {n_blocks} layers could be given a hot "
             f"host; the fleet needs more consoles with a fast coffer, or a "
-            f"shorter context ({kv_per_layer / MB:.0f} MiB of KV per layer at "
-            f"{context_tokens} tokens)")
+            f"shorter context "
+            f"({profile.kv_cache_bytes(context_tokens) / profile.n_layers / MB:.0f}"
+            f" MiB of KV per layer on average at {context_tokens} tokens)")
     if len(stages) > 1:
         hops = len(stages) - 1
         warnings.append(
@@ -461,11 +468,11 @@ def _assign_layer_ranges(profile: ModelProfile,
 def _shrink_until_hosted(profile: ModelProfile, shelf: Sequence[str],
                          units: Dict[str, UnitPlan],
                          caps: Dict[str, EffectiveCapability],
-                         first: int, count: int, kv_per_layer: int
+                         first: int, count: int, context_tokens: int
                          ) -> Tuple[int, Optional[str]]:
     """Largest prefix of a shelf's range that one member can host, and who."""
     while count > 0:
-        need = sum(_block_bytes(profile, first + o) + kv_per_layer
+        need = sum(_block_need(profile, first + o, context_tokens)
                    for o in range(count))
         host = _shelf_host(shelf, units, caps, need)
         if host is not None:
@@ -664,7 +671,6 @@ def _estimate_decode(profile: ModelProfile,
     expert_bytes = profile.expert_bytes()
     top_k = profile.moe.top_k
     n_routed = profile.moe.n_routed_experts
-    kv_read = context_tokens * profile.mla.kv_cache_bytes_per_token("bf16")
     total = 0.0
     active_per_layer: List[float] = []
 
@@ -677,6 +683,9 @@ def _estimate_decode(profile: ModelProfile,
     for stage in stages:
         host_cap = caps[stage.host_unit]
         for layer in stage.layers:
+            # Under CSA the cache a layer *reads* is a small selection of the
+            # cache it holds, so the read is what decode costs, not residency.
+            kv_read = profile.block_kv_read_bytes(layer, context_tokens)
             worst = _read_seconds(host_cap,
                                   _block_bytes(profile, layer) + kv_read,
                                   "fast")

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -1,0 +1,757 @@
+"""Splitting planner: a DeepSeek MoE checkpoint across a heterogeneous fleet.
+
+The PS3 port of this idea had one placement axis, because a 256 MB console can
+hold exactly one thing: **one expert per console**. A ninth-generation console
+holds 8-13 GiB, which is enough for a whole layer's hot weights *and* a few
+dozen routed experts, so the interesting question stops being "does it fit" and
+becomes "what belongs where". This module answers it along four axes at once:
+
+1. **Pipeline, by contiguous layer range.** A stage owns consecutive decoder
+   layers so a token crosses the network once per stage, carrying one
+   ``hidden_size`` activation (16 KiB at V4-Pro width in bf16) rather than
+   anything proportional to the weights. Gigabit ethernet is the fleet's
+   scarcest resource and this is the axis that respects it.
+
+2. **Hot/cold, by coffer.** Everything an MoE layer reads for *every* token —
+   MLA attention, the router, the shared expert, the norms — is small
+   (~300 MiB at V4-Pro width) and must sit in the fastest coffer the owning
+   console has. The routed experts are ~19 GiB per layer and are read a handful
+   at a time, so they belong in slow coffers and on NVMe. This is the RAM
+   Coffers thesis applied to a memory hierarchy the console vendors built for
+   their own reasons: the Series X's 560/336 GB/s split is a hot/cold boundary
+   already drawn in silicon.
+
+3. **Expert-parallel, within a stage.** A layer's routed experts are spread over
+   the stage's consoles in proportion to what each can hold *and* how fast it
+   can read, so a Series S and a Series X in the same stage finish their share
+   of a token at the same time instead of the small one stalling the group.
+
+4. **SSD streaming, as the overflow tier.** These consoles have 2.4-5.5 GB/s
+   NVMe, which is the one respect in which they beat a commodity desktop. An
+   expert that does not fit in RAM is not a planning failure; it is a resident
+   of the cold tier, streamed on a routing hit, and the plan reports what that
+   costs.
+
+The load-balancing rule (axis 3) and the hot/cold rule (axis 2) are borrowed
+directly from what works for DeepSeek on consumer hardware: KTransformers and
+Fiddler both keep attention and the popular experts on the fast device and push
+the long tail to the slow one, partitioning by arithmetic intensity rather than
+by parameter count; llama.cpp's ``-ot`` expert-offload does the same thing by
+hand. The difference here is that the "fast device" and the "slow device" are two
+coffers of the same console, and there are dozens of consoles.
+
+The planner is pure arithmetic. It never touches a console, so a fleet can be
+sized, rebalanced, and argued about from a laptop, and the same plan is what the
+deployment tools turn into a ``cluster.json``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .hardware import (BANDWIDTH_EFFICIENCY, GB, MB, ConsoleUnit,
+                       EffectiveCapability)
+from .model import ModelProfile
+
+#: A weight read every token belongs in a coffer at least this fast. Below it,
+#: the hot block alone would dominate the layer's time budget. Chosen just under
+#: the Series S's 224 GB/s tier so a Series S can still host attention.
+HOT_BANDWIDTH_FLOOR_GBPS = 200.0
+
+#: Headroom kept free on every unit for activations, the KV cache's growth, the
+#: runtime, and fragmentation. Fractional, applied to the unit's usable bytes.
+RESIDENCY_HEADROOM = 0.08
+
+#: Consoles per shelf. A shelf is the unit of expert fan-out: one switch, one
+#: coordinator, one contiguous range of layers. 22 is the size Condor's PS3
+#: cluster used per subcluster and it remains a good number — large enough that
+#: a layer's experts are spread thin, small enough that a gigabit switch and one
+#: coordinator can serve the fan-out for every layer of every token.
+DEFAULT_SHELF_SIZE = 22
+
+#: One-way cost of a stage hop on the fleet's network, in seconds. Gigabit
+#: ethernet plus a switch; the payload is one activation, so this is latency,
+#: not bandwidth. Overridable per plan.
+DEFAULT_HOP_SECONDS = 0.00025
+
+
+class PlanningError(ValueError):
+    """The fleet cannot host the model even with every fallback enabled."""
+
+
+@dataclass
+class ExpertShard:
+    """A contiguous run of one layer's routed experts, on one unit."""
+
+    layer: int
+    first_expert: int
+    n_experts: int
+    unit_id: str
+    #: "fast" | "slow" | "ssd" — which coffer holds them.
+    tier: str
+
+    @property
+    def expert_ids(self) -> range:
+        return range(self.first_expert, self.first_expert + self.n_experts)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"layer": self.layer, "first_expert": self.first_expert,
+                "n_experts": self.n_experts, "unit_id": self.unit_id,
+                "tier": self.tier}
+
+
+@dataclass
+class UnitPlan:
+    """Everything one console is asked to hold."""
+
+    unit_id: str
+    sku: str
+    backend: str
+    #: Layers whose hot block (attention + router + shared expert) lives here.
+    hot_layers: List[int] = field(default_factory=list)
+    #: Dense (non-MoE) layers hosted whole.
+    dense_layers: List[int] = field(default_factory=list)
+    #: "embedding" / "lm_head" / "mtp" pieces hosted here.
+    io_pieces: List[str] = field(default_factory=list)
+    shards: List[ExpertShard] = field(default_factory=list)
+    hot_bytes: int = 0
+    fast_expert_bytes: int = 0
+    slow_expert_bytes: int = 0
+    ssd_expert_bytes: int = 0
+    kv_bytes: int = 0
+    capacity_bytes: int = 0
+    fast_capacity_bytes: int = 0
+    gemv_gflops: float = 0.0
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def resident_bytes(self) -> int:
+        """Bytes held in RAM (the SSD tier is not resident)."""
+        return (self.hot_bytes + self.fast_expert_bytes + self.slow_expert_bytes
+                + self.kv_bytes)
+
+    @property
+    def n_experts(self) -> int:
+        return sum(s.n_experts for s in self.shards)
+
+    @property
+    def headroom_bytes(self) -> int:
+        return self.capacity_bytes - self.resident_bytes
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "unit_id": self.unit_id, "sku": self.sku, "backend": self.backend,
+            "hot_layers": list(self.hot_layers),
+            "dense_layers": list(self.dense_layers),
+            "io_pieces": list(self.io_pieces),
+            "shards": [s.to_dict() for s in self.shards],
+            "hot_bytes": self.hot_bytes,
+            "fast_expert_bytes": self.fast_expert_bytes,
+            "slow_expert_bytes": self.slow_expert_bytes,
+            "ssd_expert_bytes": self.ssd_expert_bytes,
+            "kv_bytes": self.kv_bytes,
+            "resident_bytes": self.resident_bytes,
+            "capacity_bytes": self.capacity_bytes,
+            "n_experts": self.n_experts,
+            "gemv_gflops": self.gemv_gflops,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass
+class StagePlan:
+    """One pipeline stage: a contiguous layer range and the units serving it."""
+
+    stage_id: str
+    first_layer: int
+    n_layers: int
+    #: Unit holding the hot blocks (and the KV cache) for these layers.
+    host_unit: str
+    #: Units holding this stage's routed experts, including the host.
+    expert_units: List[str] = field(default_factory=list)
+
+    @property
+    def layers(self) -> range:
+        return range(self.first_layer, self.first_layer + self.n_layers)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {"stage_id": self.stage_id, "first_layer": self.first_layer,
+                "n_layers": self.n_layers, "host_unit": self.host_unit,
+                "expert_units": list(self.expert_units)}
+
+
+@dataclass
+class SplitPlan:
+    """The whole placement, plus what it is expected to cost."""
+
+    model: str
+    model_assumed: bool
+    context_tokens: int
+    stages: List[StagePlan]
+    units: Dict[str, UnitPlan]
+    feasible: bool
+    shortfall_bytes: int = 0
+    tokens_per_second: float = 0.0
+    seconds_per_token: float = 0.0
+    ssd_expert_bytes: int = 0
+    active_units_per_token: int = 0
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def n_units(self) -> int:
+        return len(self.units)
+
+    def unit(self, unit_id: str) -> UnitPlan:
+        return self.units[unit_id]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "model": self.model, "model_assumed": self.model_assumed,
+            "context_tokens": self.context_tokens,
+            "stages": [s.to_dict() for s in self.stages],
+            "units": {k: v.to_dict() for k, v in self.units.items()},
+            "feasible": self.feasible, "shortfall_bytes": self.shortfall_bytes,
+            "tokens_per_second": self.tokens_per_second,
+            "seconds_per_token": self.seconds_per_token,
+            "ssd_expert_bytes": self.ssd_expert_bytes,
+            "active_units_per_token": self.active_units_per_token,
+            "warnings": list(self.warnings),
+        }
+
+
+def _block_bytes(profile: ModelProfile, index: int) -> int:
+    """Per-token weights of block ``index``, counting MTP heads as blocks."""
+    if index < profile.moe.n_dense_layers:
+        return profile.dense_layer_bytes()
+    if index < profile.n_layers:
+        return profile.hot_bytes_per_moe_layer()
+    return profile.mtp_hot_bytes()
+
+
+def _has_routed_experts(profile: ModelProfile, index: int) -> bool:
+    return index >= profile.moe.n_dense_layers
+
+
+def _usable(cap: EffectiveCapability) -> int:
+    return int(cap.weight_bytes * (1.0 - RESIDENCY_HEADROOM))
+
+
+def _usable_fast(cap: EffectiveCapability) -> int:
+    return int(cap.weight_bytes_at_least(HOT_BANDWIDTH_FLOOR_GBPS)
+               * (1.0 - RESIDENCY_HEADROOM))
+
+
+def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
+               context_tokens: int = 8192,
+               shelf_size: int = DEFAULT_SHELF_SIZE,
+               allow_ssd_tier: bool = True,
+               hop_seconds: float = DEFAULT_HOP_SECONDS) -> SplitPlan:
+    """Place ``profile`` on ``fleet``.
+
+    The fleet is first cut into **shelves** of at most ``shelf_size`` consoles,
+    and each shelf is given a contiguous range of layers in proportion to how
+    much it can hold. Everything a layer needs then lives inside one shelf: its
+    hot block and KV cache on the shelf's fastest console, its routed experts
+    spread over the shelf's members. That is what bounds the fan-out — a token's
+    top-k crosses one switch inside one shelf per layer, instead of scattering
+    over the whole fleet — and it is the same reason Condor's PS3 cluster was
+    wired as subclusters of 22 behind a head node rather than as one flat farm.
+
+    Raises :class:`PlanningError` only when the fleet cannot host the model even
+    with the SSD tier enabled: a fleet that is merely *slow* gets a plan and a
+    warning, because "this works, at 0.4 tokens/s" is a useful answer and
+    refusing to plan is not.
+    """
+    if not fleet:
+        raise PlanningError("empty fleet")
+    if shelf_size < 1:
+        raise PlanningError("shelf_size must be >= 1")
+    caps = {u.unit_id: u.effective() for u in fleet}
+    if len(caps) != len(fleet):
+        raise PlanningError("duplicate unit_id in fleet")
+
+    units: Dict[str, UnitPlan] = {
+        uid: UnitPlan(unit_id=uid, sku=cap.sku, backend=cap.backend.value,
+                      capacity_bytes=_usable(cap),
+                      fast_capacity_bytes=_usable_fast(cap),
+                      gemv_gflops=cap.gemv_gflops,
+                      warnings=list(cap.warnings))
+        for uid, cap in caps.items()
+    }
+    warnings: List[str] = []
+    if profile.assumed:
+        warnings.append(
+            f"{profile.name} is an assumed configuration; every size in this "
+            f"plan moves when the real config is published")
+
+    shelves = _build_shelves(caps, units, shelf_size)
+    stages = _assign_layer_ranges(profile, caps, units, shelves,
+                                  context_tokens, warnings)
+    shortfall = _assign_experts(profile, caps, units, stages, allow_ssd_tier,
+                                warnings)
+    _assign_io(profile, caps, units, warnings)
+
+    if shortfall > 0:
+        raise PlanningError(
+            f"fleet is short {shortfall / GB:.1f} GiB for {profile.name} at "
+            f"{context_tokens} tokens of context: add units, enable the SSD "
+            f"tier, or shrink the context")
+
+    sec, active = _estimate_decode(profile, caps, units, stages, hop_seconds,
+                                   context_tokens)
+    ssd_bytes = sum(u.ssd_expert_bytes for u in units.values())
+    if ssd_bytes:
+        warnings.append(
+            f"{ssd_bytes / GB:.1f} GiB of routed experts live on NVMe and are "
+            f"streamed on a routing hit; where that happens the layer is bound "
+            f"by SSD reads, not by memory bandwidth")
+    return SplitPlan(
+        model=profile.name, model_assumed=profile.assumed,
+        context_tokens=context_tokens, stages=stages, units=units,
+        feasible=True, shortfall_bytes=0,
+        tokens_per_second=(1.0 / sec if sec > 0 else 0.0),
+        seconds_per_token=sec, ssd_expert_bytes=ssd_bytes,
+        active_units_per_token=active, warnings=warnings)
+
+
+# -- shelves ---------------------------------------------------------------
+
+def _build_shelves(caps: Dict[str, EffectiveCapability],
+                   units: Dict[str, UnitPlan],
+                   shelf_size: int) -> List[List[str]]:
+    """Cut the fleet into shelves, each a balanced mix of what is available.
+
+    Units are dealt round-robin in descending capability order, so every shelf
+    gets some of the fast consoles rather than one shelf inheriting all the
+    Series X units and another all the Series S ones. A shelf's slowest member
+    sets its per-layer floor, so an unbalanced cut would make one shelf's layers
+    permanently the slow ones.
+    """
+    ordered = sorted(units, key=lambda uid: (-units[uid].capacity_bytes,
+                                             -units[uid].gemv_gflops, uid))
+    n_shelves = max(1, math.ceil(len(ordered) / shelf_size))
+    shelves: List[List[str]] = [[] for _ in range(n_shelves)]
+    for index, uid in enumerate(ordered):
+        shelves[index % n_shelves].append(uid)
+    return shelves
+
+
+def _shelf_capacity(shelf: Sequence[str], units: Dict[str, UnitPlan]) -> int:
+    return sum(units[uid].capacity_bytes for uid in shelf)
+
+
+def _shelf_host(shelf: Sequence[str], units: Dict[str, UnitPlan],
+                caps: Dict[str, EffectiveCapability], need: int) -> Optional[str]:
+    """The shelf member that should hold hot blocks: fastest coffer first."""
+    eligible = [uid for uid in shelf
+                if units[uid].fast_capacity_bytes >= need
+                and caps[uid].fast_bandwidth_gbps >= HOT_BANDWIDTH_FLOOR_GBPS]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda uid: (caps[uid].fast_bandwidth_gbps,
+                                          units[uid].fast_capacity_bytes, uid))
+
+
+# -- axis 1 + 2: layer ranges per shelf, hot residency on its host ----------
+
+def _assign_layer_ranges(profile: ModelProfile,
+                         caps: Dict[str, EffectiveCapability],
+                         units: Dict[str, UnitPlan],
+                         shelves: Sequence[Sequence[str]],
+                         context_tokens: int,
+                         warnings: List[str]) -> List[StagePlan]:
+    """Give each shelf a contiguous run of layers, sized by what it can hold.
+
+    A shelf's share is proportional to its capacity, so a shelf of Series S
+    consoles takes fewer layers than a shelf of PS5s instead of taking the same
+    number and overflowing to NVMe.
+    """
+    n_blocks = profile.planning_layers
+    kv_per_layer = context_tokens * profile.mla.kv_cache_bytes_per_token("bf16")
+
+    total_capacity = sum(_shelf_capacity(s, units) for s in shelves)
+    if total_capacity <= 0:
+        raise PlanningError("no unit in the fleet has usable memory")
+
+    # Layers per shelf, proportional to capacity, at least one each until the
+    # layers run out (a shelf with no layers is dead weight the operator should
+    # see as such, so it keeps its slot and gets a warning instead).
+    quotas: List[int] = []
+    for shelf in shelves:
+        share = _shelf_capacity(shelf, units) / total_capacity
+        quotas.append(int(math.floor(n_blocks * share)))
+    while sum(quotas) < n_blocks:
+        # Hand the remainder to the roomiest shelves, largest first.
+        index = max(range(len(shelves)),
+                    key=lambda i: (_shelf_capacity(shelves[i], units)
+                                   / max(quotas[i] + 1, 1)))
+        quotas[index] += 1
+    while sum(quotas) > n_blocks:
+        index = max(range(len(shelves)), key=lambda i: quotas[i])
+        quotas[index] -= 1
+
+    stages: List[StagePlan] = []
+    layer = 0
+    for shelf_index, shelf in enumerate(shelves):
+        count = quotas[shelf_index]
+        if count <= 0:
+            warnings.append(
+                f"shelf {shelf_index} ({len(shelf)} units, "
+                f"{_shelf_capacity(shelf, units) / GB:.1f} GiB) holds no layers; "
+                f"it is too small to be worth a layer of this model")
+            continue
+        first = layer
+        block_need = sum(_block_bytes(profile, first + offset) + kv_per_layer
+                         for offset in range(count))
+        host = _shelf_host(shelf, units, caps, block_need)
+        if host is None:
+            # No member can hold every hot block for this many layers. Shrink
+            # the shelf's range until one can, and push the rest onward.
+            count, host = _shrink_until_hosted(profile, shelf, units, caps,
+                                               first, count, kv_per_layer)
+            if host is None:
+                raise PlanningError(
+                    f"shelf {shelf_index} has no member able to hold even one "
+                    f"layer's hot block plus its KV cache at {context_tokens} "
+                    f"tokens of context in a coffer at or above "
+                    f"{HOT_BANDWIDTH_FLOOR_GBPS:.0f} GB/s")
+            spilled = quotas[shelf_index] - count
+            for later in range(shelf_index + 1, len(shelves)):
+                quotas[later] += spilled // max(1, len(shelves) - shelf_index - 1)
+            warnings.append(
+                f"shelf {shelf_index} could only host {count} of "
+                f"{quotas[shelf_index]} layers' hot blocks; the rest moved to "
+                f"later shelves")
+        plan = units[host]
+        for offset in range(count):
+            index = first + offset
+            if index < profile.moe.n_dense_layers:
+                plan.dense_layers.append(index)
+            else:
+                plan.hot_layers.append(index)
+            if index >= profile.n_layers:
+                plan.io_pieces.append(f"mtp-head-{index - profile.n_layers}")
+            plan.hot_bytes += _block_bytes(profile, index)
+            plan.kv_bytes += kv_per_layer
+        stages.append(StagePlan(stage_id=f"st-{len(stages):04d}",
+                                first_layer=first, n_layers=count,
+                                host_unit=host, expert_units=list(shelf)))
+        layer += count
+        if layer >= n_blocks:
+            break
+
+    if layer < n_blocks:
+        raise PlanningError(
+            f"only {layer} of {n_blocks} layers could be given a hot "
+            f"host; the fleet needs more consoles with a fast coffer, or a "
+            f"shorter context ({kv_per_layer / MB:.0f} MiB of KV per layer at "
+            f"{context_tokens} tokens)")
+    if len(stages) > 1:
+        hops = len(stages) - 1
+        warnings.append(
+            f"{len(stages)} shelves: a token crosses the network {hops} "
+            f"time{'s' if hops != 1 else ''} between shelves per forward pass, "
+            f"carrying one {profile.activation_bytes() / 1024:.0f} KiB "
+            f"activation each time")
+    return stages
+
+
+def _shrink_until_hosted(profile: ModelProfile, shelf: Sequence[str],
+                         units: Dict[str, UnitPlan],
+                         caps: Dict[str, EffectiveCapability],
+                         first: int, count: int, kv_per_layer: int
+                         ) -> Tuple[int, Optional[str]]:
+    """Largest prefix of a shelf's range that one member can host, and who."""
+    while count > 0:
+        need = sum(_block_bytes(profile, first + o) + kv_per_layer
+                   for o in range(count))
+        host = _shelf_host(shelf, units, caps, need)
+        if host is not None:
+            return count, host
+        count -= 1
+    return 0, None
+
+
+# -- axis 3 + 4: expert placement inside a shelf, with an NVMe overflow -----
+
+def _assign_experts(profile: ModelProfile,
+                    caps: Dict[str, EffectiveCapability],
+                    units: Dict[str, UnitPlan], stages: Sequence[StagePlan],
+                    allow_ssd_tier: bool, warnings: List[str]) -> int:
+    """Spread each MoE layer's routed experts over its own shelf.
+
+    Within a shelf, a unit's share is proportional to its throughput, not to its
+    capacity: what matters at decode time is that every member finishes reading
+    its slice of the token's top-k at the same moment. A Series S given a PS5's
+    share would hold the whole shelf up on every token that routes to it.
+
+    Anything the shelf cannot hold in RAM goes to NVMe on the shelf's roomiest
+    member, and only if the shelf's storage is full does the planner reach
+    outside the shelf — recorded as a warning, because a cross-shelf expert
+    costs a round trip the shelf-local ones do not.
+
+    Returns bytes that could not be placed anywhere (0 when the plan fits).
+    """
+    expert = profile.expert_bytes()
+    all_units = sorted(units)
+    shortfall = 0
+    cross_shelf = 0
+
+    for stage in stages:
+        shelf = list(stage.expert_units)
+        for layer in stage.layers:
+            if not _has_routed_experts(profile, layer):
+                continue
+            remaining = profile.moe.n_routed_experts
+            first = 0
+            shares = _shelf_shares(profile, shelf, units)
+            for uid in sorted(shelf, key=lambda u: (-units[u].headroom_bytes, u)):
+                if remaining <= 0:
+                    break
+                plan = units[uid]
+                free = plan.headroom_bytes
+                if free < expert:
+                    continue
+                take = int(max(1, min(remaining, free // expert, shares[uid])))
+                tier = _tier_for(caps[uid], plan, take * expert)
+                plan.shards.append(ExpertShard(layer, first, take, uid, tier))
+                if tier == "fast":
+                    plan.fast_expert_bytes += take * expert
+                else:
+                    plan.slow_expert_bytes += take * expert
+                first += take
+                remaining -= take
+            if remaining <= 0:
+                continue
+            if allow_ssd_tier:
+                placed = _place_on_ssd(layer, first, remaining, expert, shelf,
+                                       stage, caps, units)
+                first += placed
+                remaining -= placed
+            if remaining <= 0:
+                continue
+            # Last resort: outside the shelf.
+            outside = [uid for uid in all_units if uid not in shelf]
+            for uid in sorted(outside,
+                              key=lambda u: (-units[u].headroom_bytes, u)):
+                if remaining <= 0:
+                    break
+                plan = units[uid]
+                take = int(min(remaining, plan.headroom_bytes // expert))
+                if take <= 0:
+                    continue
+                tier = _tier_for(caps[uid], plan, take * expert)
+                plan.shards.append(ExpertShard(layer, first, take, uid, tier))
+                if tier == "fast":
+                    plan.fast_expert_bytes += take * expert
+                else:
+                    plan.slow_expert_bytes += take * expert
+                if uid not in stage.expert_units:
+                    stage.expert_units.append(uid)
+                first += take
+                remaining -= take
+                cross_shelf += take
+            shortfall += remaining * expert
+
+    if cross_shelf:
+        warnings.append(
+            f"{cross_shelf} expert placements spilled outside their shelf; "
+            f"those routing hits cost a cross-shelf round trip, so add "
+            f"consoles to the shelves that overflowed rather than anywhere")
+    return shortfall
+
+
+def _shelf_shares(profile: ModelProfile, shelf: Sequence[str],
+                  units: Dict[str, UnitPlan]) -> Dict[str, int]:
+    """How many of a layer's experts each shelf member should take."""
+    total = sum(max(units[uid].gemv_gflops, 1.0) for uid in shelf)
+    shares: Dict[str, int] = {}
+    for uid in shelf:
+        fraction = max(units[uid].gemv_gflops, 1.0) / total
+        shares[uid] = max(1, int(round(profile.moe.n_routed_experts * fraction)))
+    return shares
+
+
+def _tier_for(cap: EffectiveCapability, plan: UnitPlan, want: int) -> str:
+    """Which coffer a new shard lands in: the fast one while it has room.
+
+    On a Series X this is the 560/336 GB/s boundary doing real work — the first
+    experts a unit takes sit in the fast coffer beside the hot block, and the
+    rest fall into the slow one, which is exactly the tiering the console was
+    built with and the reason a Series X is worth more than its 16 GB suggests.
+    """
+    fast_used = plan.hot_bytes + plan.kv_bytes + plan.fast_expert_bytes
+    return "fast" if fast_used + want <= plan.fast_capacity_bytes else "slow"
+
+
+def _place_on_ssd(layer: int, first: int, count: int, expert_bytes: int,
+                  shelf: Sequence[str], stage: StagePlan,
+                  caps: Dict[str, EffectiveCapability],
+                  units: Dict[str, UnitPlan]) -> int:
+    """Put the remainder of a layer's experts on shelf-local NVMe.
+
+    Streaming is the one respect in which these consoles beat a commodity
+    desktop — 2.4 GB/s on an Xbox, 5.5 GB/s on a PS5, against a spinning fleet's
+    nothing — so an expert that misses RAM costs a read, not a refusal. Half of
+    each unit's drive is left alone for the OS, the checkpoint's own copy, and
+    the fact that a console's drive is also a console's drive.
+    """
+    placed = 0
+    for uid in sorted(shelf, key=lambda u: (-caps[u].storage.capacity_bytes, u)):
+        if placed >= count:
+            break
+        cap = caps[uid]
+        plan = units[uid]
+        room = cap.storage.capacity_bytes // 2 - plan.ssd_expert_bytes
+        take = min(count - placed, max(0, room // expert_bytes))
+        if take <= 0:
+            continue
+        plan.shards.append(ExpertShard(layer, first + placed, take, uid, "ssd"))
+        plan.ssd_expert_bytes += take * expert_bytes
+        placed += take
+    return placed
+
+
+def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
+               units: Dict[str, UnitPlan], warnings: List[str]) -> None:
+    """Place the embedding, the LM head, and any MTP heads.
+
+    Both ends of the model are read once per token and are large (~2 GiB each at
+    V4-Pro width in bf16, since the vocabulary tables are not FP8), so they go
+    wherever there is room, preferring the units that already host the first and
+    last layers so the token starts and ends where it is embedded.
+    """
+    pieces = [("embedding", profile.embedding_bytes()),
+              ("lm_head", profile.lm_head_bytes())]
+    for name, size in pieces:
+        target = max(units.values(),
+                     key=lambda p: (p.headroom_bytes, p.unit_id))
+        if target.headroom_bytes < size:
+            warnings.append(
+                f"{name} ({size / GB:.2f} GiB) does not fit in any unit's "
+                f"remaining RAM; it is placed on {target.unit_id}'s NVMe, which "
+                f"costs a streamed read once per token")
+            target.ssd_expert_bytes += size
+            target.io_pieces.append(f"{name}@ssd")
+            continue
+        target.io_pieces.append(name)
+        target.hot_bytes += size
+
+
+# -- cost model ------------------------------------------------------------
+
+def _estimate_decode(profile: ModelProfile,
+                     caps: Dict[str, EffectiveCapability],
+                     units: Dict[str, UnitPlan], stages: Sequence[StagePlan],
+                     hop_seconds: float,
+                     context_tokens: int) -> Tuple[float, int]:
+    """Seconds per decoded token, and how many consoles a token lights up.
+
+    Decode at batch 1 is memory-bound everywhere, so a layer costs what it takes
+    to *read* the weights that token needs. The shelf's members read in
+    parallel, so the layer costs the slowest of them, plus one intra-shelf
+    round trip to fan the activation out to the expert holders and gather their
+    partial sums back. That round trip, times the layer count, is usually a
+    larger term than anyone expects: it is why shelves are bounded and why the
+    experts of a layer are not scattered across the fleet.
+
+    Expert reads are prorated by the chance a unit holds one of the top-k, which
+    is what makes a wider shelf faster: the same top-k work spread over more
+    readers.
+    """
+    expert_bytes = profile.expert_bytes()
+    top_k = profile.moe.top_k
+    n_routed = profile.moe.n_routed_experts
+    kv_read = context_tokens * profile.mla.kv_cache_bytes_per_token("bf16")
+    total = 0.0
+    active_per_layer: List[float] = []
+
+    shards_by_layer: Dict[int, List[Tuple[str, ExpertShard]]] = {}
+    for plan in units.values():
+        for shard in plan.shards:
+            shards_by_layer.setdefault(shard.layer, []).append(
+                (plan.unit_id, shard))
+
+    for stage in stages:
+        host_cap = caps[stage.host_unit]
+        for layer in stage.layers:
+            worst = _read_seconds(host_cap,
+                                  _block_bytes(profile, layer) + kv_read,
+                                  "fast")
+            touched = 1.0
+            remote = False
+            for uid, shard in shards_by_layer.get(layer, ()):
+                expected = shard.n_experts * top_k / n_routed
+                if expected <= 0:
+                    continue
+                worst = max(worst, _read_seconds(caps[uid],
+                                                 expected * expert_bytes,
+                                                 shard.tier))
+                # P(this unit holds at least one of the token's top-k).
+                touched += 1.0 - (1.0 - shard.n_experts / n_routed) ** top_k
+                remote = remote or uid != stage.host_unit
+            if remote:
+                worst += 2 * hop_seconds  # fan out, gather back
+            total += worst
+            active_per_layer.append(touched)
+
+    total += hop_seconds * max(0, len(stages) - 1)
+    peak = max(active_per_layer) if active_per_layer else 0.0
+    return total, int(round(peak))
+
+
+def _read_seconds(cap: EffectiveCapability, nbytes: float, tier: str) -> float:
+    """Time to read ``nbytes`` from one tier of a unit, at real efficiency."""
+    if nbytes <= 0:
+        return 0.0
+    if tier == "ssd":
+        return nbytes / (cap.storage.effective_read_gbps * 1e9)
+    if tier == "fast" or len(cap.coffers) == 1:
+        bandwidth = cap.fast_bandwidth_gbps
+    else:
+        bandwidth = min(c.bandwidth_gbps for c in cap.coffers)
+    return nbytes / (bandwidth * 1e9 * BANDWIDTH_EFFICIENCY[cap.backend])
+
+
+def describe_plan(plan: SplitPlan, *, per_console: bool = True) -> List[str]:
+    """Readable summary, shared by the CLIs.
+
+    ``per_console=False`` keeps the headline numbers and the shelf layout but
+    drops the line-per-console listing, which is what ``g9 size`` wants: for a
+    170-console fleet that listing is the answer to a different question.
+    """
+    lines = [
+        f"{plan.model}"
+        + (" (ASSUMED CONFIGURATION)" if plan.model_assumed else "")
+        + f" on {plan.n_units} consoles in {len(plan.stages)} shelves",
+        f"  context               {plan.context_tokens} tokens",
+        f"  decode estimate       {plan.tokens_per_second:.2f} tok/s "
+        f"({plan.seconds_per_token * 1000:.0f} ms/token)",
+        f"  consoles per layer    ~{plan.active_units_per_token} lit by one token",
+    ]
+    if plan.ssd_expert_bytes:
+        lines.append(f"  streamed from NVMe    "
+                     f"{plan.ssd_expert_bytes / GB:.1f} GiB of experts")
+    lines.append("  shelves:")
+    for stage in plan.stages:
+        last = stage.first_layer + stage.n_layers - 1
+        lines.append(
+            f"    {stage.stage_id}  layers {stage.first_layer:>3}-{last:<3} "
+            f"host {stage.host_unit:<14} "
+            f"experts on {len(stage.expert_units)} consoles")
+    if per_console:
+        lines.append("  consoles:")
+        for uid in sorted(plan.units):
+            u = plan.units[uid]
+            lines.append(
+                f"    {uid:<14} {u.sku:<15} {u.backend:<9} "
+                f"{u.resident_bytes / GB:6.2f}/{u.capacity_bytes / GB:5.2f} GiB "
+                f"{u.n_experts:>6} experts "
+                f"{len(u.hot_layers) + len(u.dense_layers):>3} hot layers"
+                + (f" +{u.ssd_expert_bytes / GB:.1f} GiB NVMe"
+                   if u.ssd_expert_bytes else ""))
+    for warning in plan.warnings:
+        lines.append(f"  ! {warning}")
+    return lines

--- a/gen9-cluster/gen9_cluster/protocol.py
+++ b/gen9-cluster/gen9_cluster/protocol.py
@@ -1,0 +1,338 @@
+"""G9XC: the wire format between a shelf coordinator and its consoles.
+
+Adapted from the PS3 port's P3XC, with the changes ninth-generation hardware
+forces:
+
+* **A console holds many experts, not one.** P3XC could put the expert id in the
+  header because a PS3 held exactly one. Here a node holds dozens, and a token
+  routing into three of them must not cost three round trips — so
+  :class:`ExpertBatch` names a *set* of experts and their gate weights in one
+  frame, and the node returns their weighted sum as one :class:`ExpertResult`.
+  That single change is what keeps the per-layer latency at one round trip per
+  console instead of one per expert.
+* **Weights are FP8 with block scales.** The dtype field therefore has to name
+  ``fp8-e4m3-b128``, and a frame carrying it also carries its scale block, so a
+  shard can be shipped in the format the checkpoint already uses.
+* **Little-endian.** P3XC was big-endian because the Cell's PPE was. Every
+  console here is x86-64, so the wire order is the host order and encoding is a
+  memcpy on both ends.
+
+The framing is deliberately dull: a fixed 32-byte header, then the payload.
+Fixed-size headers mean a node can read a header, learn the payload length, and
+read exactly that — no delimiter scanning, no partial-parse states to get wrong
+at three in the morning when a shelf is wedged.
+
+Every frame carries ``request_id``, and a reply must echo it. The transport
+matches replies to requests by that id alone, which is what allows several
+requests to be in flight on one connection: at 92 blocks per token and a quarter
+of a millisecond per hop, a strictly serial connection would spend most of a
+token's time waiting.
+"""
+
+from __future__ import annotations
+
+import enum
+import struct
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+
+MAGIC = b"G9XC"
+VERSION = 1
+
+#: ``magic(4) version(1) type(1) flags(2) request_id(4) layer(2) expert(2)
+#: token(4) dtype(1) rank(1) reserved(2) payload_len(4)`` = 28, padded to 32.
+HEADER = struct.Struct("<4sBBHIHHIBBHI4x")
+HEADER_SIZE = HEADER.size
+assert HEADER_SIZE == 32
+
+#: Refuse anything larger rather than allocating it. A legitimate frame is an
+#: activation (tens of KiB) or a shard chunk; 64 MiB is far above both and far
+#: below "a malformed length field just asked for all of memory".
+MAX_PAYLOAD = 64 * 1024 * 1024
+
+
+class MsgType(enum.IntEnum):
+    HELLO = 1
+    HELLO_ACK = 2
+    #: Coordinator -> node: run these experts on this activation.
+    EXPERT_BATCH = 3
+    #: Node -> coordinator: their gate-weighted sum.
+    EXPERT_RESULT = 4
+    #: Coordinator -> node: run a hot block (attention + router + shared expert).
+    BLOCK_FWD = 5
+    BLOCK_RESULT = 6
+    #: Residency management.
+    LOAD_SHARD = 7
+    LOAD_ACK = 8
+    #: Liveness and telemetry.
+    PING = 9
+    PONG = 10
+    STATUS = 11
+    STATUS_REPLY = 12
+    ERROR = 13
+    SHUTDOWN = 14
+
+
+class DType(enum.IntEnum):
+    FP32 = 0
+    FP16 = 1
+    BF16 = 2
+    #: FP8 E4M3 with one fp32 scale per 128 elements, as DeepSeek ships it.
+    FP8_E4M3_B128 = 3
+
+    @property
+    def itemsize(self) -> float:
+        return {DType.FP32: 4.0, DType.FP16: 2.0, DType.BF16: 2.0,
+                DType.FP8_E4M3_B128: 1.0}[self]
+
+    @property
+    def numpy(self) -> np.dtype:
+        """The numpy view of the *payload* bytes.
+
+        BF16 and FP8 have no portable numpy dtype, so they travel as raw bytes
+        and are converted by the kernel; the tests exercise the fp32 path, which
+        is what the reference worker uses.
+        """
+        names: Dict["DType", str] = {DType.FP32: "<f4", DType.FP16: "<f2",
+                                     DType.BF16: "<u2",
+                                     DType.FP8_E4M3_B128: "u1"}
+        return np.dtype(names[self])
+
+
+class Flags(enum.IntFlag):
+    NONE = 0
+    #: The payload is a partial sum that the coordinator must add to others.
+    PARTIAL = 1 << 0
+    #: The sender read this expert from NVMe rather than RAM; the coordinator
+    #: uses it to explain a slow layer without guessing.
+    FROM_STORAGE = 1 << 1
+    #: The node is shedding load and would like fewer of these.
+    BACKPRESSURE = 1 << 2
+
+
+@dataclass
+class Frame:
+    """A decoded G9XC frame: a header and an undecoded payload."""
+
+    msg_type: MsgType
+    request_id: int
+    payload: bytes = b""
+    layer: int = 0
+    expert: int = 0
+    token: int = 0
+    dtype: DType = DType.FP32
+    rank: int = 0
+    flags: Flags = Flags.NONE
+    version: int = VERSION
+
+    def encode(self) -> bytes:
+        if len(self.payload) > MAX_PAYLOAD:
+            raise ValueError(f"payload of {len(self.payload)} bytes exceeds "
+                             f"the {MAX_PAYLOAD} byte limit")
+        head = HEADER.pack(MAGIC, self.version, int(self.msg_type),
+                           int(self.flags), self.request_id, self.layer,
+                           self.expert, self.token, int(self.dtype), self.rank,
+                           0, len(self.payload))
+        return head + self.payload
+
+    @classmethod
+    def decode_header(cls, raw: bytes) -> Tuple["Frame", int]:
+        """Parse a header, returning the frame and its payload length."""
+        if len(raw) != HEADER_SIZE:
+            raise ValueError(f"header must be {HEADER_SIZE} bytes, "
+                             f"got {len(raw)}")
+        (magic, version, msg_type, flags, request_id, layer, expert, token,
+         dtype, rank, _reserved, payload_len) = HEADER.unpack(raw)
+        if magic != MAGIC:
+            raise ValueError(f"bad magic {magic!r}; not a G9XC stream")
+        if version != VERSION:
+            raise ValueError(f"unsupported G9XC version {version} "
+                             f"(this build speaks {VERSION})")
+        if payload_len > MAX_PAYLOAD:
+            raise ValueError(f"declared payload of {payload_len} bytes exceeds "
+                             f"the {MAX_PAYLOAD} byte limit")
+        try:
+            typed = MsgType(msg_type)
+        except ValueError as exc:
+            raise ValueError(f"unknown message type {msg_type}") from exc
+        frame = cls(msg_type=typed, request_id=request_id, layer=layer,
+                    expert=expert, token=token, dtype=DType(dtype), rank=rank,
+                    flags=Flags(flags), version=version)
+        return frame, payload_len
+
+
+# -- payload helpers -------------------------------------------------------
+#
+# Payload layouts are declared here rather than inline at call sites so both
+# ends of the wire read from the same description.
+
+_U32 = struct.Struct("<I")
+_U16 = struct.Struct("<H")
+
+
+def encode_vector(vec: np.ndarray) -> bytes:
+    """A dense fp32 vector: the activation format between consoles.
+
+    Activations stay fp32 on the wire even though the weights are FP8. One
+    hidden state is 32 KiB at V4-Pro width, which a gigabit link moves in a
+    quarter of a millisecond, and halving it would buy less than the accuracy it
+    costs when 8 partial sums from 8 consoles are added together.
+    """
+    return np.ascontiguousarray(vec, dtype="<f4").tobytes()
+
+
+def decode_vector(payload: bytes) -> np.ndarray:
+    return np.frombuffer(payload, dtype="<f4")
+
+
+@dataclass
+class ExpertBatchPayload:
+    """The experts one console must run for one token, and their gate weights.
+
+    ``expert_ids`` are global ids within the layer, so a node that has been
+    handed a different shard range still interprets them the same way.
+    """
+
+    expert_ids: Tuple[int, ...]
+    gates: Tuple[float, ...]
+    activation: np.ndarray
+
+    def encode(self) -> bytes:
+        if len(self.expert_ids) != len(self.gates):
+            raise ValueError("expert_ids and gates must be the same length")
+        activation = encode_vector(self.activation)
+        out = [_U16.pack(len(self.expert_ids)),
+               # The activation length is stated rather than inferred from
+               # what is left in the buffer: a truncated tail is otherwise a
+               # perfectly well-formed batch with a shorter hidden state, and
+               # the node would happily compute a wrong answer from it.
+               _U32.pack(len(activation) // 4)]
+        for eid in self.expert_ids:
+            out.append(_U16.pack(eid))
+        out.append(np.asarray(self.gates, dtype="<f4").tobytes())
+        out.append(activation)
+        return b"".join(out)
+
+    @classmethod
+    def decode(cls, payload: bytes) -> "ExpertBatchPayload":
+        """Parse a batch, refusing anything short.
+
+        Every length is checked before it is used. A truncated frame is either
+        a bad peer or a bad network, and the difference between a ValueError
+        the node turns into an ERROR reply and a struct.error that escapes as
+        an unhandled exception is the difference between a logged incident and
+        a dropped connection.
+        """
+        if len(payload) < _U16.size + _U32.size:
+            raise ValueError("expert batch is too short to hold its counts")
+        (count,) = _U16.unpack_from(payload, 0)
+        (n_activation,) = _U32.unpack_from(payload, _U16.size)
+        offset = _U16.size + _U32.size
+        needed = offset + count * (_U16.size + 4) + n_activation * 4
+        if len(payload) != needed:
+            raise ValueError(f"expert batch declares {count} experts and a "
+                             f"{n_activation}-wide activation, which needs "
+                             f"{needed} bytes; got {len(payload)}")
+        if count == 0:
+            raise ValueError("expert batch names no experts")
+        ids = []
+        for _ in range(count):
+            (eid,) = _U16.unpack_from(payload, offset)
+            ids.append(eid)
+            offset += _U16.size
+        gates = np.frombuffer(payload, dtype="<f4", count=count, offset=offset)
+        offset += 4 * count
+        activation = np.frombuffer(payload, dtype="<f4", count=n_activation,
+                                   offset=offset)
+        return cls(tuple(ids), tuple(float(g) for g in gates), activation)
+
+
+@dataclass
+class ShardHeader:
+    """Describes a shard being loaded onto a node."""
+
+    layer: int
+    first_expert: int
+    n_experts: int
+    hidden_size: int
+    intermediate_size: int
+    dtype: DType = DType.FP32
+    #: Which coffer the receiving node should hold it in.
+    tier: str = "fast"
+
+    _FIXED = struct.Struct("<HHHIIB")
+
+    def encode(self) -> bytes:
+        tier = self.tier.encode("ascii")
+        return (self._FIXED.pack(self.layer, self.first_expert, self.n_experts,
+                                 self.hidden_size, self.intermediate_size,
+                                 int(self.dtype))
+                + _U16.pack(len(tier)) + tier)
+
+    @classmethod
+    def decode(cls, payload: bytes) -> Tuple["ShardHeader", int]:
+        if len(payload) < cls._FIXED.size + _U16.size:
+            raise ValueError("shard header is truncated")
+        (layer, first, count, hidden, inter,
+         dtype) = cls._FIXED.unpack_from(payload, 0)
+        offset = cls._FIXED.size
+        (length,) = _U16.unpack_from(payload, offset)
+        offset += _U16.size
+        if len(payload) < offset + length:
+            raise ValueError("shard header tier name is truncated")
+        tier = payload[offset:offset + length].decode("ascii")
+        offset += length
+        return cls(layer, first, count, hidden, inter, DType(dtype), tier), offset
+
+
+@dataclass
+class HelloPayload:
+    """What a node tells the coordinator when it connects.
+
+    A node announces what it *is*, not what the plan believes it to be, so a
+    console that came back from a repair with fewer CUs, a smaller sandbox, or a
+    different backend is caught at connect time rather than by mystery
+    slowness three hours later.
+    """
+
+    unit_id: str
+    sku: str
+    backend: str
+    runtime: str
+    weight_bytes: int
+    fast_bytes: int
+    gemv_gflops: float
+    protocol_version: int = VERSION
+
+    def encode(self) -> bytes:
+        parts = [self.unit_id, self.sku, self.backend, self.runtime]
+        out = [struct.pack("<QQdB", self.weight_bytes, self.fast_bytes,
+                           self.gemv_gflops, self.protocol_version)]
+        for text in parts:
+            raw = text.encode("utf-8")
+            out.append(_U16.pack(len(raw)))
+            out.append(raw)
+        return b"".join(out)
+
+    @classmethod
+    def decode(cls, payload: bytes) -> "HelloPayload":
+        weight, fast, gflops, version = struct.unpack_from("<QQdB", payload, 0)
+        offset = struct.calcsize("<QQdB")
+        texts = []
+        for _ in range(4):
+            (length,) = _U16.unpack_from(payload, offset)
+            offset += _U16.size
+            texts.append(payload[offset:offset + length].decode("utf-8"))
+            offset += length
+        return cls(texts[0], texts[1], texts[2], texts[3], weight, fast,
+                   gflops, version)
+
+
+def encode_error(message: str) -> bytes:
+    return message.encode("utf-8")[:4096]
+
+
+def decode_error(payload: bytes) -> str:
+    return payload.decode("utf-8", errors="replace")

--- a/gen9-cluster/gen9_cluster/protocol.py
+++ b/gen9-cluster/gen9_cluster/protocol.py
@@ -6,10 +6,18 @@ forces:
 * **A console holds many experts, not one.** P3XC could put the expert id in the
   header because a PS3 held exactly one. Here a node holds dozens, and a token
   routing into three of them must not cost three round trips — so
-  :class:`ExpertBatch` names a *set* of experts and their gate weights in one
-  frame, and the node returns their weighted sum as one :class:`ExpertResult`.
-  That single change is what keeps the per-layer latency at one round trip per
-  console instead of one per expert.
+  :class:`ExpertBatchPayload` names a *set* of experts and their gate weights in
+  one frame. That single change is what keeps the per-layer latency at one round
+  trip per console instead of one per expert.
+* **The reply is per-expert rows, not a partial sum.** This is P3XC's rule kept,
+  not dropped: a node returns one weighted row per expert, tagged with the
+  expert it came from (:class:`ExpertRowsPayload`), and the coordinator adds
+  them in strict top-k order. Collapsing a console's experts into one fp32 sum
+  re-associates the addition, so the same token would produce different logits
+  depending on which console happened to hold which expert — a replan would
+  silently change the output. ``Flags.FAST`` asks for the collapsed sum anyway,
+  for a caller that has decided it wants the bandwidth back; it is opt-in
+  precisely because it is the answer-changing choice.
 * **Weights are FP8 with block scales.** The dtype field therefore has to name
   ``fp8-e4m3-b128``, and a frame carrying it also carries its scale block, so a
   shard can be shipped in the format the checkpoint already uses.
@@ -27,6 +35,12 @@ matches replies to requests by that id alone, which is what allows several
 requests to be in flight on one connection: at 92 blocks per token and a quarter
 of a millisecond per hop, a strictly serial connection would spend most of a
 token's time waiting.
+
+``request_id`` is a *transport* id, scoped to one connection and reallocated on
+reconnect, so it cannot identify a retried batch. A batch that wants
+exactly-once execution carries its own 64-bit ``batch_id`` in the payload; the
+node runs it under that id and replays the first attempt's bytes to a retry
+(:mod:`gen9_cluster.dedup`).
 """
 
 from __future__ import annotations
@@ -34,12 +48,16 @@ from __future__ import annotations
 import enum
 import struct
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import numpy as np
 
 MAGIC = b"G9XC"
-VERSION = 1
+#: 2 since the reply to an ``EXPERT_BATCH`` became per-expert rows by default
+#: and the batch gained an optional ``batch_id``. Version 1 nodes and version 2
+#: coordinators disagree about the shape of every expert reply, which a version
+#: check catches at the first frame rather than as wrong logits.
+VERSION = 2
 
 #: ``magic(4) version(1) type(1) flags(2) request_id(4) layer(2) expert(2)
 #: token(4) dtype(1) rank(1) reserved(2) payload_len(4)`` = 28, padded to 32.
@@ -58,7 +76,8 @@ class MsgType(enum.IntEnum):
     HELLO_ACK = 2
     #: Coordinator -> node: run these experts on this activation.
     EXPERT_BATCH = 3
-    #: Node -> coordinator: their gate-weighted sum.
+    #: Node -> coordinator: one weighted row per expert, or their sum under
+    #: ``Flags.FAST``.
     EXPERT_RESULT = 4
     #: Coordinator -> node: run a hot block (attention + router + shared expert).
     BLOCK_FWD = 5
@@ -104,12 +123,23 @@ class DType(enum.IntEnum):
 class Flags(enum.IntFlag):
     NONE = 0
     #: The payload is a partial sum that the coordinator must add to others.
+    #: Set on a ``FAST`` reply, and only on one.
     PARTIAL = 1 << 0
     #: The sender read this expert from NVMe rather than RAM; the coordinator
     #: uses it to explain a slow layer without guessing.
     FROM_STORAGE = 1 << 1
     #: The node is shedding load and would like fewer of these.
     BACKPRESSURE = 1 << 2
+    #: Request: collapse this batch into one gate-weighted sum instead of
+    #: returning a row per expert. Opt-in, because it re-associates the layer's
+    #: fp32 reduction and can therefore change the token that gets emitted.
+    FAST = 1 << 3
+    #: Reply: the payload is :class:`ExpertRowsPayload` — one weighted row per
+    #: expert, tagged with its expert id. The default shape.
+    PER_EXPERT = 1 << 4
+    #: Reply: served from the node's dedup cache, i.e. this is a retry of a
+    #: batch that already ran and the experts were *not* run a second time.
+    REPLAYED = 1 << 5
 
 
 @dataclass
@@ -170,6 +200,7 @@ class Frame:
 
 _U32 = struct.Struct("<I")
 _U16 = struct.Struct("<H")
+_U64 = struct.Struct("<Q")
 
 
 def encode_vector(vec: np.ndarray) -> bytes:
@@ -193,22 +224,39 @@ class ExpertBatchPayload:
 
     ``expert_ids`` are global ids within the layer, so a node that has been
     handed a different shard range still interprets them the same way.
+
+    ``batch_id`` names this *logical* batch, as distinct from the header's
+    per-connection ``request_id``. A coordinator reuses it when it re-sends the
+    same batch after a timeout or a dropped socket, which is what lets the node
+    recognise the retry and replay its first answer instead of running the
+    experts twice. It is optional: a caller that does not care sends ``None``
+    and gets at-least-once execution, which for a pure function of
+    (activation, weights) is only a waste of a console's time.
     """
 
     expert_ids: Tuple[int, ...]
     gates: Tuple[float, ...]
     activation: np.ndarray
+    batch_id: Optional[int] = None
 
     def encode(self) -> bytes:
         if len(self.expert_ids) != len(self.gates):
             raise ValueError("expert_ids and gates must be the same length")
+        if self.batch_id is not None and not 0 <= self.batch_id < 1 << 64:
+            raise ValueError(f"batch_id {self.batch_id} is not a u64")
         activation = encode_vector(self.activation)
         out = [_U16.pack(len(self.expert_ids)),
                # The activation length is stated rather than inferred from
                # what is left in the buffer: a truncated tail is otherwise a
                # perfectly well-formed batch with a shorter hidden state, and
                # the node would happily compute a wrong answer from it.
-               _U32.pack(len(activation) // 4)]
+               _U32.pack(len(activation) // 4),
+               # Presence byte rather than a header flag: the payload then
+               # parses without reference to the header, so there is exactly
+               # one place that can be wrong about whether an id is present.
+               b"\x01" if self.batch_id is not None else b"\x00"]
+        if self.batch_id is not None:
+            out.append(_U64.pack(self.batch_id))
         for eid in self.expert_ids:
             out.append(_U16.pack(eid))
         out.append(np.asarray(self.gates, dtype="<f4").tobytes())
@@ -225,11 +273,23 @@ class ExpertBatchPayload:
         an unhandled exception is the difference between a logged incident and
         a dropped connection.
         """
-        if len(payload) < _U16.size + _U32.size:
+        if len(payload) < _U16.size + _U32.size + 1:
             raise ValueError("expert batch is too short to hold its counts")
         (count,) = _U16.unpack_from(payload, 0)
         (n_activation,) = _U32.unpack_from(payload, _U16.size)
         offset = _U16.size + _U32.size
+        has_id = payload[offset]
+        offset += 1
+        if has_id not in (0, 1):
+            raise ValueError(f"expert batch batch_id presence byte is "
+                             f"{has_id}, which is neither 0 nor 1")
+        batch_id: Optional[int] = None
+        if has_id:
+            if len(payload) < offset + _U64.size:
+                raise ValueError("expert batch claims a batch_id but is "
+                                 "truncated before it")
+            (batch_id,) = _U64.unpack_from(payload, offset)
+            offset += _U64.size
         needed = offset + count * (_U16.size + 4) + n_activation * 4
         if len(payload) != needed:
             raise ValueError(f"expert batch declares {count} experts and a "
@@ -246,7 +306,102 @@ class ExpertBatchPayload:
         offset += 4 * count
         activation = np.frombuffer(payload, dtype="<f4", count=n_activation,
                                    offset=offset)
-        return cls(tuple(ids), tuple(float(g) for g in gates), activation)
+        return cls(tuple(ids), tuple(float(g) for g in gates), activation,
+                   batch_id)
+
+
+@dataclass
+class ExpertRowsPayload:
+    """One weighted contribution per expert, each tagged with its expert id.
+
+    This is the default reply to an :class:`ExpertBatchPayload`, and the reason
+    the whole stack is reproducible. ``rows[i]`` is ``gate_i * expert_i(x)``
+    with no cross-expert addition performed anywhere on the node, so the
+    coordinator can add every expert of a layer in strict top-k order no matter
+    which console each one came from. Move an expert to a different console,
+    replan the fleet, lose a node to a replica — the arithmetic is unchanged,
+    because the additions never happened in a placement-dependent order in the
+    first place.
+
+    The cost is upstream bandwidth, and it is smaller than it looks: a shelf
+    wide enough to be worth building already scatters a token's top-k across
+    almost as many consoles as there are experts in it, so the sum a node would
+    have collapsed is usually one or two terms long. ``Flags.FAST`` buys those
+    back and gives up the guarantee.
+
+    Layout::
+
+        n_rows  : uint16
+        width   : uint32          elements per row, stated not inferred
+        experts : n_rows * uint16
+        rows    : n_rows * width * float32
+    """
+
+    expert_ids: Tuple[int, ...]
+    rows: np.ndarray                    # (n_rows, width) float32
+
+    def __post_init__(self) -> None:
+        rows = np.asarray(self.rows, dtype=np.float32)
+        if rows.ndim != 2:
+            raise ValueError(f"rows must be 2-D (n_rows, width), got shape "
+                             f"{rows.shape}")
+        if rows.shape[0] != len(self.expert_ids):
+            raise ValueError(f"{len(self.expert_ids)} expert ids against "
+                             f"{rows.shape[0]} rows")
+        self.rows = rows
+
+    def encode(self) -> bytes:
+        n_rows, width = self.rows.shape
+        out = [_U16.pack(n_rows), _U32.pack(width)]
+        for eid in self.expert_ids:
+            out.append(_U16.pack(eid))
+        out.append(np.ascontiguousarray(self.rows, dtype="<f4").tobytes())
+        return b"".join(out)
+
+    @classmethod
+    def decode(cls, payload: bytes) -> "ExpertRowsPayload":
+        if len(payload) < _U16.size + _U32.size:
+            raise ValueError("expert rows payload is too short to hold its "
+                             "counts")
+        (n_rows,) = _U16.unpack_from(payload, 0)
+        (width,) = _U32.unpack_from(payload, _U16.size)
+        offset = _U16.size + _U32.size
+        needed = offset + n_rows * _U16.size + n_rows * width * 4
+        if len(payload) != needed:
+            raise ValueError(f"expert rows payload declares {n_rows} rows of "
+                             f"width {width}, which needs {needed} bytes; got "
+                             f"{len(payload)}")
+        if n_rows == 0:
+            raise ValueError("expert rows payload carries no rows")
+        ids = []
+        for _ in range(n_rows):
+            (eid,) = _U16.unpack_from(payload, offset)
+            ids.append(eid)
+            offset += _U16.size
+        rows = np.frombuffer(payload, dtype="<f4", count=n_rows * width,
+                             offset=offset).reshape(n_rows, width)
+        return cls(tuple(ids), rows)
+
+
+def accumulate(rows: Sequence[np.ndarray]) -> np.ndarray:
+    """Add contributions left to right, in the order given.
+
+    The one place in the stack where a sum of expert outputs is formed. It is a
+    function rather than ``np.sum(rows, axis=0)`` because numpy sums pairwise:
+    that is more accurate, and it is *a different number*. Reproducibility here
+    means every summation — on a node collapsing a FAST batch, on the
+    coordinator reducing a layer, in a single-process reference run — folds in
+    exactly the same order, so a plan change cannot move a bit.
+
+    The caller is responsible for the order being the meaningful one (top-k
+    position, not arrival, and not unit id).
+    """
+    if not rows:
+        raise ValueError("nothing to accumulate")
+    total = np.array(rows[0], dtype=np.float32, copy=True)
+    for row in rows[1:]:
+        total += np.asarray(row, dtype=np.float32)
+    return total
 
 
 @dataclass

--- a/gen9-cluster/gen9_cluster/transport.py
+++ b/gen9-cluster/gen9_cluster/transport.py
@@ -1,0 +1,270 @@
+"""Persistent, multiplexed connections to console nodes.
+
+Three properties, each of which exists because of something the fleet does:
+
+**Persistent.** A token touches every shelf and every layer touches several
+consoles, so a forward pass makes hundreds of requests. Opening a TCP connection
+per request would add a handshake to each; at a quarter-millisecond RTT that is
+most of the time budget. Connections are opened once and kept.
+
+**Multiplexed.** Replies are matched to requests by ``request_id``, so the
+coordinator can have the whole shelf's requests in flight simultaneously and
+collect them as they land. A reader thread per connection owns the socket's read
+side; callers wait on their own event. This is the part that makes a wide shelf
+faster than a narrow one — without it, fan-out would serialise.
+
+**Nagle off.** Every message here is a small, complete, latency-critical unit.
+``TCP_NODELAY`` is not an optimisation in this design, it is a correctness
+requirement for the latency budget: with it left on, a 40 ms delayed-ACK
+interaction can dominate a forward pass.
+
+Failures are translated into :mod:`gen9_cluster.errors` types with the node's id
+attached, so a coordinator can decide about retries without inspecting socket
+errnos.
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .errors import (ConnectError, Gen9Error, ProtocolError, TimeoutError_)
+from .protocol import HEADER_SIZE, Frame, MsgType, decode_error
+
+#: How long to wait for a socket to connect.
+DEFAULT_CONNECT_TIMEOUT = 5.0
+#: How long to wait for a reply before giving up on it.
+DEFAULT_REQUEST_TIMEOUT = 30.0
+
+
+@dataclass
+class _Pending:
+    event: threading.Event = field(default_factory=threading.Event)
+    frame: Optional[Frame] = None
+    error: Optional[BaseException] = None
+
+
+class NodeConnection:
+    """One persistent connection to one console.
+
+    Thread-safe: any number of threads may call :meth:`request` concurrently,
+    which is exactly what a shelf coordinator does when it fans a token's top-k
+    out to the consoles holding those experts.
+    """
+
+    def __init__(self, unit_id: str, host: str, port: int, *,
+                 connect_timeout: float = DEFAULT_CONNECT_TIMEOUT):
+        self.host = host
+        self.port = port
+        self.unit_id = unit_id or f"{host}:{port}"
+        self.connect_timeout = connect_timeout
+        self._sock: Optional[socket.socket] = None
+        self._lock = threading.Lock()          # guards writes and _next_id
+        self._pending: Dict[int, _Pending] = {}
+        self._pending_lock = threading.Lock()
+        self._next_id = 1
+        self._reader: Optional[threading.Thread] = None
+        self._closed = False
+
+    # -- lifecycle --------------------------------------------------------
+    def connect(self) -> None:
+        if self._sock is not None:
+            return
+        try:
+            sock = socket.create_connection((self.host, self.port),
+                                            timeout=self.connect_timeout)
+        except OSError as exc:
+            raise ConnectError(f"cannot reach {self.host}:{self.port}: {exc}",
+                               unit_id=self.unit_id) from exc
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.settimeout(None)
+        self._sock = sock
+        self._closed = False
+        self._reader = threading.Thread(target=self._read_loop,
+                                        name=f"g9xc-{self.unit_id}",
+                                        daemon=True)
+        self._reader.start()
+
+    def close(self) -> None:
+        self._closed = True
+        sock, self._sock = self._sock, None
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            sock.close()
+        self._fail_all(ConnectError("connection closed", unit_id=self.unit_id))
+
+    def __enter__(self) -> "NodeConnection":
+        self.connect()
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    @property
+    def connected(self) -> bool:
+        return self._sock is not None and not self._closed
+
+    # -- request/response -------------------------------------------------
+    def request(self, frame: Frame, *,
+                timeout: float = DEFAULT_REQUEST_TIMEOUT) -> Frame:
+        """Send ``frame`` and wait for the reply carrying the same id."""
+        if self._sock is None:
+            self.connect()
+        pending = _Pending()
+        with self._lock:
+            request_id = self._next_request_id()
+            frame.request_id = request_id
+            with self._pending_lock:
+                self._pending[request_id] = pending
+            try:
+                self._sock.sendall(frame.encode())    # type: ignore[union-attr]
+            except OSError as exc:
+                with self._pending_lock:
+                    self._pending.pop(request_id, None)
+                self.close()
+                raise ConnectError(f"send failed: {exc}",
+                                   unit_id=self.unit_id) from exc
+
+        if not pending.event.wait(timeout):
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise TimeoutError_(
+                f"no reply to {frame.msg_type.name} within {timeout:g}s",
+                unit_id=self.unit_id, layer=frame.layer)
+        if pending.error is not None:
+            raise pending.error
+        assert pending.frame is not None
+        reply = pending.frame
+        if reply.msg_type is MsgType.ERROR:
+            raise Gen9Error(decode_error(reply.payload), unit_id=self.unit_id,
+                            layer=reply.layer)
+        return reply
+
+    def _next_request_id(self) -> int:
+        """Ids never repeat within a connection and never reach zero.
+
+        Zero is reserved for one-way messages, so a late reply to an abandoned
+        request can never be mistaken for one.
+        """
+        request_id = self._next_id
+        self._next_id = ((self._next_id + 1) & 0xFFFFFFFF) or 1
+        return request_id
+
+    def send_oneway(self, frame: Frame) -> None:
+        """Fire and forget: SHUTDOWN, and telemetry the sender does not read."""
+        if self._sock is None:
+            self.connect()
+        with self._lock:
+            frame.request_id = 0
+            try:
+                self._sock.sendall(frame.encode())    # type: ignore[union-attr]
+            except OSError as exc:
+                self.close()
+                raise ConnectError(f"send failed: {exc}",
+                                   unit_id=self.unit_id) from exc
+
+    # -- reader thread ----------------------------------------------------
+    def _read_loop(self) -> None:
+        sock = self._sock
+        try:
+            while sock is not None and not self._closed:
+                head = _recv_exactly(sock, HEADER_SIZE)
+                if head is None:
+                    raise ConnectError("node closed the connection",
+                                       unit_id=self.unit_id)
+                try:
+                    frame, length = Frame.decode_header(head)
+                except ValueError as exc:
+                    raise ProtocolError(str(exc), unit_id=self.unit_id) from exc
+                if length:
+                    body = _recv_exactly(sock, length)
+                    if body is None:
+                        raise ConnectError("truncated payload",
+                                           unit_id=self.unit_id)
+                    frame.payload = body
+                with self._pending_lock:
+                    pending = self._pending.pop(frame.request_id, None)
+                if pending is None:
+                    continue        # a reply to something we stopped waiting on
+                pending.frame = frame
+                pending.event.set()
+        except (ConnectError, ProtocolError) as exc:
+            self._fail_all(exc)
+        except OSError as exc:
+            if not self._closed and exc.errno not in (errno.EBADF,):
+                self._fail_all(ConnectError(f"read failed: {exc}",
+                                            unit_id=self.unit_id))
+            else:
+                self._fail_all(ConnectError("connection closed",
+                                            unit_id=self.unit_id))
+
+    def _fail_all(self, exc: BaseException) -> None:
+        with self._pending_lock:
+            pending, self._pending = self._pending, {}
+        for item in pending.values():
+            item.error = exc
+            item.event.set()
+
+
+def _recv_exactly(sock: socket.socket, count: int) -> Optional[bytes]:
+    """Read exactly ``count`` bytes, or None at a clean end of stream."""
+    chunks = []
+    remaining = count
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+class ConnectionPool:
+    """One connection per node, created on demand and reused.
+
+    A shelf coordinator holds one of these for its members. Reconnection is the
+    caller's decision, not the pool's: a node that dropped may have dropped for
+    a reason the coordinator wants to act on (drain it, fail its shards over)
+    rather than reconnect into a crash loop.
+    """
+
+    def __init__(self, *, connect_timeout: float = DEFAULT_CONNECT_TIMEOUT):
+        self._connections: Dict[str, NodeConnection] = {}
+        self._lock = threading.Lock()
+        self.connect_timeout = connect_timeout
+
+    def get(self, unit_id: str, host: str, port: int) -> NodeConnection:
+        with self._lock:
+            conn = self._connections.get(unit_id)
+            if conn is not None and conn.connected:
+                return conn
+            conn = NodeConnection(unit_id, host, port,
+                                  connect_timeout=self.connect_timeout)
+            self._connections[unit_id] = conn
+        conn.connect()
+        return conn
+
+    def drop(self, unit_id: str) -> None:
+        with self._lock:
+            conn = self._connections.pop(unit_id, None)
+        if conn is not None:
+            conn.close()
+
+    def close(self) -> None:
+        with self._lock:
+            connections = list(self._connections.values())
+            self._connections.clear()
+        for conn in connections:
+            conn.close()
+
+    def __enter__(self) -> "ConnectionPool":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/gen9-cluster/kernels/Makefile
+++ b/gen9-cluster/kernels/Makefile
@@ -1,0 +1,73 @@
+# Kernels for the gen9 cluster.
+#
+# The CPU path builds everywhere and is the only one the test suite requires.
+# The GPU paths build only where their toolchain exists, and their absence is a
+# supported configuration rather than a failure: a fleet may legitimately be all
+# CPU (4700S boards, Xbox Dev Mode, PS5 HEN).
+#
+#   make            CPU shared library (+ the self-test binary)
+#   make test       build and run the kernel self-test
+#   make vulkan     compile the compute shader to SPIR-V (needs glslangValidator)
+#   make hip        HIP library for gfx1013 (needs hipcc; see expert_hip.hip)
+#   make all-avail  everything whose toolchain is present
+
+CC      ?= cc
+CFLAGS  ?= -O3 -std=c11 -Wall -Wextra -fPIC
+LDFLAGS ?= -lm
+
+# -march=native is wrong here: the build host is usually not the console. Zen 2
+# is the common denominator across PS5, Series X/S and the salvage boards.
+ARCH_FLAGS ?= -march=znver2 -mtune=znver2
+FALLBACK_ARCH_FLAGS := -mavx2 -mfma
+
+OPENMP := $(shell $(CC) -fopenmp -E - </dev/null >/dev/null 2>&1 && echo -fopenmp)
+ARCH_OK := $(shell $(CC) $(ARCH_FLAGS) -E - </dev/null >/dev/null 2>&1 && echo yes)
+ifneq ($(ARCH_OK),yes)
+ARCH_FLAGS := $(FALLBACK_ARCH_FLAGS)
+endif
+
+LIB     := libgen9_cpu.so
+OBJS    := fp8.o expert_avx2.o
+SPV     := expert.comp.spv
+HIPLIB  := libgen9_hip.so
+
+GLSLC       := $(shell command -v glslangValidator 2>/dev/null)
+HIPCC       := $(shell command -v hipcc 2>/dev/null)
+
+.PHONY: all test vulkan hip all-avail clean
+
+all: $(LIB)
+
+%.o: %.c fp8.h
+	$(CC) $(CFLAGS) $(ARCH_FLAGS) $(OPENMP) -c $< -o $@
+
+$(LIB): $(OBJS)
+	$(CC) -shared $(OPENMP) $(OBJS) -o $@ $(LDFLAGS)
+
+kernel_test: kernel_test.c $(OBJS)
+	$(CC) $(CFLAGS) $(ARCH_FLAGS) $(OPENMP) $^ -o $@ $(LDFLAGS)
+
+test: kernel_test
+	./kernel_test
+
+vulkan: $(SPV)
+
+$(SPV): expert.comp
+ifeq ($(GLSLC),)
+	@echo "glslangValidator not found; skipping the Vulkan shader."
+	@echo "On Debian/Ubuntu: apt install glslang-tools"
+else
+	$(GLSLC) -V --target-env vulkan1.1 -S comp $< -o $@
+endif
+
+hip:
+ifeq ($(HIPCC),)
+	@echo "hipcc not found; skipping the HIP kernel (Vulkan is the default path)."
+else
+	$(HIPCC) -O3 --offload-arch=gfx1013 -fPIC -shared expert_hip.hip -o $(HIPLIB)
+endif
+
+all-avail: all vulkan hip
+
+clean:
+	rm -f $(OBJS) $(LIB) $(SPV) $(HIPLIB) kernel_test

--- a/gen9-cluster/kernels/expert.comp
+++ b/gen9-cluster/kernels/expert.comp
@@ -1,0 +1,89 @@
+#version 450
+/* Routed-expert GEMV as a Vulkan compute shader — the default GPU path.
+ *
+ * Why Vulkan and not HIP: a PS5 under ps5-linux and a BC-250 both present a
+ * GFX1013 amdgpu, and RADV drives that target well, while ROCm's userspace does
+ * not uniformly ship it. This shader needs nothing but core Vulkan 1.1 compute
+ * and shader-int8 arithmetic done by hand, so it runs on any RADV that comes up
+ * at all — no tuned library, no target-specific codegen, no build script that
+ * checks the gfx level and decides we are too old.
+ *
+ * The mapping: one workgroup per output row, 64 invocations per workgroup
+ * (RDNA2's wave size, so a workgroup is one wave and the subgroup reduction at
+ * the end is free of cross-wave synchronisation). Each invocation strides
+ * through the row, accumulating, then the wave reduces.
+ *
+ * FP8 E4M3 is decoded in the shader. Doing it here rather than pre-expanding to
+ * fp16 keeps the bytes crossing GDDR6 at one per weight, which is the entire
+ * reason a 16 GB console can hold a useful number of experts.
+ */
+
+layout(local_size_x = 64) in;
+
+layout(std430, binding = 0) readonly buffer Weights  { uint  packed[]; } W;
+layout(std430, binding = 1) readonly buffer Scales   { float scale[];  } S;
+layout(std430, binding = 2) readonly buffer Input    { float x[];      } X;
+layout(std430, binding = 3) writeonly buffer Output  { float y[];      } Y;
+
+layout(push_constant) uniform Params {
+    uint rows;
+    uint cols;          // multiple of 128
+    uint fp8;           // 0: weights are fp32 in `packed`; 1: FP8 E4M3 blocks
+    uint scales_per_row;
+} params;
+
+shared float partial[64];
+
+/* E4M3FN -> float. Bias 7, no infinities, 0x7F/0xFF are NaN (never stored). */
+float decode_e4m3(uint b)
+{
+    uint sign = (b >> 7) & 0x1u;
+    uint exp  = (b >> 3) & 0xFu;
+    uint mant = b & 0x7u;
+    float mag;
+    if (exp == 0u) {
+        mag = float(mant) * 0.125 * exp2(-6.0);      // subnormal
+    } else {
+        mag = (1.0 + float(mant) * 0.125) * exp2(float(exp) - 7.0);
+    }
+    return sign == 1u ? -mag : mag;
+}
+
+float weight_at(uint row, uint col)
+{
+    if (params.fp8 == 0u) {
+        return uintBitsToFloat(W.packed[row * params.cols + col]);
+    }
+    uint index = row * params.cols + col;
+    uint word = W.packed[index >> 2];
+    uint byte = (word >> (8u * (index & 3u))) & 0xFFu;
+    uint block = (row * params.scales_per_row) + (col >> 7);
+    return decode_e4m3(byte) * S.scale[block];
+}
+
+void main()
+{
+    uint row = gl_WorkGroupID.x;
+    if (row >= params.rows) {
+        return;
+    }
+    uint lane = gl_LocalInvocationID.x;
+
+    float sum = 0.0;
+    for (uint col = lane; col < params.cols; col += 64u) {
+        sum += weight_at(row, col) * X.x[col];
+    }
+
+    partial[lane] = sum;
+    barrier();
+    /* Tree reduction within the wave. */
+    for (uint stride = 32u; stride > 0u; stride >>= 1u) {
+        if (lane < stride) {
+            partial[lane] += partial[lane + stride];
+        }
+        barrier();
+    }
+    if (lane == 0u) {
+        Y.y[row] = partial[0];
+    }
+}

--- a/gen9-cluster/kernels/expert_avx2.c
+++ b/gen9-cluster/kernels/expert_avx2.c
@@ -1,0 +1,188 @@
+/* Zen 2 / AVX2 expert kernel: the CPU path every console shares.
+ *
+ * This is the fallback that always works — a PS5 under HEN, an Xbox in retail
+ * Dev Mode, a 4700S with no GPU at all — and on the salvage boards it is the
+ * *only* path, so it is written to be genuinely fast rather than merely
+ * present.
+ *
+ * What the shape of the problem dictates:
+ *
+ *   - Batch 1 decode means GEMV, not GEMM. Every weight is read once and used
+ *     once, so the kernel is memory-bound and the only thing that matters is
+ *     streaming weights at the memory's speed. Blocking, packing, and the rest
+ *     of the GEMM playbook buy nothing here.
+ *   - Zen 2 has AVX2 and two 256-bit FMA units but no AVX-512, and its
+ *     L2 is 512 KiB per core. Four independent accumulators keep both FMA
+ *     pipes fed across the 5-cycle latency; more than four gains nothing once
+ *     the loop is bandwidth-bound.
+ *   - FP8 weights are dequantised inline, 128 elements at a time, so the bytes
+ *     crossing the memory bus are one per weight rather than four. On a
+ *     bandwidth-bound kernel that is close to a 4x speedup, which is why the
+ *     checkpoint's native format is kept all the way down to the kernel.
+ *
+ * Threading is OpenMP over output rows when available; a console gives us 6-8
+ * cores and there is nothing else for them to do.
+ */
+
+#include "fp8.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* out[m] = sum_k w[m][k] * x[k], w row-major, fp32. */
+void gen9_gemv_f32(const float *w, const float *x, float *out, int rows,
+                   int cols)
+{
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int m = 0; m < rows; ++m) {
+        const float *row = w + (size_t)m * cols;
+#if defined(__AVX2__)
+        __m256 a0 = _mm256_setzero_ps();
+        __m256 a1 = _mm256_setzero_ps();
+        __m256 a2 = _mm256_setzero_ps();
+        __m256 a3 = _mm256_setzero_ps();
+        int k = 0;
+        for (; k + 31 < cols; k += 32) {
+            a0 = _mm256_fmadd_ps(_mm256_loadu_ps(row + k),
+                                 _mm256_loadu_ps(x + k), a0);
+            a1 = _mm256_fmadd_ps(_mm256_loadu_ps(row + k + 8),
+                                 _mm256_loadu_ps(x + k + 8), a1);
+            a2 = _mm256_fmadd_ps(_mm256_loadu_ps(row + k + 16),
+                                 _mm256_loadu_ps(x + k + 16), a2);
+            a3 = _mm256_fmadd_ps(_mm256_loadu_ps(row + k + 24),
+                                 _mm256_loadu_ps(x + k + 24), a3);
+        }
+        a0 = _mm256_add_ps(_mm256_add_ps(a0, a1), _mm256_add_ps(a2, a3));
+        __m128 lo = _mm256_castps256_ps128(a0);
+        __m128 hi = _mm256_extractf128_ps(a0, 1);
+        lo = _mm_add_ps(lo, hi);
+        lo = _mm_hadd_ps(lo, lo);
+        lo = _mm_hadd_ps(lo, lo);
+        float sum = _mm_cvtss_f32(lo);
+        for (; k < cols; ++k) {
+            sum += row[k] * x[k];
+        }
+#else
+        float sum = 0.0f;
+        for (int k = 0; k < cols; ++k) {
+            sum += row[k] * x[k];
+        }
+#endif
+        out[m] = sum;
+    }
+}
+
+/* Same, with FP8 blockwise weights dequantised inline.
+ *
+ * `scales` holds one fp32 per 128 weights, laid out row-major to match `w`, so
+ * row m's scales start at m * (cols / 128). Rows are padded to a whole number
+ * of blocks by the loader, which is why cols is required to be a multiple of
+ * GEN9_FP8_BLOCK here rather than handled with a tail. */
+void gen9_gemv_fp8(const uint8_t *w, const float *scales, const float *x,
+                   float *out, int rows, int cols)
+{
+    gen9_fp8_init();
+    const int blocks = cols / GEN9_FP8_BLOCK;
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (int m = 0; m < rows; ++m) {
+        const uint8_t *row = w + (size_t)m * cols;
+        const float *row_scales = scales + (size_t)m * blocks;
+        float sum = 0.0f;
+        for (int b = 0; b < blocks; ++b) {
+            const uint8_t *chunk = row + (size_t)b * GEN9_FP8_BLOCK;
+            const float *xv = x + (size_t)b * GEN9_FP8_BLOCK;
+            float block_sum = 0.0f;
+            /* The dequant table lookup defeats vectorised loads of the weights,
+             * so the inner loop is scalar over the byte stream and vectorised
+             * only in the accumulate. It remains bandwidth-bound: one byte per
+             * weight is a quarter of the traffic of the fp32 path. */
+            for (int i = 0; i < GEN9_FP8_BLOCK; ++i) {
+                block_sum += gen9_fp8_to_f32(chunk[i]) * xv[i];
+            }
+            sum += block_sum * row_scales[b];
+        }
+        out[m] = sum;
+    }
+}
+
+static void silu_mul(float *hidden, const float *other, int n)
+{
+    for (int i = 0; i < n; ++i) {
+        const float v = hidden[i];
+        hidden[i] = (v / (1.0f + expf(-v))) * other[i];
+    }
+}
+
+/* One DeepSeek routed expert, fp32: down @ (silu(gate @ x) * (up @ x)).
+ *
+ * `scratch` must hold at least 2 * intermediate floats; the caller owns it so
+ * a node running experts back to back does not malloc per token. */
+void gen9_expert_f32(const float *gate_w, const float *up_w,
+                     const float *down_w, const float *x, float *out,
+                     float *scratch, int hidden, int intermediate)
+{
+    float *g = scratch;
+    float *u = scratch + intermediate;
+    gen9_gemv_f32(gate_w, x, g, intermediate, hidden);
+    gen9_gemv_f32(up_w, x, u, intermediate, hidden);
+    silu_mul(g, u, intermediate);
+    gen9_gemv_f32(down_w, g, out, hidden, intermediate);
+}
+
+/* The same expert with FP8 blockwise weights. */
+void gen9_expert_fp8(const uint8_t *gate_w, const float *gate_s,
+                     const uint8_t *up_w, const float *up_s,
+                     const uint8_t *down_w, const float *down_s,
+                     const float *x, float *out, float *scratch, int hidden,
+                     int intermediate)
+{
+    float *g = scratch;
+    float *u = scratch + intermediate;
+    gen9_gemv_fp8(gate_w, gate_s, x, g, intermediate, hidden);
+    gen9_gemv_fp8(up_w, up_s, x, u, intermediate, hidden);
+    silu_mul(g, u, intermediate);
+    gen9_gemv_fp8(down_w, down_s, g, out, hidden, intermediate);
+}
+
+/* Accumulate `gate * expert(x)` for a batch of experts into `out`.
+ *
+ * Summing on the node is what keeps a layer at one reply per console instead of
+ * one per expert; see gen9_cluster.protocol.ExpertBatch. */
+void gen9_expert_batch_f32(const float *const *gate_w, const float *const *up_w,
+                           const float *const *down_w, const float *gates,
+                           int n_experts, const float *x, float *out,
+                           float *scratch, int hidden, int intermediate)
+{
+    float *partial = scratch + 2 * intermediate;
+    memset(out, 0, sizeof(float) * (size_t)hidden);
+    for (int e = 0; e < n_experts; ++e) {
+        gen9_expert_f32(gate_w[e], up_w[e], down_w[e], x, partial, scratch,
+                        hidden, intermediate);
+        const float g = gates[e];
+        for (int i = 0; i < hidden; ++i) {
+            out[i] += g * partial[i];
+        }
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/gen9-cluster/kernels/expert_hip.hip
+++ b/gen9-cluster/kernels/expert_hip.hip
@@ -1,0 +1,177 @@
+/* Optional HIP/ROCm expert kernel, for nodes with a working gfx1013 stack.
+ *
+ * READ THIS BEFORE ENABLING IT.
+ *
+ * ROCm on console silicon is real but partial. Debian's ROCm packages do build
+ * and run against gfx1013 (the PS5's Oberon GPU and the BC-250's Cyan
+ * Skillfish), and HIP itself — the compiler, the runtime, the kernel launch
+ * path this file uses — works. What does not uniformly work is the *library*
+ * layer above it: several ROCm libraries either omit gfx1013 from their target
+ * list entirely or fall back to a generic, much slower path, because their
+ * build scripts assume a capability level the target does not advertise. Tuned
+ * BLAS kernels are the usual casualty.
+ *
+ * This kernel is therefore written to depend on **nothing but HIP**. No
+ * rocBLAS, no hipBLASLt, no Tensile, no library whose gfx1013 support is a
+ * question. A GEMV is a hundred lines; a dependency that may silently
+ * decay to a generic path is not worth the twenty lines it would save.
+ *
+ * Consequently the planner never assumes a throughput number for a ROCm node.
+ * A node declares `backend: "rocm"` in the inventory *and* a
+ * `measured_gemv_gflops` from `g9-probe`, and the planner uses the measurement.
+ * A ROCm node with no measurement is planned as if it were Vulkan, which is the
+ * conservative direction to be wrong in.
+ *
+ * Build:
+ *     hipcc -O3 --offload-arch=gfx1013 -fPIC -shared expert_hip.hip \
+ *           -o libgen9_hip.so
+ *
+ * If hipcc rejects gfx1013, the installed ROCm predates its support and the
+ * Vulkan path is the answer on that node — that is a supported configuration,
+ * not a failure.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include <cstdint>
+#include <cstdio>
+
+#define GEN9_FP8_BLOCK 128
+#define GEN9_WAVE 32            /* RDNA wave32 */
+
+__device__ __forceinline__ float decode_e4m3(unsigned int b)
+{
+    const unsigned int sign = (b >> 7) & 0x1u;
+    const unsigned int exp = (b >> 3) & 0xFu;
+    const unsigned int mant = b & 0x7u;
+    float mag;
+    if (exp == 0u) {
+        mag = float(mant) * 0.125f * exp2f(-6.0f);
+    } else {
+        mag = (1.0f + float(mant) * 0.125f) * exp2f(float(exp) - 7.0f);
+    }
+    return sign ? -mag : mag;
+}
+
+/* One block per output row; the block reduces in shared memory.
+ *
+ * A row of a DeepSeek expert is `hidden` wide (7168 on V3, 8192 on the assumed
+ * V4-Pro profile), so a 256-thread block gives each thread ~32 weights: enough
+ * to keep the loads coalesced and short enough that the reduction is not the
+ * dominant cost. */
+template <int BLOCK>
+__global__ void gemv_fp8_kernel(const uint8_t *__restrict__ w,
+                                const float *__restrict__ scales,
+                                const float *__restrict__ x,
+                                float *__restrict__ y, int rows, int cols,
+                                int scales_per_row)
+{
+    __shared__ float partial[BLOCK];
+    const int row = blockIdx.x;
+    if (row >= rows) {
+        return;
+    }
+    const uint8_t *row_w = w + (size_t)row * cols;
+    const float *row_s = scales + (size_t)row * scales_per_row;
+
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += BLOCK) {
+        sum += decode_e4m3(row_w[col]) * row_s[col / GEN9_FP8_BLOCK] * x[col];
+    }
+    partial[threadIdx.x] = sum;
+    __syncthreads();
+
+    for (int stride = BLOCK / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            partial[threadIdx.x] += partial[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        y[row] = partial[0];
+    }
+}
+
+template <int BLOCK>
+__global__ void gemv_f32_kernel(const float *__restrict__ w,
+                                const float *__restrict__ x,
+                                float *__restrict__ y, int rows, int cols)
+{
+    __shared__ float partial[BLOCK];
+    const int row = blockIdx.x;
+    if (row >= rows) {
+        return;
+    }
+    const float *row_w = w + (size_t)row * cols;
+    float sum = 0.0f;
+    for (int col = threadIdx.x; col < cols; col += BLOCK) {
+        sum += row_w[col] * x[col];
+    }
+    partial[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = BLOCK / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            partial[threadIdx.x] += partial[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        y[row] = partial[0];
+    }
+}
+
+__global__ void silu_mul_kernel(float *__restrict__ gate,
+                                const float *__restrict__ up, int n)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        const float v = gate[i];
+        gate[i] = (v / (1.0f + __expf(-v))) * up[i];
+    }
+}
+
+extern "C" {
+
+hipError_t gen9_hip_gemv_f32(const float *w, const float *x, float *y,
+                             int rows, int cols, hipStream_t stream)
+{
+    hipLaunchKernelGGL((gemv_f32_kernel<256>), dim3(rows), dim3(256), 0, stream,
+                       w, x, y, rows, cols);
+    return hipGetLastError();
+}
+
+hipError_t gen9_hip_gemv_fp8(const uint8_t *w, const float *scales,
+                             const float *x, float *y, int rows, int cols,
+                             hipStream_t stream)
+{
+    const int scales_per_row = cols / GEN9_FP8_BLOCK;
+    hipLaunchKernelGGL((gemv_fp8_kernel<256>), dim3(rows), dim3(256), 0, stream,
+                       w, scales, x, y, rows, cols, scales_per_row);
+    return hipGetLastError();
+}
+
+hipError_t gen9_hip_silu_mul(float *gate, const float *up, int n,
+                             hipStream_t stream)
+{
+    const int threads = 256;
+    const int blocks = (n + threads - 1) / threads;
+    hipLaunchKernelGGL(silu_mul_kernel, dim3(blocks), dim3(threads), 0, stream,
+                       gate, up, n);
+    return hipGetLastError();
+}
+
+/* Reports what the runtime actually found, so `g9-probe` can record the gfx
+ * target rather than trusting the inventory file's claim about it. */
+hipError_t gen9_hip_target(char *out, int len)
+{
+    hipDeviceProp_t props;
+    const hipError_t err = hipGetDeviceProperties(&props, 0);
+    if (err != hipSuccess) {
+        return err;
+    }
+    snprintf(out, len, "%s cu=%d clock=%dMHz", props.gcnArchName,
+             props.multiProcessorCount, props.clockRate / 1000);
+    return hipSuccess;
+}
+
+}  /* extern "C" */

--- a/gen9-cluster/kernels/fp8.c
+++ b/gen9-cluster/kernels/fp8.c
@@ -1,0 +1,97 @@
+#include "fp8.h"
+
+#include <math.h>
+#include <string.h>
+
+static float g_table[256];
+static int g_ready = 0;
+
+/* Decode one E4M3FN byte the slow, obvious way. Called 256 times, ever. */
+static float decode_e4m3(uint8_t v)
+{
+    const int sign = (v >> 7) & 0x1;
+    const int exp = (v >> 3) & 0xF;
+    const int mant = v & 0x7;
+    float mag;
+
+    if (exp == 0) {
+        /* Subnormal: no implicit leading 1, exponent fixed at 1 - bias. */
+        mag = (float)mant * 0.125f * ldexpf(1.0f, -6);
+    } else if (exp == 0xF && mant == 0x7) {
+        /* E4M3FN has no infinity; 0x7F/0xFF are the only NaNs. */
+        return NAN;
+    } else {
+        mag = (1.0f + (float)mant * 0.125f) * ldexpf(1.0f, exp - 7);
+    }
+    return sign ? -mag : mag;
+}
+
+void gen9_fp8_init(void)
+{
+    if (g_ready) {
+        return;
+    }
+    for (int i = 0; i < 256; ++i) {
+        g_table[i] = decode_e4m3((uint8_t)i);
+    }
+    g_ready = 1;
+}
+
+float gen9_fp8_to_f32(uint8_t v)
+{
+    gen9_fp8_init();
+    return g_table[v];
+}
+
+void gen9_fp8_dequant(const uint8_t *src, const float *scales, float *out,
+                      size_t n)
+{
+    gen9_fp8_init();
+    for (size_t base = 0; base < n; base += GEN9_FP8_BLOCK) {
+        const float scale = scales[base / GEN9_FP8_BLOCK];
+        const size_t end = (base + GEN9_FP8_BLOCK < n) ? base + GEN9_FP8_BLOCK
+                                                       : n;
+        for (size_t i = base; i < end; ++i) {
+            out[i] = g_table[src[i]] * scale;
+        }
+    }
+}
+
+uint8_t gen9_f32_to_fp8(float v)
+{
+    if (isnan(v)) {
+        return 0x7F;
+    }
+    const int sign = signbit(v) ? 0x80 : 0x00;
+    float mag = fabsf(v);
+
+    if (mag > 448.0f) {
+        return (uint8_t)(sign | 0x7E);          /* saturate at max normal */
+    }
+    if (mag < ldexpf(1.0f, -9) * 0.5f) {
+        return (uint8_t)sign;                   /* flush to zero */
+    }
+    if (mag < ldexpf(1.0f, -6)) {
+        /* Subnormal: quantise to the 1/8 grid at 2^-6. */
+        int mant = (int)lrintf(mag / (0.125f * ldexpf(1.0f, -6)));
+        if (mant > 7) {
+            mant = 7;
+        }
+        return (uint8_t)(sign | mant);
+    }
+    int exp;
+    const float frac = frexpf(mag, &exp);       /* mag = frac * 2^exp, .5<=frac<1 */
+    int e = exp - 1 + 7;                        /* unbiased -> biased */
+    int mant = (int)lrintf((frac * 2.0f - 1.0f) * 8.0f);
+    if (mant == 8) {
+        mant = 0;
+        e += 1;
+    }
+    if (e >= 0xF && mant >= 0x7) {
+        return (uint8_t)(sign | 0x7E);
+    }
+    if (e > 0xF) {
+        return (uint8_t)(sign | 0x7E);
+    }
+    return (uint8_t)(sign | (e << 3) | mant);
+}

--- a/gen9-cluster/kernels/fp8.h
+++ b/gen9-cluster/kernels/fp8.h
@@ -1,0 +1,55 @@
+/* FP8 E4M3 with 128-element block scales — the format DeepSeek ships.
+ *
+ * A block of 128 weights shares one fp32 scale, so a weight is one byte and the
+ * overhead is 4 bytes per 128, about 3%. Dequantisation is therefore a byte
+ * load, a table lookup or bit shuffle, and a multiply — cheap enough to do
+ * inside the GEMV loop, which is the whole point: the weights stay FP8 in
+ * memory, and memory is what a console is short of.
+ *
+ * E4M3 layout (OCP / NVIDIA "E4M3FN" variant, which is what DeepSeek's
+ * checkpoints use):
+ *
+ *     s eeee mmm     bias 7, no infinities, 0xFF/0x7F are NaN
+ *     max normal     448.0     (0x7E / 0xFE)
+ *     min normal     2^-6      (0x08)
+ *     min subnormal  2^-9      (0x01)
+ *
+ * The conversion here is a 256-entry table built once at startup. A branchless
+ * bit-twiddle version is possible and marginally faster on paper, but on Zen 2
+ * the table lives in L1 and the loop is bound by the weight stream from GDDR6,
+ * not by the conversion.
+ */
+
+#ifndef GEN9_FP8_H
+#define GEN9_FP8_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Elements sharing one scale. Fixed by the checkpoint format, not a tunable. */
+#define GEN9_FP8_BLOCK 128
+
+/* Build the 256-entry E4M3 -> fp32 table. Idempotent and thread-safe to call
+ * more than once before any conversion begins. */
+void gen9_fp8_init(void);
+
+/* One value, for tests and for code that is not in a loop. */
+float gen9_fp8_to_f32(uint8_t v);
+
+/* Dequantise `n` FP8 values into `out`, applying one scale per 128 elements.
+ * `scales` must hold ceil(n / GEN9_FP8_BLOCK) entries. */
+void gen9_fp8_dequant(const uint8_t *src, const float *scales, float *out,
+                      size_t n);
+
+/* Round-trip helper used by the tests to build fixtures; saturates at 448. */
+uint8_t gen9_f32_to_fp8(float v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEN9_FP8_H */

--- a/gen9-cluster/kernels/kernel_test.c
+++ b/gen9-cluster/kernels/kernel_test.c
@@ -1,0 +1,256 @@
+/* Self-test for the CPU kernels: correctness first, then a throughput figure.
+ *
+ * The throughput number printed here is what `g9-probe` records as a node's
+ * measured GEMV rate, and it is the number the planner should be given for any
+ * node whose backend it cannot predict — every ROCm node, and any console with
+ * an unusual downbin.
+ */
+
+#include "fp8.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+void gen9_gemv_f32(const float *w, const float *x, float *out, int rows,
+                   int cols);
+void gen9_gemv_fp8(const uint8_t *w, const float *scales, const float *x,
+                   float *out, int rows, int cols);
+void gen9_expert_f32(const float *gate_w, const float *up_w,
+                     const float *down_w, const float *x, float *out,
+                     float *scratch, int hidden, int intermediate);
+
+static int failures = 0;
+
+static void check(const char *what, int ok)
+{
+    printf("%-46s %s\n", what, ok ? "ok" : "FAILED");
+    if (!ok) {
+        failures++;
+    }
+}
+
+static double now_seconds(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+static void test_fp8_roundtrip(void)
+{
+    /* Exactly representable E4M3 values must survive a round trip. */
+    const float exact[] = {0.0f, 1.0f, -1.0f, 2.0f, 0.5f, 1.25f, 448.0f,
+                           -448.0f, 0.015625f};
+    int ok = 1;
+    for (size_t i = 0; i < sizeof(exact) / sizeof(exact[0]); ++i) {
+        const float back = gen9_fp8_to_f32(gen9_f32_to_fp8(exact[i]));
+        if (fabsf(back - exact[i]) > 1e-6f * fmaxf(1.0f, fabsf(exact[i]))) {
+            printf("  %g -> %g\n", (double)exact[i], (double)back);
+            ok = 0;
+        }
+    }
+    check("fp8 e4m3 round-trips exact values", ok);
+
+    /* Saturation, not overflow to NaN or infinity. */
+    check("fp8 saturates above the max normal",
+          fabsf(gen9_fp8_to_f32(gen9_f32_to_fp8(1e6f)) - 448.0f) < 1e-3f);
+
+    /* Relative error inside the normal range stays within the format's 3-bit
+     * mantissa: 2^-4 = 6.25% worst case, half that typical. */
+    float worst = 0.0f;
+    for (float v = 0.02f; v < 400.0f; v *= 1.037f) {
+        const float back = gen9_fp8_to_f32(gen9_f32_to_fp8(v));
+        const float rel = fabsf(back - v) / v;
+        if (rel > worst) {
+            worst = rel;
+        }
+    }
+    printf("  worst relative error over the normal range: %.4f\n",
+           (double)worst);
+    check("fp8 relative error within the format's bound", worst <= 0.0626f);
+}
+
+static void test_gemv(void)
+{
+    const int rows = 64;
+    const int cols = 256;
+    float *w = malloc(sizeof(float) * rows * cols);
+    float *x = malloc(sizeof(float) * cols);
+    float *y = malloc(sizeof(float) * rows);
+    float *ref = malloc(sizeof(float) * rows);
+
+    for (int i = 0; i < rows * cols; ++i) {
+        w[i] = (float)((i * 37 % 101) - 50) / 50.0f;
+    }
+    for (int i = 0; i < cols; ++i) {
+        x[i] = (float)((i * 17 % 61) - 30) / 30.0f;
+    }
+    for (int m = 0; m < rows; ++m) {
+        double sum = 0.0;
+        for (int k = 0; k < cols; ++k) {
+            sum += (double)w[m * cols + k] * (double)x[k];
+        }
+        ref[m] = (float)sum;
+    }
+
+    gen9_gemv_f32(w, x, y, rows, cols);
+    int ok = 1;
+    for (int m = 0; m < rows; ++m) {
+        if (fabsf(y[m] - ref[m]) > 1e-3f * fmaxf(1.0f, fabsf(ref[m]))) {
+            ok = 0;
+        }
+    }
+    check("gemv fp32 matches a scalar reference", ok);
+
+    /* FP8: the same GEMV within the quantisation error the format allows. */
+    uint8_t *wq = malloc((size_t)rows * cols);
+    float *scales = malloc(sizeof(float) * rows * (cols / GEN9_FP8_BLOCK));
+    for (int m = 0; m < rows; ++m) {
+        for (int b = 0; b < cols / GEN9_FP8_BLOCK; ++b) {
+            float peak = 0.0f;
+            for (int i = 0; i < GEN9_FP8_BLOCK; ++i) {
+                const float v = fabsf(w[m * cols + b * GEN9_FP8_BLOCK + i]);
+                if (v > peak) {
+                    peak = v;
+                }
+            }
+            const float scale = peak > 0.0f ? peak / 448.0f : 1.0f;
+            scales[m * (cols / GEN9_FP8_BLOCK) + b] = scale;
+            for (int i = 0; i < GEN9_FP8_BLOCK; ++i) {
+                const int index = m * cols + b * GEN9_FP8_BLOCK + i;
+                wq[index] = gen9_f32_to_fp8(w[index] / scale);
+            }
+        }
+    }
+    gen9_gemv_fp8(wq, scales, x, y, rows, cols);
+
+    /* Two separate questions, which a single comparison against the fp32
+     * reference would conflate.
+     *
+     * First: does the kernel compute the right thing *given* the quantised
+     * weights? That is exact arithmetic and is checked tightly, against a
+     * scalar dot product over the dequantised values. */
+    float *dequant = malloc(sizeof(float) * (size_t)rows * cols);
+    for (int m = 0; m < rows; ++m) {
+        gen9_fp8_dequant(wq + (size_t)m * cols,
+                         scales + (size_t)m * (cols / GEN9_FP8_BLOCK),
+                         dequant + (size_t)m * cols, (size_t)cols);
+    }
+    int exact_ok = 1;
+    for (int m = 0; m < rows; ++m) {
+        double sum = 0.0;
+        for (int k = 0; k < cols; ++k) {
+            sum += (double)dequant[m * cols + k] * (double)x[k];
+        }
+        if (fabs((double)y[m] - sum) > 1e-3 * fmax(1.0, fabs(sum))) {
+            exact_ok = 0;
+        }
+    }
+    check("gemv fp8 matches its own dequantised weights", exact_ok);
+
+    /* Second: how much did quantisation itself cost? Measured against the
+     * magnitude of the terms being summed, not against the dot product, which
+     * is near-zero under cancellation and would make a 3% weight error look
+     * like a 30% one. */
+    double worst = 0.0;
+    for (int m = 0; m < rows; ++m) {
+        double magnitude = 0.0;
+        for (int k = 0; k < cols; ++k) {
+            magnitude += fabs((double)w[m * cols + k]) * fabs((double)x[k]);
+        }
+        const double err = fabs((double)y[m] - (double)ref[m])
+                           / fmax(1e-9, magnitude);
+        if (err > worst) {
+            worst = err;
+        }
+    }
+    printf("  fp8 quantisation error, relative to term magnitude: %.4f\n",
+           worst);
+    check("fp8 blockwise quantisation stays under 2% of magnitude",
+          worst < 0.02);
+
+    free(dequant);
+    free(w);
+    free(x);
+    free(y);
+    free(ref);
+    free(wq);
+    free(scales);
+}
+
+static void test_expert_and_throughput(void)
+{
+    /* DeepSeek's expert shape, at V3/V4-Pro width. */
+    const int hidden = 7168;
+    const int intermediate = 2048;
+    float *gate = malloc(sizeof(float) * (size_t)intermediate * hidden);
+    float *up = malloc(sizeof(float) * (size_t)intermediate * hidden);
+    float *down = malloc(sizeof(float) * (size_t)hidden * intermediate);
+    float *x = malloc(sizeof(float) * hidden);
+    float *out = malloc(sizeof(float) * hidden);
+    float *scratch = malloc(sizeof(float) * 2 * intermediate);
+
+    if (!gate || !up || !down || !x || !out || !scratch) {
+        printf("not enough memory for the expert benchmark; skipping\n");
+        free(gate); free(up); free(down); free(x); free(out); free(scratch);
+        return;
+    }
+    for (size_t i = 0; i < (size_t)intermediate * hidden; ++i) {
+        gate[i] = 0.001f * (float)(i % 7);
+        up[i] = 0.001f * (float)(i % 5);
+    }
+    for (size_t i = 0; i < (size_t)hidden * intermediate; ++i) {
+        down[i] = 0.001f * (float)(i % 3);
+    }
+    for (int i = 0; i < hidden; ++i) {
+        x[i] = 0.01f * (float)(i % 11);
+    }
+
+    gen9_expert_f32(gate, up, down, x, out, scratch, hidden, intermediate);
+    int finite = 1;
+    for (int i = 0; i < hidden; ++i) {
+        if (!isfinite(out[i])) {
+            finite = 0;
+        }
+    }
+    check("expert fp32 produces finite output", finite);
+
+    const int iterations = 3;
+    const double started = now_seconds();
+    for (int i = 0; i < iterations; ++i) {
+        gen9_expert_f32(gate, up, down, x, out, scratch, hidden, intermediate);
+    }
+    const double elapsed = now_seconds() - started;
+    /* Three GEMVs, two multiply-accumulates each. */
+    const double flops = 2.0 * 3.0 * (double)hidden * intermediate * iterations;
+    const double bytes = 3.0 * (double)hidden * intermediate * 4.0 * iterations;
+    printf("\nmeasured on this host (fp32 weights):\n");
+    printf("  %.1f GFLOP/s, %.1f GB/s effective, %.2f ms per expert\n",
+           flops / elapsed / 1e9, bytes / elapsed / 1e9,
+           elapsed / iterations * 1e3);
+    printf("  (this is the figure g9-probe records as measured_gemv_gflops)\n");
+
+    free(gate);
+    free(up);
+    free(down);
+    free(x);
+    free(out);
+    free(scratch);
+}
+
+int main(void)
+{
+    gen9_fp8_init();
+    test_fp8_roundtrip();
+    test_gemv();
+    test_expert_and_throughput();
+    if (failures) {
+        printf("\n%d check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("\nall kernel checks passed\n");
+    return 0;
+}

--- a/gen9-cluster/tests/test_backends.py
+++ b/gen9-cluster/tests/test_backends.py
@@ -1,0 +1,106 @@
+"""The compiled kernel, where it exists, must agree with the reference.
+
+If ``libgen9_cpu.so`` has not been built on this machine the kernel tests are
+skipped rather than faked: a green run that silently tested numpy against numpy
+would be worse than no run at all.
+"""
+
+import unittest
+
+import numpy as np
+
+from gen9_cluster.backends import (CpuKernelRunner, describe_backends,
+                                   select_runner)
+from gen9_cluster.node import ExpertRunner, ExpertWeights
+
+HIDDEN = 64
+INTERMEDIATE = 32
+
+
+def make_expert(seed):
+    rng = np.random.default_rng(seed)
+    return ExpertWeights(
+        gate=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32)
+        * 0.1,
+        up=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32) * 0.1,
+        down=rng.standard_normal((HIDDEN, INTERMEDIATE), dtype=np.float32)
+        * 0.1)
+
+
+def cpu_kernel_or_skip():
+    try:
+        return CpuKernelRunner()
+    except (FileNotFoundError, OSError) as exc:
+        raise unittest.SkipTest(f"CPU kernel not built here: {exc}")
+
+
+class TestCpuKernel(unittest.TestCase):
+    def setUp(self):
+        self.kernel = cpu_kernel_or_skip()
+        self.reference = ExpertRunner()
+
+    def test_it_agrees_with_the_reference_runner(self):
+        """The AVX2 kernel and the numpy path must produce the same token; the
+        fleet mixes consoles running either one."""
+        experts = [make_expert(i) for i in range(4)]
+        gates = [0.4, 0.3, 0.2, 0.1]
+        x = np.linspace(-1.5, 1.5, HIDDEN, dtype=np.float32)
+        np.testing.assert_allclose(self.kernel(x, experts, gates),
+                                   self.reference(x, experts, gates),
+                                   rtol=1e-4, atol=1e-5)
+
+    def test_a_single_expert_matches_the_silu_gate_definition(self):
+        expert = make_expert(11)
+        x = np.linspace(-1, 1, HIDDEN, dtype=np.float32)
+        hidden = x @ expert.gate.T
+        hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))
+        expected = (hidden * (x @ expert.up.T)) @ expert.down.T
+        np.testing.assert_allclose(self.kernel(x, [expert], [1.0]), expected,
+                                   rtol=1e-4, atol=1e-5)
+
+    def test_an_empty_batch_is_a_zero_vector(self):
+        out = self.kernel(np.ones(HIDDEN, dtype=np.float32), [], [])
+        np.testing.assert_array_equal(out, np.zeros(HIDDEN, dtype=np.float32))
+
+    def test_non_contiguous_input_is_handled(self):
+        """Activations arriving as a slice of a larger buffer must not be
+        handed to the kernel as a stale or strided pointer."""
+        expert = make_expert(3)
+        buffer = np.zeros(HIDDEN * 2, dtype=np.float32)
+        buffer[::2] = np.linspace(-1, 1, HIDDEN, dtype=np.float32)
+        strided = buffer[::2]
+        self.assertFalse(strided.flags["C_CONTIGUOUS"])
+        np.testing.assert_allclose(self.kernel(strided, [expert], [1.0]),
+                                   self.reference(strided, [expert], [1.0]),
+                                   rtol=1e-4, atol=1e-5)
+
+    def test_repeated_calls_do_not_accumulate(self):
+        """The scratch buffer is reused between calls; if it is not cleared the
+        second token of a conversation is wrong."""
+        expert = make_expert(5)
+        x = np.ones(HIDDEN, dtype=np.float32)
+        first = self.kernel(x, [expert], [1.0]).copy()
+        for _ in range(4):
+            np.testing.assert_allclose(self.kernel(x, [expert], [1.0]), first,
+                                       rtol=0, atol=0)
+
+
+class TestSelection(unittest.TestCase):
+    def test_a_runner_is_always_available(self):
+        """A console with no kernel built must still serve, slowly, rather than
+        refuse to start."""
+        self.assertTrue(callable(select_runner()))
+
+    def test_an_unavailable_gpu_backend_falls_back_visibly(self):
+        runner = select_runner("vulkan")
+        self.assertIn(runner.name, {"cpu-avx2", "numpy"})
+
+    def test_probe_reports_each_backend(self):
+        text = "\n".join(describe_backends())
+        for expected in ("cpu kernel", "vulkan shader", "hip kernel",
+                         "rocminfo"):
+            self.assertIn(expected, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_dedup.py
+++ b/gen9-cluster/tests/test_dedup.py
@@ -1,0 +1,262 @@
+"""The dedup cache: a retried batch runs once, and the state stays bounded.
+
+The concurrency tests here use real threads rather than a fake clock, because
+the case that matters — a coordinator retrying while the first attempt is still
+on the console's GPU — is a race, and a test that cannot lose the race cannot
+show that the cache wins it.
+"""
+
+import threading
+import time
+import unittest
+
+import numpy as np
+
+from gen9_cluster.dedup import (DedupCache, DedupCapacityError,
+                                MismatchedBatchError, batch_fingerprint)
+
+FP_A = b"a" * 32
+FP_B = b"b" * 32
+
+
+class TestSingleExecution(unittest.TestCase):
+    def test_a_repeated_batch_id_runs_once(self):
+        cache = DedupCache()
+        calls = []
+
+        def compute():
+            calls.append(1)
+            return b"reply"
+
+        first, replayed = cache.run(7, FP_A, compute)
+        second, again = cache.run(7, FP_A, compute)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(first, second)
+        self.assertFalse(replayed)
+        self.assertTrue(again)
+        self.assertEqual((cache.hits, cache.misses), (1, 1))
+
+    def test_no_batch_id_means_no_deduplication(self):
+        """An unnamed batch has nothing to match on, and must not be matched
+        against some other unnamed batch."""
+        cache = DedupCache()
+        calls = []
+        for _ in range(3):
+            cache.run(None, FP_A, lambda: (calls.append(1), b"x")[1])
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(len(cache), 0)
+
+    def test_a_reused_id_with_different_content_is_refused(self):
+        """Answering this from cache would be a wrong activation's output
+        returned as if it were this one's."""
+        cache = DedupCache()
+        cache.run(7, FP_A, lambda: b"reply")
+        with self.assertRaises(MismatchedBatchError):
+            cache.run(7, FP_B, lambda: b"other")
+
+    def test_a_failed_batch_is_not_cached_as_an_answer(self):
+        cache = DedupCache()
+        with self.assertRaises(ZeroDivisionError):
+            cache.run(7, FP_A, lambda: 1 // 0)
+        self.assertIsNone(cache.replay(7))
+        # And the id is free to be retried properly.
+        reply, replayed = cache.run(7, FP_A, lambda: b"second time")
+        self.assertEqual(reply, b"second time")
+        self.assertFalse(replayed)
+
+    def test_fast_and_exact_are_not_the_same_batch(self):
+        """Same experts, same activation, different arithmetic and different
+        reply shape: a FAST retry must not be served an exact reply."""
+        x = np.arange(8, dtype=np.float32)
+        exact = batch_fingerprint(3, [1, 2], [0.5, 0.5], x, False)
+        fast = batch_fingerprint(3, [1, 2], [0.5, 0.5], x, True)
+        self.assertNotEqual(exact, fast)
+
+    def test_the_fingerprint_covers_everything_that_changes_the_answer(self):
+        x = np.arange(8, dtype=np.float32)
+        base = batch_fingerprint(3, [1, 2], [0.5, 0.5], x, False)
+        self.assertNotEqual(base, batch_fingerprint(4, [1, 2], [0.5, 0.5], x,
+                                                    False))
+        self.assertNotEqual(base, batch_fingerprint(3, [1, 9], [0.5, 0.5], x,
+                                                    False))
+        self.assertNotEqual(base, batch_fingerprint(3, [1, 2], [0.6, 0.4], x,
+                                                    False))
+        self.assertNotEqual(base, batch_fingerprint(3, [1, 2], [0.5, 0.5],
+                                                    x + 1, False))
+        self.assertEqual(base, batch_fingerprint(3, [1, 2], [0.5, 0.5],
+                                                 x.copy(), False))
+
+
+class TestConcurrentRetries(unittest.TestCase):
+    def test_a_retry_waits_for_the_attempt_already_running(self):
+        """The expensive case: a coordinator whose timeout fired early. The
+        console must not start a second pass over the same weights."""
+        cache = DedupCache()
+        started = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def compute():
+            calls.append(1)
+            started.set()
+            release.wait(5.0)
+            return b"reply"
+
+        results = {}
+
+        def attempt(name):
+            results[name] = cache.run(7, FP_A, compute)
+
+        first = threading.Thread(target=attempt, args=("first",))
+        first.start()
+        self.assertTrue(started.wait(5.0))
+
+        second = threading.Thread(target=attempt, args=("second",))
+        second.start()
+        time.sleep(0.05)                # long enough to have raced, if it did
+        self.assertEqual(len(calls), 1)
+
+        release.set()
+        first.join(5.0)
+        second.join(5.0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(results["first"], (b"reply", False))
+        self.assertEqual(results["second"], (b"reply", True))
+
+    def test_waiting_on_one_batch_does_not_stall_the_others(self):
+        """A node runs several batches at once. If a waiter held the cache
+        lock, one slow expert would serialise the whole console."""
+        cache = DedupCache()
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow():
+            started.set()
+            release.wait(30.0)
+            return b"slow"
+
+        blocked = threading.Thread(target=lambda: cache.run(1, FP_A, slow))
+        blocked.start()
+        self.assertTrue(started.wait(5.0))
+        waiter = threading.Thread(target=lambda: cache.run(1, FP_A, slow))
+        waiter.start()
+
+        done = threading.Event()
+
+        def unrelated():
+            cache.run(2, FP_B, lambda: b"quick")
+            done.set()
+
+        threading.Thread(target=unrelated).start()
+        # Short, and unrelated to the slow batch's own timeout: the point is
+        # that this must not wait on it at all.
+        self.assertTrue(done.wait(2.0), "an unrelated batch was blocked")
+
+        release.set()
+        blocked.join(5.0)
+        waiter.join(5.0)
+
+    def test_a_waiter_sees_the_failure_rather_than_hanging(self):
+        cache = DedupCache()
+        started = threading.Event()
+        release = threading.Event()
+
+        def compute():
+            started.set()
+            release.wait(5.0)
+            raise ValueError("the shard is missing")
+
+        errors = []
+
+        def attempt():
+            try:
+                cache.run(7, FP_A, compute)
+            except BaseException as exc:        # noqa: BLE001
+                errors.append(exc)
+
+        first = threading.Thread(target=attempt)
+        first.start()
+        self.assertTrue(started.wait(5.0))
+        second = threading.Thread(target=attempt)
+        second.start()
+        release.set()
+        first.join(5.0)
+        second.join(5.0)
+
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(all(isinstance(e, ValueError) for e in errors))
+
+
+class TestBounds(unittest.TestCase):
+    def test_entries_are_capped_and_the_oldest_completed_goes_first(self):
+        cache = DedupCache(max_entries=3)
+        for batch in range(5):
+            cache.run(batch, FP_A, lambda: b"x")
+        self.assertEqual(len(cache), 3)
+        self.assertIsNone(cache.replay(0))
+        self.assertIsNotNone(cache.replay(4))
+        self.assertEqual(cache.evictions, 2)
+
+    def test_in_flight_batches_are_never_evicted(self):
+        """Evicting a running batch would leave its waiters orphaned and let a
+        second attempt start, which is the whole thing this prevents."""
+        cache = DedupCache(max_entries=1)
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow():
+            started.set()
+            release.wait(5.0)
+            return b"slow"
+
+        worker = threading.Thread(target=lambda: cache.run(1, FP_A, slow))
+        worker.start()
+        self.assertTrue(started.wait(5.0))
+
+        with self.assertRaises(DedupCapacityError):
+            cache.run(2, FP_B, lambda: b"fast")
+        self.assertEqual(cache.rejected, 1)
+
+        release.set()
+        worker.join(5.0)
+        self.assertEqual(cache.replay(1), b"slow")
+
+    def test_the_byte_budget_is_enforced(self):
+        cache = DedupCache(max_entries=100, max_bytes=300)
+        for batch in range(4):
+            cache.run(batch, FP_A, lambda: b"x" * 100)
+        self.assertLessEqual(cache.bytes_used, 300)
+        self.assertIsNone(cache.replay(0))
+        self.assertIsNotNone(cache.replay(3))
+
+    def test_a_reply_too_large_to_cache_is_returned_but_not_kept(self):
+        cache = DedupCache(max_bytes=10)
+        reply, replayed = cache.run(1, FP_A, lambda: b"x" * 100)
+        self.assertEqual(len(reply), 100)
+        self.assertFalse(replayed)
+        self.assertIsNone(cache.replay(1))
+        self.assertEqual(cache.oversized, 1)
+        self.assertEqual(cache.bytes_used, 0)
+
+    def test_a_reply_older_than_the_ttl_is_dropped(self):
+        cache = DedupCache(ttl=0.05)
+        cache.run(1, FP_A, lambda: b"x")
+        time.sleep(0.1)
+        calls = []
+        _, replayed = cache.run(1, FP_A, lambda: (calls.append(1), b"x")[1])
+        self.assertFalse(replayed, "an expired reply was replayed")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(cache.expiries, 1)
+
+    def test_the_byte_count_does_not_drift(self):
+        cache = DedupCache(max_entries=4, max_bytes=1000)
+        for batch in range(12):
+            cache.run(batch, FP_A, lambda: b"x" * 50)
+        self.assertEqual(cache.bytes_used, 4 * 50)
+        cache.clear()
+        self.assertEqual(cache.bytes_used, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_dispatch.py
+++ b/gen9-cluster/tests/test_dispatch.py
@@ -1,0 +1,290 @@
+"""Expert fan-out, reduction, failover, and a whole fleet end to end.
+
+Everything here runs against real node servers on loopback, because the
+properties being checked — that a token's experts are grouped into one request
+per console, that the reduction is order-independent, that a dead console is
+routed around — are properties of the distributed system, not of the functions
+in isolation.
+"""
+
+import socket
+import unittest
+
+import numpy as np
+
+from gen9_cluster.coordinator import FleetCoordinator
+from gen9_cluster.dispatch import (ExpertDispatcher, NodeAddress,
+                                   placement_from_plan)
+from gen9_cluster.errors import Gen9Error, ShardMissing
+from gen9_cluster.hardware import ConsoleUnit, Runtime
+from gen9_cluster.model import DEEPSEEK_TINY
+from gen9_cluster.node import ExpertWeights, NodeServer, ShardStore
+from gen9_cluster.planner import plan_split
+
+HIDDEN = 16
+INTERMEDIATE = 8
+
+
+def make_expert(seed):
+    rng = np.random.default_rng(seed)
+    return ExpertWeights(
+        gate=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32)
+        * 0.05,
+        up=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32) * 0.05,
+        down=rng.standard_normal((HIDDEN, INTERMEDIATE), dtype=np.float32)
+        * 0.05)
+
+
+def _closed_port():
+    """A port nothing is listening on, for simulating a console that died."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def reference_expert(weights, x, gate):
+    hidden = x @ weights.gate.T
+    hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))
+    hidden = hidden * (x @ weights.up.T)
+    return gate * (hidden @ weights.down.T)
+
+
+class ClusterFixture(unittest.TestCase):
+    """Three consoles, each holding two of six experts in layer 0."""
+
+    placement_map = {"n0": [0, 1], "n1": [2, 3], "n2": [4, 5]}
+
+    def setUp(self):
+        self.experts = {e: make_expert(e) for e in range(6)}
+        self.nodes = {}
+        self.addresses = {}
+        for unit_id, expert_ids in self.placement_map.items():
+            store = ShardStore()
+            for expert in expert_ids:
+                store.put(0, expert, self.experts[expert])
+            node = NodeServer(store, unit_id=unit_id, host="127.0.0.1", port=0,
+                              block_fn=lambda layer, x: x)
+            port = node.start()
+            self.nodes[unit_id] = node
+            self.addresses[unit_id] = NodeAddress(unit_id, "127.0.0.1", port)
+            self.addCleanup(node.stop)
+        self.placement = {(0, e): [u]
+                          for u, ids in self.placement_map.items()
+                          for e in ids}
+
+    def dispatcher(self, **kwargs):
+        disp = ExpertDispatcher(self.placement, self.addresses, **kwargs)
+        self.addCleanup(disp.close)
+        return disp
+
+
+class TestGrouping(ClusterFixture):
+    def test_a_token_is_grouped_into_one_request_per_console(self):
+        """Six experts across three consoles is three requests, not six. On a
+        fleet this is the difference between 8 round trips per layer and 3."""
+        grouped = self.dispatcher().group_by_unit(0, [0, 1, 2, 3, 4, 5],
+                                                  [1 / 6] * 6)
+        self.assertEqual(set(grouped), {"n0", "n1", "n2"})
+        self.assertEqual(grouped["n0"][0], [0, 1])
+        self.assertEqual(grouped["n1"][0], [2, 3])
+
+    def test_gates_stay_with_their_experts(self):
+        grouped = self.dispatcher().group_by_unit(0, [5, 0, 3], [0.6, 0.3, 0.1])
+        self.assertEqual(grouped["n2"], ([5], [0.6]))
+        self.assertEqual(grouped["n0"], ([0], [0.3]))
+        self.assertEqual(grouped["n1"], ([3], [0.1]))
+
+    def test_an_unplaced_expert_is_refused_rather_than_dropped(self):
+        """Silently omitting an expert produces a plausible wrong answer, which
+        is worse than a failure."""
+        with self.assertRaises(ShardMissing):
+            self.dispatcher().group_by_unit(0, [42], [1.0])
+
+
+class TestReduction(ClusterFixture):
+    def test_the_layer_output_matches_a_local_computation(self):
+        disp = self.dispatcher()
+        x = np.linspace(-1, 1, HIDDEN, dtype=np.float32)
+        ids, gates = [0, 2, 4, 5], [0.4, 0.3, 0.2, 0.1]
+        got, stats = disp.run_layer(0, x, ids, gates)
+
+        expected = np.zeros(HIDDEN, dtype=np.float32)
+        for expert, gate in zip(ids, gates):
+            expected += reference_expert(self.experts[expert], x, gate)
+        np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+        self.assertEqual(stats.consoles_contacted, 3)
+        self.assertEqual(stats.experts_run, 4)
+
+    def test_the_result_is_bit_identical_across_runs(self):
+        """Replies arrive in whatever order the network chooses, so the sum is
+        taken in a fixed order instead. Without that, the same prompt can
+        produce different tokens on different runs."""
+        disp = self.dispatcher()
+        x = np.linspace(-2, 2, HIDDEN, dtype=np.float32)
+        ids, gates = [0, 1, 2, 3, 4, 5], [1 / 6] * 6
+        first, _ = disp.run_layer(0, x, ids, gates)
+        for _ in range(6):
+            again, _ = disp.run_layer(0, x, ids, gates)
+            np.testing.assert_array_equal(first, again)
+
+    def test_routing_all_experts_to_one_console_still_works(self):
+        disp = self.dispatcher()
+        x = np.ones(HIDDEN, dtype=np.float32)
+        got, stats = disp.run_layer(0, x, [0, 1], [0.5, 0.5])
+        self.assertEqual(stats.consoles_contacted, 1)
+        expected = (reference_expert(self.experts[0], x, 0.5)
+                    + reference_expert(self.experts[1], x, 0.5))
+        np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+
+
+class TestFailover(ClusterFixture):
+    def test_a_dead_console_with_no_replica_fails_the_token(self):
+        disp = self.dispatcher(request_timeout=2.0)
+        self.nodes["n1"].stop()
+        with self.assertRaises(Gen9Error):
+            disp.run_layer(0, np.ones(HIDDEN, dtype=np.float32), [2], [1.0])
+
+    def test_a_replica_takes_over(self):
+        """Experts are stateless, so a second console holding the same shard is
+        a complete substitute — the one kind of failure that can be handled
+        inside a token rather than by re-planning."""
+        store = ShardStore()
+        for expert in (2, 3):
+            store.put(0, expert, self.experts[expert])
+        replica = NodeServer(store, unit_id="n1-replica", host="127.0.0.1",
+                             port=0)
+        port = replica.start()
+        self.addCleanup(replica.stop)
+        self.addresses["n1-replica"] = NodeAddress("n1-replica", "127.0.0.1",
+                                                   port)
+        for expert in (2, 3):
+            self.placement[(0, expert)].append("n1-replica")
+
+        disp = self.dispatcher(request_timeout=2.0, max_retries=2)
+        self.nodes["n1"].stop()
+        x = np.ones(HIDDEN, dtype=np.float32)
+        got, stats = disp.run_layer(0, x, [2, 3], [0.5, 0.5])
+        expected = (reference_expert(self.experts[2], x, 0.5)
+                    + reference_expert(self.experts[3], x, 0.5))
+        np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+        self.assertGreaterEqual(stats.retries, 1)
+
+    def test_a_console_with_no_address_is_named_in_the_error(self):
+        placement = dict(self.placement)
+        placement[(0, 7)] = ["n9"]
+        disp = ExpertDispatcher(placement, self.addresses)
+        self.addCleanup(disp.close)
+        with self.assertRaises(ShardMissing) as caught:
+            disp.run_layer(0, np.ones(HIDDEN, dtype=np.float32), [7], [1.0])
+        self.assertIn("n9", str(caught.exception))
+
+
+class TestPlacementFromPlan(unittest.TestCase):
+    def test_the_index_covers_every_expert_the_plan_placed(self):
+        fleet = [ConsoleUnit(f"ps5-{i}", "ps5", Runtime.PS5_LINUX)
+                 for i in range(4)]
+        plan = plan_split(DEEPSEEK_TINY, fleet, context_tokens=1024)
+        placement = placement_from_plan(plan)
+        for layer in range(DEEPSEEK_TINY.moe.n_dense_layers,
+                           DEEPSEEK_TINY.n_layers):
+            for expert in range(DEEPSEEK_TINY.moe.n_routed_experts):
+                self.assertIn((layer, expert), placement)
+                self.assertTrue(placement[(layer, expert)])
+
+
+class TestEndToEnd(unittest.TestCase):
+    """A planned fleet, served and driven, from plan to hidden state."""
+
+    def setUp(self):
+        self.profile = DEEPSEEK_TINY
+        fleet = [ConsoleUnit(f"ps5-{i}", "ps5", Runtime.PS5_LINUX)
+                 for i in range(3)]
+        self.plan = plan_split(self.profile, fleet, context_tokens=512,
+                               shelf_size=3)
+        self.addresses = {}
+        self.stores = {}
+        rng = np.random.default_rng(7)
+        for unit_id, unit_plan in self.plan.units.items():
+            store = ShardStore()
+            for shard in unit_plan.shards:
+                for expert in shard.expert_ids:
+                    store.put(shard.layer, expert,
+                              ExpertWeights(
+                                  gate=rng.standard_normal(
+                                      (INTERMEDIATE, HIDDEN),
+                                      dtype=np.float32) * 0.01,
+                                  up=rng.standard_normal((INTERMEDIATE, HIDDEN),
+                                                         dtype=np.float32)
+                                  * 0.01,
+                                  down=rng.standard_normal((HIDDEN,
+                                                            INTERMEDIATE),
+                                                           dtype=np.float32)
+                                  * 0.01,
+                                  tier=shard.tier))
+            self.stores[unit_id] = store
+            node = NodeServer(store, unit_id=unit_id, host="127.0.0.1", port=0,
+                              sku=unit_plan.sku, backend=unit_plan.backend,
+                              block_fn=lambda layer, x: x * 1.01)
+            port = node.start()
+            self.addCleanup(node.stop)
+            self.addresses[unit_id] = NodeAddress(unit_id, "127.0.0.1", port)
+
+    def router(self, layer, state):
+        k = self.profile.moe.top_k
+        return list(range(k)), [1.0 / k] * k
+
+    def test_a_token_traverses_every_block(self):
+        with FleetCoordinator(self.plan, self.addresses,
+                              router=self.router) as fleet:
+            x = np.ones(HIDDEN, dtype=np.float32)
+            out, trace = fleet.forward(x)
+            self.assertEqual(out.shape, (HIDDEN,))
+            self.assertTrue(np.all(np.isfinite(out)))
+            self.assertEqual(len(trace.layers), self.profile.planning_layers)
+            self.assertGreater(trace.seconds, 0.0)
+
+    def test_the_trace_identifies_the_slowest_block(self):
+        with FleetCoordinator(self.plan, self.addresses,
+                              router=self.router) as fleet:
+            _, trace = fleet.forward(np.ones(HIDDEN, dtype=np.float32))
+            self.assertIsNotNone(trace.slowest)
+            self.assertIn("ms/token", trace.summary())
+
+    def test_health_reports_every_console(self):
+        with FleetCoordinator(self.plan, self.addresses,
+                              router=self.router) as fleet:
+            status = fleet.health()
+            self.assertEqual(set(status), set(self.addresses))
+            for text in status.values():
+                self.assertIn("shards=", text)
+
+    def test_repeated_tokens_are_deterministic(self):
+        with FleetCoordinator(self.plan, self.addresses,
+                              router=self.router) as fleet:
+            x = np.full(HIDDEN, 0.5, dtype=np.float32)
+            first, _ = fleet.forward(x)
+            second, _ = fleet.forward(x)
+            np.testing.assert_array_equal(first, second)
+
+    def test_losing_the_shelf_host_is_reported_as_unrecoverable(self):
+        """The host holds the KV cache for its layers; failing over would mean
+        continuing a different conversation."""
+        host = self.plan.stages[0].host_unit
+        with FleetCoordinator(self.plan, self.addresses, router=self.router,
+                              request_timeout=2.0) as fleet:
+            fleet.forward(np.ones(HIDDEN, dtype=np.float32))
+
+            # Point the host at a closed port and drop the live connection:
+            # the console is gone as far as the fleet is concerned.
+            fleet.pool.drop(host)
+            self.addresses[host] = NodeAddress(host, "127.0.0.1",
+                                               _closed_port())
+
+            with self.assertRaises(Gen9Error) as caught:
+                fleet.forward(np.ones(HIDDEN, dtype=np.float32))
+            self.assertIn("restarted", str(caught.exception))
+            self.assertEqual(caught.exception.unit_id, host)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_dispatch.py
+++ b/gen9-cluster/tests/test_dispatch.py
@@ -20,6 +20,8 @@ from gen9_cluster.hardware import ConsoleUnit, Runtime
 from gen9_cluster.model import DEEPSEEK_TINY
 from gen9_cluster.node import ExpertWeights, NodeServer, ShardStore
 from gen9_cluster.planner import plan_split
+from gen9_cluster.protocol import (ExpertRowsPayload, Flags, Frame, MsgType,
+                                   accumulate, encode_vector)
 
 HIDDEN = 16
 INTERMEDIATE = 8
@@ -126,6 +128,82 @@ class TestReduction(ClusterFixture):
         for _ in range(6):
             again, _ = disp.run_layer(0, x, ids, gates)
             np.testing.assert_array_equal(first, again)
+
+    def test_the_result_does_not_depend_on_where_the_experts_live(self):
+        """The property the whole per-expert reply shape exists to provide.
+
+        This is the failure mode that matters on a fleet of second-hand
+        consoles: a unit dies, the planner reshuffles the experts, and the
+        model starts emitting different tokens for the same prompt with no
+        error anywhere. Reducing per console would do exactly that, because
+        fp32 addition is not associative. Here the same six experts are served
+        by three consoles and then by one, and the bits must match.
+        """
+        x = np.linspace(-2, 2, HIDDEN, dtype=np.float32)
+        ids = [3, 0, 5, 1, 4, 2]
+        gates = [0.3, 0.25, 0.2, 0.1, 0.1, 0.05]
+        spread, _ = self.dispatcher().run_layer(0, x, ids, gates)
+
+        store = ShardStore()
+        for expert, weights in self.experts.items():
+            store.put(0, expert, weights)
+        node = NodeServer(store, unit_id="all", host="127.0.0.1", port=0)
+        port = node.start()
+        self.addCleanup(node.stop)
+        one = ExpertDispatcher(
+            {(0, e): ["all"] for e in self.experts},
+            {"all": NodeAddress("all", "127.0.0.1", port)})
+        self.addCleanup(one.close)
+
+        together, stats = one.run_layer(0, x, ids, gates)
+        self.assertEqual(stats.consoles_contacted, 1)
+        np.testing.assert_array_equal(spread, together)
+
+    def test_the_reduction_follows_top_k_order_not_expert_id(self):
+        """Rank order is the router's order, and it is what gets summed."""
+        disp = self.dispatcher()
+        x = np.linspace(-1, 1, HIDDEN, dtype=np.float32)
+        ids, gates = [5, 1, 3, 0], [0.4, 0.3, 0.2, 0.1]
+        got, _ = disp.run_layer(0, x, ids, gates)
+
+        rows = [reference_expert(self.experts[e], x, np.float32(g))
+                for e, g in zip(ids, gates)]
+        want = rows[0].astype(np.float32).copy()
+        for row in rows[1:]:
+            want += row
+        np.testing.assert_array_equal(got, want)
+
+    def test_fast_mode_is_opt_in_and_re_associates_the_sum(self):
+        """FAST is allowed to differ from exact — that is the trade — but it
+        must only happen when it was asked for."""
+        disp = self.dispatcher()
+        x = np.linspace(-3, 3, HIDDEN, dtype=np.float32)
+        ids, gates = [0, 1, 2, 3, 4, 5], [0.3, 0.25, 0.2, 0.1, 0.1, 0.05]
+        exact, _ = disp.run_layer(0, x, ids, gates)
+        fast, _ = disp.run_layer(0, x, ids, gates, fast=True)
+        np.testing.assert_allclose(fast, exact, rtol=1e-5, atol=1e-6)
+
+    def test_a_console_that_collapses_without_being_asked_is_refused(self):
+        """A stale node answering a v2 coordinator must not be silently
+        accepted: its sum is arithmetically unplaceable."""
+        node = self.nodes["n0"]
+        original = node._on_expert_batch
+
+        def collapse(frame):
+            reply = original(frame)
+            rows = ExpertRowsPayload.decode(reply.payload).rows
+            return Frame(MsgType.EXPERT_RESULT, frame.request_id,
+                         encode_vector(accumulate(list(rows))),
+                         layer=frame.layer, flags=Flags.PARTIAL)
+
+        node._on_expert_batch = collapse
+        try:
+            with self.assertRaises(Gen9Error) as caught:
+                self.dispatcher(max_retries=0).run_layer(
+                    0, np.ones(HIDDEN, dtype=np.float32), [0], [1.0])
+        finally:
+            node._on_expert_batch = original
+        self.assertIn("did not ask for FAST", str(caught.exception))
 
     def test_routing_all_experts_to_one_console_still_works(self):
         disp = self.dispatcher()

--- a/gen9-cluster/tests/test_fp8.py
+++ b/gen9-cluster/tests/test_fp8.py
@@ -1,0 +1,215 @@
+"""FP8 E4M3FN with 128-element block scales.
+
+Two implementations exist — numpy here and C in ``kernels/fp8.c`` — and a
+disagreement between them is a fleet where two consoles decode the same weight
+differently. The last test in this file is the one that matters: it checks them
+against each other over all 256 codes.
+"""
+
+import ctypes
+import math
+import unittest
+
+import numpy as np
+
+from gen9_cluster import fp8
+from gen9_cluster.backends import _DEFAULT_LIB, CpuKernelRunner
+from gen9_cluster.node import ExpertRunner, ExpertWeights
+from gen9_cluster.protocol import DType, ShardHeader
+
+
+class TestFormat(unittest.TestCase):
+    def test_the_table_covers_every_code(self):
+        self.assertEqual(fp8.TABLE.shape, (256,))
+
+    def test_powers_of_two_are_exact(self):
+        """E4M3 represents these exactly, so a round trip that perturbs them
+        is a bug in the encoder, not quantisation noise."""
+        for value in (1.0, 2.0, 0.5, 8.0, 0.25, 256.0):
+            codes, scales = fp8.quantize(np.full(fp8.BLOCK, value,
+                                                 dtype=np.float32))
+            back = fp8.dequantize(codes, scales)
+            np.testing.assert_allclose(back, value, rtol=1e-6)
+
+    def test_the_maximum_normal_is_448(self):
+        finite = fp8.TABLE[~np.isnan(fp8.TABLE)]
+        self.assertEqual(finite.max(), 448.0)
+        self.assertEqual(finite.min(), -448.0)
+
+    def test_only_two_codes_are_nan(self):
+        """E4M3FN spends its would-be infinities on extra range; if more codes
+        decoded to NaN, a weight would silently poison a whole token."""
+        self.assertEqual(int(np.isnan(fp8.TABLE).sum()), 2)
+
+    def test_the_smallest_subnormal(self):
+        finite = np.abs(fp8.TABLE[~np.isnan(fp8.TABLE)])
+        self.assertAlmostEqual(float(finite[finite > 0].min()), 2.0 ** -9)
+
+    def test_relative_error_is_bounded_over_the_normal_range(self):
+        """3 mantissa bits gives at worst 1/16 relative error. Anything much
+        larger means the encoder is picking the wrong code, not that the format
+        is coarse."""
+        values = np.exp(np.linspace(math.log(1e-3), math.log(400), fp8.BLOCK))
+        values = values.astype(np.float32)
+        codes, scales = fp8.quantize(values)
+        back = fp8.dequantize(codes, scales)
+        self.assertLess(float(np.abs(back - values).max() / values.max()),
+                        1 / 16)
+
+
+class TestBlockwise(unittest.TestCase):
+    def test_one_scale_per_128_values(self):
+        codes, scales = fp8.quantize(np.ones(512, dtype=np.float32))
+        self.assertEqual(scales.shape, (4,))
+        self.assertEqual(codes.shape, (512,))
+
+    def test_a_partial_final_block_still_gets_a_scale(self):
+        codes, scales = fp8.quantize(np.ones(200, dtype=np.float32))
+        self.assertEqual(scales.shape, (2,))
+        self.assertEqual(codes.shape, (200,))
+
+    def test_an_outlier_does_not_flatten_its_neighbours(self):
+        """Per-block scaling is the reason a 1e4 outlier next to 1e-2 weights
+        costs one block's precision rather than the whole tensor's."""
+        values = np.full(2 * fp8.BLOCK, 0.01, dtype=np.float32)
+        values[0] = 10000.0
+        back = fp8.dequantize(*fp8.quantize(values))
+        # The block with the outlier loses precision...
+        self.assertGreater(abs(back[1] - 0.01) / 0.01, 0.1)
+        # ...and the next block does not.
+        np.testing.assert_allclose(back[fp8.BLOCK:], 0.01, rtol=0.05)
+
+    def test_shape_is_preserved(self):
+        matrix = np.random.default_rng(0).standard_normal((8, 256),
+                                                          dtype=np.float32)
+        codes, scales = fp8.quantize(matrix)
+        self.assertEqual(codes.shape, (8, 256))
+        self.assertEqual(fp8.dequantize(codes, scales).shape, (8, 256))
+
+    def test_zeros_survive(self):
+        back = fp8.dequantize(*fp8.quantize(np.zeros(fp8.BLOCK,
+                                                     dtype=np.float32)))
+        np.testing.assert_array_equal(back, np.zeros(fp8.BLOCK))
+
+    def test_the_wrong_number_of_scales_is_refused(self):
+        codes, _ = fp8.quantize(np.ones(512, dtype=np.float32))
+        with self.assertRaises(ValueError):
+            fp8.dequantize(codes, np.ones(3, dtype=np.float32))
+
+    def test_a_quantised_tensor_is_a_quarter_the_size(self):
+        """The entire reason this format is here."""
+        values = np.ones(1024, dtype=np.float32)
+        codes, scales = fp8.quantize(values)
+        self.assertLess(codes.nbytes + scales.nbytes, values.nbytes * 0.3)
+
+
+class TestQuantisedExperts(unittest.TestCase):
+    hidden = fp8.BLOCK
+    intermediate = fp8.BLOCK
+
+    def make(self, seed=0):
+        rng = np.random.default_rng(seed)
+        raw = {
+            "gate": rng.standard_normal((self.intermediate, self.hidden),
+                                        dtype=np.float32) * 0.05,
+            "up": rng.standard_normal((self.intermediate, self.hidden),
+                                      dtype=np.float32) * 0.05,
+            "down": rng.standard_normal((self.hidden, self.intermediate),
+                                        dtype=np.float32) * 0.05,
+        }
+        codes, scales = {}, []
+        for name, matrix in raw.items():
+            code, scale = fp8.quantize(matrix)
+            codes[name] = code
+            scales.append(scale)
+        quantised = ExpertWeights(gate=codes["gate"], up=codes["up"],
+                                  down=codes["down"],
+                                  scales=np.concatenate(scales))
+        exact = ExpertWeights(**raw)
+        return quantised, exact
+
+    def test_a_quantised_expert_is_recognised_as_such(self):
+        quantised, exact = self.make()
+        self.assertTrue(quantised.quantised)
+        self.assertFalse(exact.quantised)
+
+    def test_the_reference_runner_accepts_fp8_shards(self):
+        quantised, exact = self.make()
+        x = np.linspace(-1, 1, self.hidden, dtype=np.float32)
+        runner = ExpertRunner()
+        got = runner(x, [quantised], [1.0])
+        want = runner(x, [exact], [1.0])
+        self.assertLess(float(np.abs(got - want).max()
+                              / np.abs(want).max()), 0.1)
+
+    def test_an_fp8_expert_without_scales_is_an_error_not_garbage(self):
+        quantised, _ = self.make()
+        quantised.scales = None
+        with self.assertRaises(ValueError):
+            quantised.dequantised()
+
+    def test_the_wrong_number_of_scales_is_caught(self):
+        quantised, _ = self.make()
+        quantised.scales = quantised.scales[:-1]
+        with self.assertRaises(ValueError):
+            quantised.dequantised()
+
+    def test_the_compiled_kernel_agrees_with_numpy_on_fp8_experts(self):
+        try:
+            kernel = CpuKernelRunner()
+        except (FileNotFoundError, OSError) as exc:
+            self.skipTest(f"CPU kernel not built here: {exc}")
+        quantised, _ = self.make(3)
+        x = np.linspace(-1, 1, self.hidden, dtype=np.float32)
+        np.testing.assert_allclose(kernel(x, [quantised], [1.0]),
+                                   ExpertRunner()(x, [quantised], [1.0]),
+                                   rtol=1e-4, atol=1e-5)
+
+
+class TestAgainstTheCKernel(unittest.TestCase):
+    """The two decoders must be the same decoder."""
+
+    def setUp(self):
+        if not _DEFAULT_LIB.exists():
+            self.skipTest("CPU kernel not built here")
+        self.lib = ctypes.CDLL(str(_DEFAULT_LIB))
+        self.lib.gen9_fp8_to_f32.argtypes = [ctypes.c_uint8]
+        self.lib.gen9_fp8_to_f32.restype = ctypes.c_float
+        self.lib.gen9_f32_to_fp8.argtypes = [ctypes.c_float]
+        self.lib.gen9_f32_to_fp8.restype = ctypes.c_uint8
+
+    def test_every_code_decodes_identically(self):
+        for code in range(256):
+            c_value = self.lib.gen9_fp8_to_f32(code)
+            py_value = float(fp8.TABLE[code])
+            if math.isnan(py_value):
+                self.assertTrue(math.isnan(c_value), f"code {code:#04x}")
+            else:
+                self.assertEqual(c_value, py_value, f"code {code:#04x}")
+
+    def test_encoding_agrees_on_representable_values(self):
+        for value in (0.0, 1.0, -1.0, 0.5, 448.0, -448.0, 2.0 ** -9, 6.0):
+            code = self.lib.gen9_f32_to_fp8(value)
+            self.assertEqual(float(fp8.TABLE[code]), value, f"{value}")
+
+    def test_both_saturate_rather_than_overflow(self):
+        code = self.lib.gen9_f32_to_fp8(1e6)
+        self.assertEqual(float(fp8.TABLE[code]), 448.0)
+        codes, scales = fp8.quantize(np.full(fp8.BLOCK, 1e6,
+                                             dtype=np.float32))
+        np.testing.assert_allclose(fp8.dequantize(codes, scales), 1e6,
+                                   rtol=1e-6)
+
+
+class TestShardHeaderIntegration(unittest.TestCase):
+    def test_the_header_can_declare_fp8(self):
+        header = ShardHeader(layer=4, first_expert=0, n_experts=2,
+                             hidden_size=fp8.BLOCK,
+                             intermediate_size=fp8.BLOCK,
+                             dtype=DType.FP8_E4M3_B128, tier="slow")
+        decoded, _ = ShardHeader.decode(header.encode())
+        self.assertIs(decoded.dtype, DType.FP8_E4M3_B128)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_hardware.py
+++ b/gen9-cluster/tests/test_hardware.py
@@ -1,0 +1,188 @@
+"""The hardware model: what a console is after reality gets to it."""
+
+import unittest
+
+from gen9_cluster.hardware import (GB, ComputeBackend, ConsoleUnit,
+                                   Downbin, Runtime, SKUS, fleet_summary,
+                                   sku_for)
+
+
+class TestSKUs(unittest.TestCase):
+    def test_consoles_ship_downbinned_by_design(self):
+        """Every one of these parts has CUs fused off at the factory."""
+        for name, expected_physical, expected_enabled in [
+            ("ps5", 40, 36), ("ps5-slim", 40, 36),
+            ("xbox-series-x", 56, 52), ("xbox-series-s", 24, 20),
+        ]:
+            spec = sku_for(name)
+            self.assertEqual(spec.cu_physical, expected_physical, name)
+            self.assertEqual(spec.cu_enabled, expected_enabled, name)
+            self.assertLess(spec.cu_enabled, spec.cu_physical, name)
+
+    def test_series_x_memory_is_split_into_two_speeds(self):
+        """The Series X's 10 GB fast / 6 GB slow split is the whole reason
+        MemoryTier exists rather than a single capacity number."""
+        spec = sku_for("xbox-series-x")
+        tiers = {tier.name: tier for tier in spec.tiers}
+        self.assertIn("gddr6-fast", tiers)
+        self.assertIn("gddr6-slow", tiers)
+        self.assertGreater(tiers["gddr6-fast"].bandwidth_gbps,
+                           tiers["gddr6-slow"].bandwidth_gbps)
+        self.assertEqual(sum(t.total_bytes for t in spec.tiers), 16 * GB)
+
+    def test_salvage_boards_are_first_class(self):
+        for name in ("amd-4700s", "amd-4800s", "bc-250"):
+            self.assertIn(name, SKUS)
+
+    def test_4700s_has_no_usable_gpu(self):
+        """The 4700S is a Series X SoC sold as a desktop kit with the GPU fused
+        off. Planning it as if it had 52 CUs would be a 40x error."""
+        cap = ConsoleUnit("kit", "amd-4700s", Runtime.SALVAGE_LINUX).effective()
+        self.assertEqual(cap.cu_active, 0)
+        self.assertEqual(cap.backend, ComputeBackend.CPU_AVX2)
+
+
+class TestDownbin(unittest.TestCase):
+    def test_disabled_cus_come_off_the_enabled_count(self):
+        unit = ConsoleUnit("ps5-x", "ps5", Runtime.PS5_LINUX,
+                           downbin=Downbin(cu_disabled=8,
+                                           reasons=("dead shader array",)))
+        self.assertEqual(unit.effective().cu_active, 36 - 8)
+
+    def test_a_clock_cap_only_ever_lowers(self):
+        """A cap above the stock clock is a typo, not an overclock."""
+        fast = ConsoleUnit("a", "ps5", Runtime.PS5_LINUX,
+                           downbin=Downbin(gpu_ghz_cap=9.9)).effective()
+        slow = ConsoleUnit("b", "ps5", Runtime.PS5_LINUX,
+                           downbin=Downbin(gpu_ghz_cap=1.2)).effective()
+        self.assertEqual(fast.gpu_ghz, sku_for("ps5").gpu_ghz)
+        self.assertEqual(slow.gpu_ghz, 1.2)
+
+    def test_a_throttled_gpu_is_still_bandwidth_bound(self):
+        """Decode is GEMV, so a downclocked PS5 loses almost nothing: it was
+        waiting on GDDR6, not on the shader clock. Halving the clock only
+        matters once the arithmetic ceiling drops below the memory one."""
+        stock = ConsoleUnit("a", "ps5", Runtime.PS5_LINUX).effective()
+        throttled = ConsoleUnit("b", "ps5", Runtime.PS5_LINUX,
+                                downbin=Downbin(gpu_ghz_cap=1.2)).effective()
+        self.assertEqual(throttled.gemv_gflops, stock.gemv_gflops)
+
+        crippled = ConsoleUnit("c", "ps5", Runtime.PS5_LINUX,
+                               downbin=Downbin(cu_disabled=32)).effective()
+        self.assertLess(crippled.gemv_gflops, stock.gemv_gflops)
+
+    def test_a_dead_memory_package_reduces_that_tier_only(self):
+        unit = ConsoleUnit("ps5-y", "ps5", Runtime.PS5_LINUX,
+                           downbin=Downbin(tier_losses={"gddr6": 2 * GB},
+                                           reasons=("failed memtest",)))
+        stock = ConsoleUnit("ps5-z", "ps5", Runtime.PS5_LINUX).effective()
+        self.assertEqual(stock.weight_bytes - unit.effective().weight_bytes,
+                         2 * GB)
+
+    def test_losses_never_drive_capacity_negative(self):
+        unit = ConsoleUnit("gone", "xbox-series-s", Runtime.XBOX_GDK,
+                           downbin=Downbin(tier_losses={"gddr6-fast": 99 * GB}))
+        for tier in unit.effective().coffers:
+            self.assertGreaterEqual(tier.usable_bytes, 0)
+
+    def test_reasons_survive_into_the_capability(self):
+        """An operator reading a plan must be able to see *why* a console is
+        small, or they will 'fix' it by re-planning with the wrong numbers."""
+        unit = ConsoleUnit("ps5-w", "ps5", Runtime.PS5_LINUX,
+                           downbin=Downbin(cu_disabled=4,
+                                           reasons=("shader array 3 fused",)))
+        self.assertTrue(any("shader array 3 fused" in w
+                            for w in unit.effective().warnings))
+
+
+class TestRuntimeSandboxes(unittest.TestCase):
+    def test_xbox_devmode_is_capped_far_below_the_hardware(self):
+        """Dev Mode hands a game-like app about 5 GB of a 16 GB console. The
+        planner must see 5, not 16, or it will place four times too much."""
+        cap = ConsoleUnit("xsx", "xbox-series-x",
+                          Runtime.XBOX_DEVMODE).effective()
+        self.assertLessEqual(cap.weight_bytes, 5 * GB)
+
+    def test_devmode_app_budget_is_smaller_still(self):
+        game = ConsoleUnit("g", "xbox-series-x", Runtime.XBOX_DEVMODE).effective()
+        app = ConsoleUnit("a", "xbox-series-x", Runtime.XBOX_DEVMODE,
+                          devmode_app=True).effective()
+        self.assertLess(app.weight_bytes, game.weight_bytes)
+
+    def test_gdk_gets_the_real_machine(self):
+        gdk = ConsoleUnit("g", "xbox-series-x", Runtime.XBOX_GDK).effective()
+        dev = ConsoleUnit("d", "xbox-series-x", Runtime.XBOX_DEVMODE).effective()
+        self.assertGreater(gdk.weight_bytes, dev.weight_bytes * 2)
+        self.assertEqual(gdk.backend, ComputeBackend.D3D12)
+
+
+class TestBackendSelection(unittest.TestCase):
+    def test_ps5_defaults_to_vulkan(self):
+        """RADV drives gfx1013; ROCm's library layer does not, uniformly."""
+        cap = ConsoleUnit("ps5", "ps5", Runtime.PS5_LINUX).effective()
+        self.assertEqual(cap.backend, ComputeBackend.VULKAN)
+
+    def test_rocm_is_available_but_warns_without_a_measurement(self):
+        cap = ConsoleUnit("ps5", "ps5", Runtime.PS5_LINUX,
+                          backend=ComputeBackend.ROCM).effective()
+        self.assertEqual(cap.backend, ComputeBackend.ROCM)
+        self.assertFalse(cap.throughput_measured)
+        self.assertTrue(any("rocm" in w.lower() for w in cap.warnings))
+
+    def test_a_measured_rocm_node_is_trusted_and_not_warned_about_speed(self):
+        cap = ConsoleUnit("ps5", "ps5", Runtime.PS5_LINUX,
+                          backend=ComputeBackend.ROCM,
+                          measured_gemv_gflops=1234.0).effective()
+        self.assertTrue(cap.throughput_measured)
+        self.assertEqual(cap.gemv_gflops, 1234.0)
+
+    def test_hen_runtime_has_no_gpu_path(self):
+        cap = ConsoleUnit("ps5", "ps5", Runtime.PS5_HEN).effective()
+        self.assertEqual(cap.backend, ComputeBackend.CPU_AVX2)
+
+    def test_a_gpu_backend_with_every_cu_dead_falls_back_to_the_cpu(self):
+        cap = ConsoleUnit("ps5", "ps5", Runtime.PS5_LINUX,
+                          downbin=Downbin(cu_disabled=36)).effective()
+        self.assertEqual(cap.backend, ComputeBackend.CPU_AVX2)
+
+
+class TestBC250(unittest.TestCase):
+    """The mining board: 40 CUs on the die, 24 lit by the stock driver."""
+
+    def test_stock_driver_baseline(self):
+        cap = ConsoleUnit("bc", "bc-250", Runtime.SALVAGE_LINUX).effective()
+        self.assertEqual(cap.cu_active, 24)
+
+    def test_the_community_unlock_is_allowed_but_flagged(self):
+        cap = ConsoleUnit("bc", "bc-250", Runtime.SALVAGE_LINUX,
+                          cu_enabled_override=40).effective()
+        self.assertEqual(cap.cu_active, 40)
+        self.assertTrue(any("40" in w or "unlock" in w.lower()
+                            for w in cap.warnings))
+
+    def test_the_override_cannot_exceed_the_silicon(self):
+        cap = ConsoleUnit("bc", "bc-250", Runtime.SALVAGE_LINUX,
+                          cu_enabled_override=64).effective()
+        self.assertEqual(cap.cu_active, sku_for("bc-250").cu_physical)
+
+
+class TestFleetSummary(unittest.TestCase):
+    def test_summary_counts_what_an_operator_needs_to_worry_about(self):
+        fleet = [
+            ConsoleUnit("a", "ps5", Runtime.PS5_LINUX),
+            ConsoleUnit("b", "ps5", Runtime.PS5_LINUX,
+                        downbin=Downbin(cu_disabled=4, reasons=("dead CU",))),
+            ConsoleUnit("c", "xbox-series-s", Runtime.XBOX_GDK),
+            ConsoleUnit("d", "bc-250", Runtime.SALVAGE_LINUX,
+                        measured_gemv_gflops=500.0),
+        ]
+        summary = fleet_summary(fleet)
+        self.assertEqual(summary.units, 4)
+        self.assertEqual(summary.by_sku["ps5"], 2)
+        self.assertEqual(summary.downbinned_units, 1)
+        self.assertEqual(summary.estimated_throughput_units, 3)
+        self.assertGreater(summary.weight_bytes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_hardware.py
+++ b/gen9-cluster/tests/test_hardware.py
@@ -35,11 +35,27 @@ class TestSKUs(unittest.TestCase):
             self.assertIn(name, SKUS)
 
     def test_4700s_has_no_usable_gpu(self):
-        """The 4700S is a Series X SoC sold as a desktop kit with the GPU fused
-        off. Planning it as if it had 52 CUs would be a 40x error."""
+        """The 4700S is a PS5 Ariel die sold as a desktop kit with the GPU fused
+        off. Planning it as if it had 36 CUs would be a 40x error."""
         cap = ConsoleUnit("kit", "amd-4700s", Runtime.SALVAGE_LINUX).effective()
         self.assertEqual(cap.cu_active, 0)
         self.assertEqual(cap.backend, ComputeBackend.CPU_AVX2)
+
+    def test_the_two_kits_are_different_harvests(self):
+        """The 4800S is not a revision of the 4700S: PS5 Ariel silicon against
+        Series X silicon, and a SATA-only board against one with an M.2. Both
+        distinctions reach the planner, so neither may be collapsed."""
+        kit47, kit48 = sku_for("amd-4700s"), sku_for("amd-4800s")
+        self.assertEqual(kit47.cu_physical, 40)
+        self.assertEqual(kit48.cu_physical, 56)
+        self.assertLess(kit47.storage.effective_read_gbps,
+                        kit48.storage.effective_read_gbps)
+
+    def test_neither_kit_can_host_a_shelf(self):
+        """Their GDDR6 is fast for system memory and far short of a console's,
+        which is the entire reason they are capacity nodes and not hosts."""
+        for name in ("amd-4700s", "amd-4800s"):
+            self.assertLess(sku_for(name).fast_tier.bandwidth_gbps, 200.0, name)
 
 
 class TestDownbin(unittest.TestCase):

--- a/gen9-cluster/tests/test_inventory.py
+++ b/gen9-cluster/tests/test_inventory.py
@@ -1,0 +1,172 @@
+"""Inventory files and the CLI that consumes them."""
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from gen9_cluster.cli import main
+from gen9_cluster.hardware import GB, ComputeBackend, Runtime
+from gen9_cluster.inventory import (addresses, deployment_config,
+                                    entry_from_dict, load_fleet, save_fleet,
+                                    synthetic_fleet, units)
+from gen9_cluster.model import DEEPSEEK_TINY
+from gen9_cluster.planner import plan_split
+
+FLEET = {
+    "fleet": [
+        {"unit_id": "ps5-01", "sku": "ps5", "runtime": "ps5-linux",
+         "host": "10.0.0.11", "port": 9713},
+        {"unit_id": "ps5-02", "sku": "ps5", "runtime": "ps5-linux",
+         "host": "10.0.0.12",
+         "downbin": {"cu_disabled": 4, "gpu_ghz_cap": 1.8,
+                     "tier_losses": {"gddr6": 2147483648},
+                     "reasons": ["dead GDDR6 package", "fan replaced"]}},
+        {"unit_id": "bc-01", "sku": "bc-250", "runtime": "salvage-linux",
+         "host": "10.0.0.31", "cu_enabled_override": 40, "backend": "rocm",
+         "measured_gemv_gflops": 940.0},
+        {"unit_id": "xsx-01", "sku": "xbox-series-x", "runtime": "xbox-devmode",
+         "host": "10.0.0.21", "labels": {"rack": "b", "slot": "4"}},
+    ]
+}
+
+
+class InventoryFile(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.dir.cleanup)
+        self.path = Path(self.dir.name) / "fleet.json"
+        self.path.write_text(json.dumps(FLEET))
+
+
+class TestLoading(InventoryFile):
+    def test_every_entry_is_read(self):
+        self.assertEqual(len(load_fleet(self.path)), 4)
+
+    def test_downbin_survives_the_file(self):
+        fleet = {e.unit.unit_id: e for e in load_fleet(self.path)}
+        damaged = fleet["ps5-02"].unit
+        self.assertEqual(damaged.downbin.cu_disabled, 4)
+        self.assertEqual(damaged.downbin.gpu_ghz_cap, 1.8)
+        self.assertEqual(damaged.downbin.tier_losses["gddr6"], 2 * GB)
+        self.assertIn("dead GDDR6 package", damaged.downbin.reasons)
+        self.assertEqual(damaged.effective().cu_active, 32)
+
+    def test_a_declared_rocm_node_keeps_its_measurement(self):
+        fleet = {e.unit.unit_id: e for e in load_fleet(self.path)}
+        board = fleet["bc-01"].unit
+        self.assertEqual(board.backend, ComputeBackend.ROCM)
+        self.assertEqual(board.effective().gemv_gflops, 940.0)
+        self.assertTrue(board.effective().throughput_measured)
+        self.assertEqual(board.effective().cu_active, 40)
+
+    def test_addresses_are_extracted_for_the_dispatcher(self):
+        table = addresses(load_fleet(self.path))
+        self.assertEqual(table["ps5-01"].host, "10.0.0.11")
+        self.assertEqual(table["ps5-01"].port, 9713)
+        self.assertEqual(table["bc-01"].port, 9713)     # default
+
+    def test_a_duplicate_unit_id_is_rejected(self):
+        """Two consoles with the same id means one of them silently never gets
+        its shards, and the plan will not say so."""
+        path = Path(self.dir.name) / "dupe.json"
+        path.write_text(json.dumps({"fleet": [FLEET["fleet"][0],
+                                              FLEET["fleet"][0]]}))
+        with self.assertRaises(ValueError):
+            load_fleet(path)
+
+    def test_a_missing_field_names_itself(self):
+        with self.assertRaises(ValueError) as caught:
+            entry_from_dict({"sku": "ps5"})
+        self.assertIn("unit_id", str(caught.exception))
+
+    def test_round_trip_through_save(self):
+        original = load_fleet(self.path)
+        out = Path(self.dir.name) / "out.json"
+        save_fleet(out, original)
+        again = {e.unit.unit_id: e.unit for e in load_fleet(out)}
+        self.assertEqual(again["ps5-02"].downbin.reasons,
+                         ("dead GDDR6 package", "fan replaced"))
+        self.assertEqual(again["xsx-01"].labels, {"rack": "b", "slot": "4"})
+        self.assertEqual(again["xsx-01"].runtime, Runtime.XBOX_DEVMODE)
+
+
+class TestSyntheticFleet(unittest.TestCase):
+    def test_counts_are_honoured_and_ids_are_unique(self):
+        fleet = synthetic_fleet({"ps5": 3, "xbox-series-s": 2})
+        self.assertEqual(len(fleet), 5)
+        self.assertEqual(len({e.unit.unit_id for e in fleet}), 5)
+        self.assertEqual(len({e.port for e in fleet}), 5)
+
+
+class TestDeploymentConfig(InventoryFile):
+    def test_each_console_is_told_only_its_own_shards(self):
+        fleet = load_fleet(self.path)
+        plan = plan_split(DEEPSEEK_TINY, units(fleet), context_tokens=512)
+        config = deployment_config(plan, fleet)
+        self.assertEqual(set(config["nodes"]), set(plan.units))
+        for unit_id, node in config["nodes"].items():
+            self.assertEqual(node["host"],
+                             {e.unit.unit_id: e.host for e in fleet}[unit_id])
+            for shard in node["shards"]:
+                self.assertEqual(shard["unit_id"], unit_id)
+
+    def test_the_config_is_json_serialisable(self):
+        fleet = load_fleet(self.path)
+        plan = plan_split(DEEPSEEK_TINY, units(fleet), context_tokens=512)
+        json.dumps(deployment_config(plan, fleet))
+
+    def test_an_assumed_model_is_marked_in_the_deployment(self):
+        fleet = load_fleet(self.path)
+        plan = plan_split(DEEPSEEK_TINY, units(fleet), context_tokens=512)
+        self.assertIn("model_assumed", deployment_config(plan, fleet))
+
+
+class TestCLI(InventoryFile):
+    def run_cli(self, *argv):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = main(list(argv))
+        return code, buffer.getvalue()
+
+    def test_model_sizes_a_profile(self):
+        code, out = self.run_cli("model", "--model", "deepseek-v3")
+        self.assertEqual(code, 0)
+        self.assertIn("deepseek-v3", out)
+
+    def test_plan_places_a_model_on_the_inventory(self):
+        code, out = self.run_cli("plan", str(self.path), "--model",
+                                 "deepseek-tiny", "--context", "512")
+        self.assertEqual(code, 0)
+        self.assertIn("shelves", out)
+        self.assertIn("bc-01", out)
+
+    def test_plan_can_write_a_deployment_config(self):
+        target = Path(self.dir.name) / "cluster.json"
+        code, _ = self.run_cli("plan", str(self.path), "--model",
+                               "deepseek-tiny", "--config", str(target))
+        self.assertEqual(code, 0)
+        self.assertIn("nodes", json.loads(target.read_text()))
+
+    def test_plan_reports_an_impossible_fleet_without_a_traceback(self):
+        small = Path(self.dir.name) / "one.json"
+        small.write_text(json.dumps({"fleet": [FLEET["fleet"][0]]}))
+        code, _ = self.run_cli("plan", str(small), "--model",
+                               "deepseek-v4-pro", "--no-ssd")
+        self.assertEqual(code, 1)
+
+    def test_size_answers_how_many_consoles(self):
+        code, out = self.run_cli("size", "--model", "deepseek-tiny", "--ps5",
+                                 "4")
+        self.assertEqual(code, 0)
+        self.assertIn("4 x ps5", out)
+
+    def test_size_without_counts_is_a_usage_error(self):
+        code, _ = self.run_cli("size", "--model", "deepseek-tiny")
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_model.py
+++ b/gen9-cluster/tests/test_model.py
@@ -1,0 +1,114 @@
+"""Model sizing: the arithmetic that decides how many consoles are needed."""
+
+import unittest
+
+from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_PRO,
+                                PROFILES, profile_for)
+
+GB = 1024 ** 3
+
+
+class TestV3AgainstPublishedFigures(unittest.TestCase):
+    """V3 is the calibration case: its parameter counts are published, so if the
+    sizing arithmetic is wrong it is wrong here, visibly."""
+
+    def test_total_parameters_match_the_published_671b(self):
+        total = DEEPSEEK_V3.total_params()
+        self.assertAlmostEqual(total / 1e9, 671.0, delta=15.0)
+
+    def test_activated_parameters_match_the_published_37b(self):
+        self.assertAlmostEqual(DEEPSEEK_V3.activated_params() / 1e9, 37.0,
+                               delta=2.0)
+
+    def test_fp8_weights_are_about_a_byte_per_parameter(self):
+        """The block scales add ~3%; anything far off that means the scale
+        accounting is broken."""
+        ratio = DEEPSEEK_V3.total_bytes() / DEEPSEEK_V3.total_params()
+        self.assertGreater(ratio, 1.0)
+        self.assertLess(ratio, 1.10)
+
+    def test_routed_experts_dominate_the_checkpoint(self):
+        """~95% of the weights are experts that a given token does not touch.
+        This ratio is the entire reason a console fleet is viable."""
+        cold = DEEPSEEK_V3.cold_bytes_per_moe_layer()
+        hot = DEEPSEEK_V3.hot_bytes_per_moe_layer()
+        self.assertGreater(cold / (cold + hot), 0.9)
+
+
+class TestMLAKVCache(unittest.TestCase):
+    def test_mla_cache_is_far_smaller_than_a_plain_kv_cache(self):
+        """MLA caches one 512-wide latent per layer instead of 128 heads of
+        keys and values; on a console that is the difference between a usable
+        context and none."""
+        mla = DEEPSEEK_V3.kv_cache_bytes(8192)
+        mha = (2 * DEEPSEEK_V3.n_layers * 8192 * DEEPSEEK_V3.mla.n_heads
+               * (DEEPSEEK_V3.mla.qk_nope_head_dim
+                  + DEEPSEEK_V3.mla.qk_rope_head_dim) * 2)
+        self.assertLess(mla * 20, mha)
+
+    def test_the_cache_grows_linearly_with_context(self):
+        self.assertAlmostEqual(DEEPSEEK_V3.kv_cache_bytes(16384)
+                               / DEEPSEEK_V3.kv_cache_bytes(8192), 2.0,
+                               places=3)
+
+    def test_a_console_sized_context_fits_in_a_coffer(self):
+        self.assertLess(DEEPSEEK_V3.kv_cache_bytes(8192), 2 * GB)
+
+
+class TestV4ProAssumption(unittest.TestCase):
+    """V4 Pro has no public configuration. The profile must say so everywhere
+    it can, because every number downstream inherits the uncertainty."""
+
+    def test_the_profile_is_flagged_as_assumed(self):
+        self.assertTrue(DEEPSEEK_V4_PRO.assumed)
+        self.assertFalse(DEEPSEEK_V3.assumed)
+
+    def test_it_carries_its_reasoning(self):
+        self.assertTrue(DEEPSEEK_V4_PRO.assumptions)
+        joined = " ".join(DEEPSEEK_V4_PRO.assumptions).lower()
+        self.assertIn("no deepseek v4 pro configuration is public", joined)
+
+    def test_it_is_larger_than_v3_but_the_same_family(self):
+        self.assertGreater(DEEPSEEK_V4_PRO.total_bytes(),
+                           DEEPSEEK_V3.total_bytes())
+        self.assertEqual(DEEPSEEK_V4_PRO.moe.top_k, 8)
+        self.assertEqual(DEEPSEEK_V4_PRO.dtype, "fp8")
+
+    def test_an_expert_stays_small_enough_to_place(self):
+        """Placement granularity is one expert. If an expert did not fit in a
+        console's fast coffer with room for anything else, the whole
+        shelf-and-shard scheme would collapse to layer-level pipelining."""
+        self.assertLess(DEEPSEEK_V4_PRO.expert_bytes(), 64 * 1024 * 1024)
+
+
+class TestPlanningLayers(unittest.TestCase):
+    def test_mtp_heads_are_schedulable_blocks(self):
+        """An MTP head is a decoder block. Treating it as one lump of I/O sent
+        it to NVMe as a unit; counting it as a block lets it be placed."""
+        self.assertEqual(DEEPSEEK_V4_PRO.planning_layers,
+                         DEEPSEEK_V4_PRO.n_layers + DEEPSEEK_V4_PRO.n_mtp_heads)
+
+    def test_an_mtp_block_costs_about_what_a_layer_costs(self):
+        layer = (DEEPSEEK_V4_PRO.hot_bytes_per_moe_layer()
+                 + DEEPSEEK_V4_PRO.cold_bytes_per_moe_layer())
+        mtp = DEEPSEEK_V4_PRO.mtp_bytes() / DEEPSEEK_V4_PRO.n_mtp_heads
+        self.assertGreater(mtp, layer * 0.5)
+
+
+class TestProfileRegistry(unittest.TestCase):
+    def test_named_lookup(self):
+        self.assertIs(profile_for("deepseek-v3"), DEEPSEEK_V3)
+        self.assertIs(profile_for("deepseek-v4-pro"), DEEPSEEK_V4_PRO)
+
+    def test_unknown_names_say_what_is_available(self):
+        with self.assertRaises(KeyError) as caught:
+            profile_for("gpt-5")
+        self.assertIn("deepseek-v3", str(caught.exception))
+
+    def test_the_tiny_profile_is_small_enough_for_tests(self):
+        self.assertLess(DEEPSEEK_TINY.total_bytes(), GB)
+        self.assertIn(DEEPSEEK_TINY.name, PROFILES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_model.py
+++ b/gen9-cluster/tests/test_model.py
@@ -2,10 +2,11 @@
 
 import unittest
 
-from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_PRO,
-                                PROFILES, profile_for)
+from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_FLASH,
+                                DEEPSEEK_V4_PRO, MXFP4, PROFILES, profile_for)
 
 GB = 1024 ** 3
+MB = 1024 ** 2
 
 
 class TestV3AgainstPublishedFigures(unittest.TestCase):
@@ -13,19 +14,22 @@ class TestV3AgainstPublishedFigures(unittest.TestCase):
     sizing arithmetic is wrong it is wrong here, visibly."""
 
     def test_total_parameters_match_the_published_671b(self):
-        total = DEEPSEEK_V3.total_params()
-        self.assertAlmostEqual(total / 1e9, 671.0, delta=15.0)
+        """The card's figure excludes the MTP head, which the fleet still has
+        to store; both numbers have to come out right."""
+        self.assertAlmostEqual(DEEPSEEK_V3.total_params(include_mtp=False) / 1e9,
+                               671.0, delta=8.0)
+        self.assertGreater(DEEPSEEK_V3.total_params(), 671e9)
 
     def test_activated_parameters_match_the_published_37b(self):
         self.assertAlmostEqual(DEEPSEEK_V3.activated_params() / 1e9, 37.0,
                                delta=2.0)
 
     def test_fp8_weights_are_about_a_byte_per_parameter(self):
-        """The block scales add ~3%; anything far off that means the scale
-        accounting is broken."""
+        """An fp32 scale per 128x128 tile is 0.02%, not the 3% you get if you
+        mistake the tile for a 128-element vector."""
         ratio = DEEPSEEK_V3.total_bytes() / DEEPSEEK_V3.total_params()
         self.assertGreater(ratio, 1.0)
-        self.assertLess(ratio, 1.10)
+        self.assertLess(ratio, 1.02)
 
     def test_routed_experts_dominate_the_checkpoint(self):
         """~95% of the weights are experts that a given token does not touch.
@@ -41,9 +45,9 @@ class TestMLAKVCache(unittest.TestCase):
         keys and values; on a console that is the difference between a usable
         context and none."""
         mla = DEEPSEEK_V3.kv_cache_bytes(8192)
-        mha = (2 * DEEPSEEK_V3.n_layers * 8192 * DEEPSEEK_V3.mla.n_heads
-               * (DEEPSEEK_V3.mla.qk_nope_head_dim
-                  + DEEPSEEK_V3.mla.qk_rope_head_dim) * 2)
+        mha = (2 * DEEPSEEK_V3.n_layers * 8192 * DEEPSEEK_V3.attention.n_heads
+               * (DEEPSEEK_V3.attention.qk_nope_head_dim
+                  + DEEPSEEK_V3.attention.qk_rope_head_dim) * 2)
         self.assertLess(mla * 20, mha)
 
     def test_the_cache_grows_linearly_with_context(self):
@@ -55,30 +59,126 @@ class TestMLAKVCache(unittest.TestCase):
         self.assertLess(DEEPSEEK_V3.kv_cache_bytes(8192), 2 * GB)
 
 
-class TestV4ProAssumption(unittest.TestCase):
-    """V4 Pro has no public configuration. The profile must say so everywhere
-    it can, because every number downstream inherits the uncertainty."""
+class TestV4AgainstPublishedFigures(unittest.TestCase):
+    """Both V4 configurations are public, so the profiles are checked against
+    the cards rather than flagged as guesses."""
 
-    def test_the_profile_is_flagged_as_assumed(self):
-        self.assertTrue(DEEPSEEK_V4_PRO.assumed)
-        self.assertFalse(DEEPSEEK_V3.assumed)
+    def test_pro_matches_the_published_1_6t_and_49b(self):
+        self.assertAlmostEqual(DEEPSEEK_V4_PRO.total_params() / 1e12, 1.6,
+                               delta=0.05)
+        self.assertAlmostEqual(DEEPSEEK_V4_PRO.activated_params() / 1e9, 49.0,
+                               delta=2.0)
 
-    def test_it_carries_its_reasoning(self):
-        self.assertTrue(DEEPSEEK_V4_PRO.assumptions)
-        joined = " ".join(DEEPSEEK_V4_PRO.assumptions).lower()
-        self.assertIn("no deepseek v4 pro configuration is public", joined)
+    def test_flash_matches_the_published_284b_and_13b(self):
+        self.assertAlmostEqual(
+            DEEPSEEK_V4_FLASH.total_params(include_mtp=False) / 1e9, 284.0,
+            delta=6.0)
+        self.assertAlmostEqual(DEEPSEEK_V4_FLASH.activated_params() / 1e9, 13.0,
+                               delta=1.0)
 
-    def test_it_is_larger_than_v3_but_the_same_family(self):
-        self.assertGreater(DEEPSEEK_V4_PRO.total_bytes(),
-                           DEEPSEEK_V3.total_bytes())
-        self.assertEqual(DEEPSEEK_V4_PRO.moe.top_k, 8)
-        self.assertEqual(DEEPSEEK_V4_PRO.dtype, "fp8")
+    def test_neither_is_flagged_as_assumed(self):
+        for profile in (DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH):
+            self.assertFalse(profile.assumed)
+            self.assertFalse(profile.assumptions)
+            self.assertIn("config.json", profile.source)
+
+    def test_experts_are_fp4_and_everything_else_is_fp8(self):
+        """Where the bytes went: dropping only the experts to MXFP4 takes the
+        checkpoint to roughly half a byte per parameter, and it is the single
+        biggest term in how many consoles a fleet needs."""
+        for profile in (DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH):
+            self.assertTrue(profile.mixed_precision)
+            self.assertEqual(profile.expert_quant, MXFP4)
+            self.assertEqual(profile.dtype, "fp8")
+            ratio = profile.total_bytes() / profile.total_params()
+            self.assertGreater(ratio, 0.5)
+            self.assertLess(ratio, 0.6)
+
+    def test_mxfp4_carries_its_scales(self):
+        """E2M1 is half a byte; the E8M0 scale per 32 values adds 6.25%, and
+        forgetting it under-counts a fleet by a console per shelf."""
+        self.assertAlmostEqual(MXFP4.bytes_per_param, 0.53125, places=5)
+
+    def test_pro_is_smaller_on_disk_than_v3_despite_being_larger(self):
+        """The headline result of FP4 experts, and the reason the fleet size
+        for V4 Pro is not simply V3's scaled by parameter count."""
+        self.assertGreater(DEEPSEEK_V4_PRO.total_params(),
+                           2 * DEEPSEEK_V3.total_params())
+        self.assertLess(DEEPSEEK_V4_PRO.total_bytes(),
+                        1.5 * DEEPSEEK_V3.total_bytes())
 
     def test_an_expert_stays_small_enough_to_place(self):
         """Placement granularity is one expert. If an expert did not fit in a
         console's fast coffer with room for anything else, the whole
         shelf-and-shard scheme would collapse to layer-level pipelining."""
-        self.assertLess(DEEPSEEK_V4_PRO.expert_bytes(), 64 * 1024 * 1024)
+        self.assertLess(DEEPSEEK_V4_PRO.expert_bytes(), 64 * MB)
+        self.assertLess(DEEPSEEK_V4_FLASH.expert_bytes(), 64 * MB)
+
+
+class TestHybridAttention(unittest.TestCase):
+    """CSA and HCA differ by a factor of 32 in cache size and by far more in
+    what a decoded token reads. Modelling them as one average layer is what the
+    planner used to do and it is wrong in both directions at once."""
+
+    def test_the_schedule_covers_every_block_including_mtp(self):
+        for profile in (DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH):
+            self.assertEqual(len(profile.attention.compress_ratios),
+                             profile.planning_layers)
+
+    def test_pro_starts_with_hca_and_flash_with_sliding_window(self):
+        self.assertEqual(DEEPSEEK_V4_PRO.attention.kind(0), "hca")
+        self.assertEqual(DEEPSEEK_V4_PRO.attention.kind(1), "hca")
+        self.assertEqual(DEEPSEEK_V4_FLASH.attention.kind(0), "swa")
+        self.assertEqual(DEEPSEEK_V4_FLASH.attention.kind(1), "swa")
+
+    def test_layers_alternate_after_the_prologue(self):
+        kinds = [DEEPSEEK_V4_PRO.attention.kind(i) for i in range(2, 20)]
+        self.assertEqual(kinds, ["csa", "hca"] * 9)
+
+    def test_an_hca_layer_caches_far_less_than_a_csa_layer(self):
+        csa = DEEPSEEK_V4_PRO.kv_cache_bytes_for_layer(2, 1_000_000)
+        hca = DEEPSEEK_V4_PRO.kv_cache_bytes_for_layer(3, 1_000_000)
+        self.assertGreater(csa / hca, 20)
+
+    def test_a_sliding_window_layer_does_not_grow_with_context(self):
+        short = DEEPSEEK_V4_FLASH.kv_cache_bytes_for_layer(0, 4096)
+        long = DEEPSEEK_V4_FLASH.kv_cache_bytes_for_layer(0, 1_000_000)
+        self.assertEqual(short, long)
+
+    def test_csa_reads_only_its_selected_entries(self):
+        """Sparse selection is the whole point: at a million tokens a CSA layer
+        holds far more cache than it reads, which is why long context costs
+        capacity here rather than bandwidth."""
+        held = DEEPSEEK_V4_PRO.kv_cache_bytes_for_layer(2, 1_000_000)
+        read = DEEPSEEK_V4_PRO.kv_read_bytes_for_layer(2, 1_000_000)
+        self.assertLess(read * 4, held)
+
+    def test_short_contexts_read_everything_they_hold(self):
+        """Below the indexer's top-k there is nothing to select away, so the
+        sparse path must not claim a saving it is not making."""
+        held = DEEPSEEK_V4_PRO.kv_cache_bytes_for_layer(2, 2048)
+        read = DEEPSEEK_V4_PRO.kv_read_bytes_for_layer(2, 2048)
+        self.assertGreaterEqual(read, held * 0.9)
+
+    def test_the_whole_cache_is_a_tenth_of_v3s(self):
+        """The paper's claim, at the context it is claimed for."""
+        v4 = DEEPSEEK_V4_PRO.kv_cache_bytes(1_000_000)
+        v3 = DEEPSEEK_V3.kv_cache_bytes(1_000_000)
+        self.assertLess(v4 / v3, 0.15)
+
+
+class TestHyperConnections(unittest.TestCase):
+    def test_a_shelf_hop_carries_the_whole_residual_stream(self):
+        """mHC widens the residual to 4x hidden. The layer input stays hidden-
+        wide, but a pipeline boundary has to ship every branch, so the wire
+        cost of a shelf hop is four times what the hidden size suggests."""
+        self.assertEqual(DEEPSEEK_V4_PRO.hc_mult, 4)
+        self.assertEqual(DEEPSEEK_V4_PRO.activation_bytes(),
+                         4 * DEEPSEEK_V4_PRO.hidden_size * 2)
+
+    def test_v3_has_a_plain_residual(self):
+        self.assertEqual(DEEPSEEK_V3.activation_bytes(),
+                         DEEPSEEK_V3.hidden_size * 2)
 
 
 class TestPlanningLayers(unittest.TestCase):
@@ -99,6 +199,7 @@ class TestProfileRegistry(unittest.TestCase):
     def test_named_lookup(self):
         self.assertIs(profile_for("deepseek-v3"), DEEPSEEK_V3)
         self.assertIs(profile_for("deepseek-v4-pro"), DEEPSEEK_V4_PRO)
+        self.assertIs(profile_for("deepseek-v4-flash"), DEEPSEEK_V4_FLASH)
 
     def test_unknown_names_say_what_is_available(self):
         with self.assertRaises(KeyError) as caught:

--- a/gen9-cluster/tests/test_planner.py
+++ b/gen9-cluster/tests/test_planner.py
@@ -1,10 +1,17 @@
 """The splitter: which console holds what, and whether it fits at all."""
 
+import dataclasses
 import unittest
 
 from gen9_cluster.hardware import GB, ConsoleUnit, Downbin, Runtime
 from gen9_cluster.model import DEEPSEEK_TINY, DEEPSEEK_V4_PRO
 from gen9_cluster.planner import PlanningError, describe_plan, plan_split
+
+#: A hypothetical unpublished model, for the paths that have to keep warning
+#: about extrapolated configurations now that both V4 profiles are published.
+ASSUMED_MODEL = dataclasses.replace(
+    DEEPSEEK_V4_PRO, name="deepseek-v5-guess", assumed=True,
+    assumptions=("nothing about this model is published",))
 
 
 def ps5_fleet(count, **kwargs):
@@ -33,9 +40,9 @@ class TestFeasibility(unittest.TestCase):
         self.assertTrue(any("nvme" in w.lower() or "ssd" in w.lower()
                             for w in plan.warnings))
 
-    def test_without_ssd_the_same_fleet_is_rejected(self):
+    def test_without_ssd_a_tight_fleet_is_rejected(self):
         with self.assertRaises(PlanningError):
-            plan_split(DEEPSEEK_V4_PRO, ps5_fleet(100), allow_ssd_tier=False)
+            plan_split(DEEPSEEK_V4_PRO, ps5_fleet(70), allow_ssd_tier=False)
 
 
 class TestShelves(unittest.TestCase):
@@ -148,9 +155,14 @@ class TestEstimates(unittest.TestCase):
         self.assertLess(tight.tokens_per_second, roomy.tokens_per_second)
 
     def test_an_assumed_model_taints_the_plan(self):
-        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        plan = plan_split(ASSUMED_MODEL, ps5_fleet(160))
         self.assertTrue(plan.model_assumed)
         self.assertTrue(any("assum" in w.lower() for w in plan.warnings))
+
+    def test_a_published_model_does_not(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertFalse(plan.model_assumed)
+        self.assertFalse(any("assum" in w.lower() for w in plan.warnings))
 
 
 class TestDescription(unittest.TestCase):
@@ -159,7 +171,10 @@ class TestDescription(unittest.TestCase):
         text = "\n".join(describe_plan(plan))
         self.assertIn("shelves", text)
         self.assertIn("tok/s", text)
-        self.assertIn("ASSUMED", text)
+
+    def test_an_assumed_model_says_so_in_the_summary(self):
+        plan = plan_split(ASSUMED_MODEL, ps5_fleet(160))
+        self.assertIn("ASSUMED", "\n".join(describe_plan(plan)))
 
 
 if __name__ == "__main__":

--- a/gen9-cluster/tests/test_planner.py
+++ b/gen9-cluster/tests/test_planner.py
@@ -1,0 +1,166 @@
+"""The splitter: which console holds what, and whether it fits at all."""
+
+import unittest
+
+from gen9_cluster.hardware import GB, ConsoleUnit, Downbin, Runtime
+from gen9_cluster.model import DEEPSEEK_TINY, DEEPSEEK_V4_PRO
+from gen9_cluster.planner import PlanningError, describe_plan, plan_split
+
+
+def ps5_fleet(count, **kwargs):
+    return [ConsoleUnit(f"ps5-{i:03d}", "ps5", Runtime.PS5_LINUX, **kwargs)
+            for i in range(count)]
+
+
+class TestFeasibility(unittest.TestCase):
+    def test_one_console_cannot_hold_a_frontier_model(self):
+        """16 GB against ~1.3 TiB. The planner must refuse rather than emit a
+        plan that silently drops most of the weights."""
+        with self.assertRaises(PlanningError):
+            plan_split(DEEPSEEK_V4_PRO, ps5_fleet(1), allow_ssd_tier=False)
+
+    def test_a_large_fleet_hosts_it(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertTrue(plan.feasible)
+        self.assertEqual(plan.shortfall_bytes, 0)
+
+    def test_slow_is_not_infeasible(self):
+        """A deployment that has to stream experts off NVMe is bad, not
+        impossible; the planner reports it and continues."""
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(100), allow_ssd_tier=True)
+        self.assertTrue(plan.feasible)
+        self.assertGreater(plan.ssd_expert_bytes, 0)
+        self.assertTrue(any("nvme" in w.lower() or "ssd" in w.lower()
+                            for w in plan.warnings))
+
+    def test_without_ssd_the_same_fleet_is_rejected(self):
+        with self.assertRaises(PlanningError):
+            plan_split(DEEPSEEK_V4_PRO, ps5_fleet(100), allow_ssd_tier=False)
+
+
+class TestShelves(unittest.TestCase):
+    """A shelf is the expert fan-out group: a token's top-k should be answered
+    without leaving it, because leaving it costs a network hop."""
+
+    def test_a_small_fleet_is_one_shelf(self):
+        plan = plan_split(DEEPSEEK_TINY, ps5_fleet(4), shelf_size=22)
+        self.assertEqual(len(plan.stages), 1)
+
+    def test_a_large_fleet_is_divided_by_shelf_size(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160), shelf_size=22)
+        self.assertEqual(len(plan.stages), 8)
+
+    def test_every_block_is_hosted_exactly_once(self):
+        """The pipeline must be a partition: a missing block is a wrong answer
+        and a duplicated one is wasted memory."""
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        hosted = [layer for stage in plan.stages for layer in stage.layers]
+        self.assertEqual(sorted(hosted), list(range(len(hosted))))
+        self.assertEqual(len(hosted), DEEPSEEK_V4_PRO.planning_layers)
+
+    def test_ranges_are_contiguous_and_in_order(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        cursor = 0
+        for stage in plan.stages:
+            self.assertEqual(stage.first_layer, cursor)
+            cursor += stage.n_layers
+
+    def test_crossing_shelves_is_counted_and_warned_about(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160), shelf_size=22)
+        self.assertTrue(any("crosses the network" in w.lower()
+                            for w in plan.warnings))
+
+
+class TestPlacement(unittest.TestCase):
+    def test_experts_stay_on_their_own_shelf(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160), shelf_size=22)
+        for stage in plan.stages:
+            members = set(stage.expert_units)
+            for layer in stage.layers:
+                holders = {shard.unit_id for unit in plan.units.values()
+                           for shard in unit.shards if shard.layer == layer}
+                self.assertTrue(holders <= members,
+                                f"layer {layer} spilled off its shelf")
+
+    def test_every_expert_of_every_moe_layer_is_placed_once(self):
+        plan = plan_split(DEEPSEEK_TINY, ps5_fleet(4))
+        for layer in range(DEEPSEEK_TINY.moe.n_dense_layers,
+                           DEEPSEEK_TINY.n_layers):
+            placed = sorted(e for unit in plan.units.values()
+                            for shard in unit.shards if shard.layer == layer
+                            for e in shard.expert_ids)
+            self.assertEqual(placed,
+                             list(range(DEEPSEEK_TINY.moe.n_routed_experts)),
+                             f"layer {layer}")
+
+    def test_nothing_is_placed_beyond_a_console_capacity(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        for unit in plan.units.values():
+            resident = unit.resident_bytes - unit.ssd_expert_bytes
+            self.assertLessEqual(resident, unit.capacity_bytes, unit.unit_id)
+
+    def test_a_faster_console_is_given_more_experts(self):
+        """Allocation is throughput-weighted, not equal: giving a crippled
+        console its 'fair share' makes it the tail latency of every token."""
+        fleet = ps5_fleet(3) + [
+            ConsoleUnit("ps5-slow", "ps5", Runtime.PS5_LINUX,
+                        downbin=Downbin(cu_disabled=30,
+                                        tier_bandwidth_scale={"gddr6": 0.25},
+                                        reasons=("degraded",)))]
+        plan = plan_split(DEEPSEEK_TINY, fleet)
+        counts = {uid: sum(s.n_experts for s in u.shards)
+                  for uid, u in plan.units.items()}
+        self.assertLess(counts["ps5-slow"], max(counts.values()))
+
+    def test_the_shelf_host_holds_the_hot_weights(self):
+        plan = plan_split(DEEPSEEK_TINY, ps5_fleet(4))
+        for stage in plan.stages:
+            host = plan.units[stage.host_unit]
+            self.assertEqual(sorted(host.hot_layers + host.dense_layers),
+                             sorted(stage.layers))
+            self.assertGreater(host.kv_bytes, 0)
+
+    def test_a_devmode_xbox_is_not_asked_to_hold_more_than_its_sandbox(self):
+        fleet = ps5_fleet(3) + [ConsoleUnit("xsx-dev", "xbox-series-x",
+                                            Runtime.XBOX_DEVMODE)]
+        plan = plan_split(DEEPSEEK_TINY, fleet)
+        sandboxed = plan.units["xsx-dev"]
+        self.assertLessEqual(sandboxed.resident_bytes - sandboxed.ssd_expert_bytes,
+                             5 * GB)
+
+
+class TestEstimates(unittest.TestCase):
+    def test_the_estimate_is_positive_and_slow(self):
+        """It is a bandwidth-and-hops arithmetic model, not a benchmark. It
+        should land in single-digit tokens per second, which is the honest
+        expectation for this hardware."""
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertGreater(plan.tokens_per_second, 0.0)
+        self.assertLess(plan.tokens_per_second, 100.0)
+
+    def test_only_a_fraction_of_the_fleet_is_lit_per_token(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertLess(plan.active_units_per_token, len(plan.units))
+
+    def test_ssd_streaming_shows_up_as_a_slowdown(self):
+        tight = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(100))
+        roomy = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertLess(tight.tokens_per_second, roomy.tokens_per_second)
+
+    def test_an_assumed_model_taints_the_plan(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        self.assertTrue(plan.model_assumed)
+        self.assertTrue(any("assum" in w.lower() for w in plan.warnings))
+
+
+class TestDescription(unittest.TestCase):
+    def test_the_summary_names_the_things_an_operator_must_act_on(self):
+        plan = plan_split(DEEPSEEK_V4_PRO, ps5_fleet(160))
+        text = "\n".join(describe_plan(plan))
+        self.assertIn("shelves", text)
+        self.assertIn("tok/s", text)
+        self.assertIn("ASSUMED", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_protocol.py
+++ b/gen9-cluster/tests/test_protocol.py
@@ -1,0 +1,168 @@
+"""G9XC framing: round trips, and the malformed frames a network will produce."""
+
+import struct
+import unittest
+
+import numpy as np
+
+from gen9_cluster.protocol import (HEADER_SIZE, MAX_PAYLOAD, VERSION,
+                                   DType, ExpertBatchPayload, Flags, Frame,
+                                   HelloPayload, MsgType, ShardHeader,
+                                   decode_error, decode_vector, encode_error,
+                                   encode_vector)
+
+
+class TestFrame(unittest.TestCase):
+    def test_header_is_fixed_width(self):
+        """A fixed header is what lets the reader do exactly two recvs per
+        frame instead of parsing a stream."""
+        self.assertEqual(HEADER_SIZE, 32)
+        raw = Frame(MsgType.PING, 1).encode()
+        self.assertEqual(len(raw), HEADER_SIZE)
+
+    def test_round_trip_preserves_every_field(self):
+        frame = Frame(MsgType.EXPERT_BATCH, request_id=0xDEADBEEF,
+                      payload=b"body", layer=37, expert=291, token=1234,
+                      dtype=DType.FP8_E4M3_B128, flags=Flags.FROM_STORAGE,
+                      rank=5)
+        decoded, length = Frame.decode_header(frame.encode()[:HEADER_SIZE])
+        self.assertEqual(length, 4)
+        self.assertEqual(decoded.msg_type, MsgType.EXPERT_BATCH)
+        self.assertEqual(decoded.request_id, 0xDEADBEEF)
+        self.assertEqual(decoded.layer, 37)
+        self.assertEqual(decoded.expert, 291)
+        self.assertEqual(decoded.token, 1234)
+        self.assertEqual(decoded.dtype, DType.FP8_E4M3_B128)
+        self.assertEqual(decoded.flags, Flags.FROM_STORAGE)
+        self.assertEqual(decoded.rank, 5)
+
+    def test_request_ids_survive_the_full_32_bit_range(self):
+        """Correlation breaks silently if the id is truncated, and a truncated
+        id means a reply delivered to the wrong caller."""
+        for rid in (0, 1, 0x7FFFFFFF, 0xFFFFFFFF):
+            decoded, _ = Frame.decode_header(
+                Frame(MsgType.PONG, rid).encode()[:HEADER_SIZE])
+            self.assertEqual(decoded.request_id, rid)
+
+    def test_a_wrong_magic_is_rejected(self):
+        raw = bytearray(Frame(MsgType.PING, 1).encode())
+        raw[0:4] = b"XXXX"
+        with self.assertRaises(ValueError):
+            Frame.decode_header(bytes(raw))
+
+    def test_a_wrong_version_is_rejected(self):
+        raw = bytearray(Frame(MsgType.PING, 1).encode())
+        raw[4] = VERSION + 7
+        with self.assertRaises(ValueError):
+            Frame.decode_header(bytes(raw))
+
+    def test_a_short_header_is_rejected(self):
+        with self.assertRaises(ValueError):
+            Frame.decode_header(Frame(MsgType.PING, 1).encode()[:20])
+
+    def test_an_oversized_payload_is_rejected_rather_than_allocated(self):
+        """Trusting a length field is how a peer turns a bad frame into an OOM
+        on every console at once."""
+        raw = bytearray(Frame(MsgType.PING, 1).encode())
+        struct.pack_into("<I", raw, 24, MAX_PAYLOAD + 1)
+        with self.assertRaises(ValueError):
+            Frame.decode_header(bytes(raw))
+
+    def test_an_unknown_message_type_is_rejected(self):
+        raw = bytearray(Frame(MsgType.PING, 1).encode())
+        raw[5] = 200
+        with self.assertRaises(ValueError):
+            Frame.decode_header(bytes(raw))
+
+
+class TestVectors(unittest.TestCase):
+    def test_activation_round_trip(self):
+        vec = np.arange(128, dtype=np.float32) * 0.25
+        np.testing.assert_array_equal(decode_vector(encode_vector(vec)), vec)
+
+    def test_non_float32_input_is_converted(self):
+        vec = np.arange(8, dtype=np.float64)
+        np.testing.assert_allclose(decode_vector(encode_vector(vec)), vec)
+
+
+class TestExpertBatch(unittest.TestCase):
+    def test_round_trip(self):
+        payload = ExpertBatchPayload(
+            expert_ids=(3, 17, 256, 4095),
+            gates=(0.5, 0.25, 0.125, 0.125),
+            activation=np.linspace(-1, 1, 64, dtype=np.float32))
+        decoded = ExpertBatchPayload.decode(payload.encode())
+        self.assertEqual(decoded.expert_ids, payload.expert_ids)
+        np.testing.assert_allclose(decoded.gates, payload.gates, rtol=1e-6)
+        np.testing.assert_allclose(decoded.activation, payload.activation)
+
+    def test_one_message_carries_the_whole_top_k(self):
+        """Eight experts on one console is one round trip, not eight."""
+        payload = ExpertBatchPayload(tuple(range(8)), (0.125,) * 8,
+                                     np.zeros(7168, dtype=np.float32))
+        decoded = ExpertBatchPayload.decode(payload.encode())
+        self.assertEqual(len(decoded.expert_ids), 8)
+
+    def test_truncated_payloads_are_rejected(self):
+        raw = ExpertBatchPayload((1, 2), (0.5, 0.5),
+                                 np.zeros(16, dtype=np.float32)).encode()
+        for cut in (4, len(raw) // 2, len(raw) - 4):
+            with self.assertRaises(ValueError):
+                ExpertBatchPayload.decode(raw[:cut])
+
+    def test_mismatched_gates_are_refused_at_construction(self):
+        with self.assertRaises(ValueError):
+            ExpertBatchPayload((1, 2, 3), (0.5, 0.5),
+                               np.zeros(4, dtype=np.float32)).encode()
+
+
+class TestShardHeader(unittest.TestCase):
+    def test_fp8_shard_round_trip(self):
+        header = ShardHeader(layer=12, first_expert=64, n_experts=8,
+                             hidden_size=7168, intermediate_size=2048,
+                             dtype=DType.FP8_E4M3_B128, tier="ssd")
+        decoded, offset = ShardHeader.decode(header.encode())
+        self.assertEqual(offset, len(header.encode()))
+        self.assertEqual(decoded.layer, 12)
+        self.assertEqual(decoded.first_expert, 64)
+        self.assertEqual(decoded.n_experts, 8)
+        self.assertEqual(decoded.hidden_size, 7168)
+        self.assertEqual(decoded.intermediate_size, 2048)
+        self.assertEqual(decoded.dtype, DType.FP8_E4M3_B128)
+        self.assertEqual(decoded.tier, "ssd")
+
+    def test_the_body_follows_the_header(self):
+        header = ShardHeader(layer=0, first_expert=0, n_experts=1,
+                             hidden_size=8, intermediate_size=4)
+        blob = header.encode() + b"weights"
+        _, offset = ShardHeader.decode(blob)
+        self.assertEqual(blob[offset:], b"weights")
+
+
+class TestHello(unittest.TestCase):
+    def test_round_trip(self):
+        hello = HelloPayload(unit_id="bc-250-07", sku="bc-250", backend="rocm",
+                             runtime="salvage-linux",
+                             weight_bytes=14 * 1024 ** 3,
+                             fast_bytes=13 * 1024 ** 3, gemv_gflops=940.5)
+        decoded = HelloPayload.decode(hello.encode())
+        self.assertEqual(decoded.unit_id, "bc-250-07")
+        self.assertEqual(decoded.sku, "bc-250")
+        self.assertEqual(decoded.backend, "rocm")
+        self.assertEqual(decoded.runtime, "salvage-linux")
+        self.assertEqual(decoded.weight_bytes, 14 * 1024 ** 3)
+        self.assertAlmostEqual(decoded.gemv_gflops, 940.5, places=1)
+
+
+class TestErrors(unittest.TestCase):
+    def test_round_trip(self):
+        self.assertEqual(decode_error(encode_error("shard 3/17 missing")),
+                         "shard 3/17 missing")
+
+    def test_non_ascii_survives(self):
+        self.assertEqual(decode_error(encode_error("düşük bellek")),
+                         "düşük bellek")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_protocol.py
+++ b/gen9-cluster/tests/test_protocol.py
@@ -5,11 +5,12 @@ import unittest
 
 import numpy as np
 
-from gen9_cluster.protocol import (HEADER_SIZE, MAX_PAYLOAD, VERSION,
-                                   DType, ExpertBatchPayload, Flags, Frame,
+from gen9_cluster.protocol import (HEADER_SIZE, MAX_PAYLOAD, VERSION, _U16,
+                                   _U32, DType, ExpertBatchPayload,
+                                   ExpertRowsPayload, Flags, Frame,
                                    HelloPayload, MsgType, ShardHeader,
-                                   decode_error, decode_vector, encode_error,
-                                   encode_vector)
+                                   accumulate, decode_error, decode_vector,
+                                   encode_error, encode_vector)
 
 
 class TestFrame(unittest.TestCase):
@@ -114,6 +115,87 @@ class TestExpertBatch(unittest.TestCase):
         with self.assertRaises(ValueError):
             ExpertBatchPayload((1, 2, 3), (0.5, 0.5),
                                np.zeros(4, dtype=np.float32)).encode()
+
+    def test_the_batch_id_survives_the_round_trip(self):
+        x = np.zeros(8, dtype=np.float32)
+        with_id = ExpertBatchPayload((1,), (1.0,), x, 2 ** 63 + 5)
+        self.assertEqual(ExpertBatchPayload.decode(with_id.encode()).batch_id,
+                         2 ** 63 + 5)
+        without = ExpertBatchPayload((1,), (1.0,), x)
+        self.assertIsNone(ExpertBatchPayload.decode(without.encode()).batch_id)
+
+    def test_a_batch_id_that_is_not_a_u64_is_refused(self):
+        x = np.zeros(4, dtype=np.float32)
+        for bad in (-1, 2 ** 64):
+            with self.assertRaises(ValueError):
+                ExpertBatchPayload((1,), (1.0,), x, bad).encode()
+
+    def test_a_batch_truncated_inside_its_id_is_rejected(self):
+        raw = ExpertBatchPayload((1,), (1.0,), np.zeros(4, dtype=np.float32),
+                                 99).encode()
+        with self.assertRaises(ValueError):
+            ExpertBatchPayload.decode(raw[:11])
+
+
+class TestExpertRows(unittest.TestCase):
+    def test_round_trip(self):
+        rows = np.arange(12, dtype=np.float32).reshape(3, 4)
+        payload = ExpertRowsPayload((7, 8, 9), rows)
+        decoded = ExpertRowsPayload.decode(payload.encode())
+        self.assertEqual(decoded.expert_ids, (7, 8, 9))
+        np.testing.assert_array_equal(decoded.rows, rows)
+
+    def test_a_row_stays_with_its_expert(self):
+        """The tag is the whole point: the coordinator reorders these, so a
+        row that loses its expert id becomes a term in the wrong place."""
+        rows = np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32)
+        decoded = ExpertRowsPayload.decode(
+            ExpertRowsPayload((41, 5), rows).encode())
+        by_expert = dict(zip(decoded.expert_ids, decoded.rows))
+        np.testing.assert_array_equal(by_expert[41], [1.0, 1.0])
+        np.testing.assert_array_equal(by_expert[5], [2.0, 2.0])
+
+    def test_truncated_payloads_are_rejected(self):
+        raw = ExpertRowsPayload(
+            (1, 2), np.zeros((2, 8), dtype=np.float32)).encode()
+        for cut in (2, len(raw) // 2, len(raw) - 4):
+            with self.assertRaises(ValueError):
+                ExpertRowsPayload.decode(raw[:cut])
+
+    def test_trailing_bytes_are_rejected(self):
+        raw = ExpertRowsPayload(
+            (1,), np.zeros((1, 4), dtype=np.float32)).encode()
+        with self.assertRaises(ValueError):
+            ExpertRowsPayload.decode(raw + b"\x00\x00\x00\x00")
+
+    def test_ids_and_rows_must_agree(self):
+        with self.assertRaises(ValueError):
+            ExpertRowsPayload((1, 2), np.zeros((3, 4), dtype=np.float32))
+
+    def test_an_empty_reply_is_rejected(self):
+        """A batch always names at least one expert, so no rows means the
+        reply is malformed rather than legitimately empty."""
+        with self.assertRaises(ValueError):
+            ExpertRowsPayload.decode(_U16.pack(0) + _U32.pack(4))
+
+
+class TestAccumulate(unittest.TestCase):
+    def test_it_folds_left_to_right(self):
+        """Not np.sum: numpy sums pairwise, which is a different number."""
+        rows = [np.float32([1.0]), np.float32([1e8]), np.float32([-1e8])]
+        # 1 + 1e8 rounds the 1 away, and it never comes back.
+        np.testing.assert_array_equal(accumulate(rows), np.float32([0.0]))
+        np.testing.assert_array_equal(
+            accumulate(list(reversed(rows))), np.float32([1.0]))
+
+    def test_it_does_not_alias_its_first_row(self):
+        first = np.ones(4, dtype=np.float32)
+        accumulate([first, np.ones(4, dtype=np.float32)])
+        np.testing.assert_array_equal(first, np.ones(4, dtype=np.float32))
+
+    def test_nothing_to_add_is_an_error_not_a_zero(self):
+        with self.assertRaises(ValueError):
+            accumulate([])
 
 
 class TestShardHeader(unittest.TestCase):

--- a/gen9-cluster/tests/test_transport.py
+++ b/gen9-cluster/tests/test_transport.py
@@ -1,0 +1,319 @@
+"""Transport and node worker, over real loopback sockets.
+
+These tests open actual TCP connections to an actual :class:`NodeServer`.
+Mocking the socket would test the mock: the behaviours that matter here —
+multiplexing, correlation under concurrency, and what happens when a console
+disappears mid-request — only exist in the real thing.
+"""
+
+import socket
+import threading
+import time
+import unittest
+
+import numpy as np
+
+from gen9_cluster import fp8
+from gen9_cluster.errors import ConnectError, Gen9Error
+from gen9_cluster.node import ExpertWeights, NodeServer, ShardStore
+from gen9_cluster.protocol import (DType, ExpertBatchPayload, Frame, MsgType,
+                                   ShardHeader, decode_vector,
+                                   encode_vector)
+from gen9_cluster.transport import ConnectionPool, NodeConnection
+
+HIDDEN = 16
+INTERMEDIATE = 8
+
+
+def make_expert(seed):
+    rng = np.random.default_rng(seed)
+    return ExpertWeights(
+        gate=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32),
+        up=rng.standard_normal((INTERMEDIATE, HIDDEN), dtype=np.float32),
+        down=rng.standard_normal((HIDDEN, INTERMEDIATE), dtype=np.float32))
+
+
+class NodeFixture(unittest.TestCase):
+    """A running single-console node, torn down after each test."""
+
+    n_experts = 4
+
+    def setUp(self):
+        self.store = ShardStore()
+        for expert in range(self.n_experts):
+            self.store.put(0, expert, make_expert(expert))
+        self.node = NodeServer(self.store, unit_id="ps5-test", host="127.0.0.1",
+                               port=0, sku="ps5", backend="vulkan",
+                               block_fn=lambda layer, x: x * 2.0)
+        self.port = self.node.start()
+        self.addCleanup(self.node.stop)
+
+    def connect(self):
+        conn = NodeConnection("ps5-test", "127.0.0.1", self.port)
+        conn.connect()
+        self.addCleanup(conn.close)
+        return conn
+
+
+class TestBasicExchange(NodeFixture):
+    def test_hello_reports_what_the_console_is(self):
+        conn = self.connect()
+        reply = conn.request(Frame(MsgType.HELLO, 0))
+        self.assertEqual(reply.msg_type, MsgType.HELLO_ACK)
+
+    def test_ping_pong(self):
+        conn = self.connect()
+        reply = conn.request(Frame(MsgType.PING, 0, b"beat"))
+        self.assertEqual(reply.msg_type, MsgType.PONG)
+        self.assertEqual(reply.payload, b"beat")
+
+    def test_the_connection_is_reused_across_requests(self):
+        """Reconnecting per token would add a handshake to every layer."""
+        conn = self.connect()
+        for _ in range(20):
+            conn.request(Frame(MsgType.PING, 0))
+        self.assertTrue(conn.connected)
+
+    def test_nagle_is_off(self):
+        """Small frames must go out immediately; Nagle would add up to 40 ms
+        per hop to a workload made entirely of small frames."""
+        conn = self.connect()
+        value = conn._sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
+        self.assertTrue(value)
+
+
+class TestExpertExecution(NodeFixture):
+    def test_a_batch_returns_the_gate_weighted_sum(self):
+        conn = self.connect()
+        x = np.arange(HIDDEN, dtype=np.float32) * 0.1
+        ids, gates = (0, 1, 2), (0.5, 0.25, 0.25)
+        payload = ExpertBatchPayload(ids, gates, x).encode()
+        reply = conn.request(Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0))
+        got = decode_vector(reply.payload)
+
+        expected = np.zeros(HIDDEN, dtype=np.float32)
+        for expert, gate in zip(ids, gates):
+            weights = self.store.get(0, expert)
+            hidden = x @ weights.gate.T
+            hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))
+            hidden = hidden * (x @ weights.up.T)
+            expected += gate * (hidden @ weights.down.T)
+        np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+
+    def test_a_missing_shard_is_an_error_reply_not_a_dropped_connection(self):
+        """The console keeps serving: one bad request must not cost the
+        coordinator its connection to a console holding 300 other experts."""
+        conn = self.connect()
+        payload = ExpertBatchPayload((99,), (1.0,),
+                                     np.ones(HIDDEN, dtype=np.float32)).encode()
+        with self.assertRaises(Gen9Error) as caught:
+            conn.request(Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0))
+        self.assertIn("not resident", str(caught.exception))
+        self.assertEqual(caught.exception.unit_id, "ps5-test")
+        self.assertEqual(conn.request(Frame(MsgType.PING, 0)).msg_type,
+                         MsgType.PONG)
+
+    def test_a_malformed_batch_is_answered_not_fatal(self):
+        conn = self.connect()
+        with self.assertRaises(Gen9Error):
+            conn.request(Frame(MsgType.EXPERT_BATCH, 0, b"\x02\x00garbage",
+                               layer=0))
+        self.assertTrue(conn.connected)
+        self.assertEqual(conn.request(Frame(MsgType.PING, 0)).msg_type,
+                         MsgType.PONG)
+
+    def test_loading_a_shard_over_the_wire(self):
+        conn = self.connect()
+        header = ShardHeader(layer=1, first_expert=0, n_experts=2,
+                             hidden_size=HIDDEN, intermediate_size=INTERMEDIATE)
+        body = np.arange(2 * 3 * HIDDEN * INTERMEDIATE,
+                         dtype=np.float32) * 0.001
+        reply = conn.request(Frame(MsgType.LOAD_SHARD, 0,
+                                   header.encode() + body.tobytes()))
+        self.assertEqual(reply.msg_type, MsgType.LOAD_ACK)
+        self.assertTrue(self.store.holds(1, 0))
+        self.assertTrue(self.store.holds(1, 1))
+
+    def test_a_shard_body_of_the_wrong_size_is_refused(self):
+        conn = self.connect()
+        header = ShardHeader(layer=2, first_expert=0, n_experts=2,
+                             hidden_size=HIDDEN, intermediate_size=INTERMEDIATE)
+        with self.assertRaises(Gen9Error):
+            conn.request(Frame(MsgType.LOAD_SHARD, 0,
+                               header.encode() + b"\x00" * 64))
+        self.assertFalse(self.store.holds(2, 0))
+
+    def test_loading_an_fp8_shard_over_the_wire(self):
+        """The format the weights actually ship in: codes then block scales,
+        loaded without ever being materialised at fp32."""
+        conn = self.connect()
+        rng = np.random.default_rng(1)
+        matrices = [rng.standard_normal((fp8.BLOCK, fp8.BLOCK),
+                                        dtype=np.float32) * 0.05
+                    for _ in range(3)]
+        codes, scales = [], []
+        for matrix in matrices:
+            code, scale = fp8.quantize(matrix)
+            codes.append(code.reshape(-1))
+            scales.append(scale)
+        header = ShardHeader(layer=5, first_expert=0, n_experts=1,
+                             hidden_size=fp8.BLOCK,
+                             intermediate_size=fp8.BLOCK,
+                             dtype=DType.FP8_E4M3_B128)
+        body = (np.concatenate(codes).tobytes()
+                + np.concatenate(scales).astype("<f4").tobytes())
+        reply = conn.request(Frame(MsgType.LOAD_SHARD, 0,
+                                   header.encode() + body,
+                                   dtype=DType.FP8_E4M3_B128))
+        self.assertEqual(reply.msg_type, MsgType.LOAD_ACK)
+        held = self.store.get(5, 0)
+        self.assertTrue(held.quantised)
+        np.testing.assert_allclose(held.dequantised().gate, matrices[0],
+                                   atol=0.01)
+
+    def test_an_fp8_shard_missing_its_scales_is_refused(self):
+        conn = self.connect()
+        header = ShardHeader(layer=6, first_expert=0, n_experts=1,
+                             hidden_size=fp8.BLOCK,
+                             intermediate_size=fp8.BLOCK,
+                             dtype=DType.FP8_E4M3_B128)
+        codes = np.zeros(3 * fp8.BLOCK * fp8.BLOCK, dtype=np.uint8)
+        with self.assertRaises(Gen9Error):
+            conn.request(Frame(MsgType.LOAD_SHARD, 0,
+                               header.encode() + codes.tobytes()))
+        self.assertFalse(self.store.holds(6, 0))
+
+    def test_block_forward_runs_on_the_host(self):
+        conn = self.connect()
+        x = np.ones(HIDDEN, dtype=np.float32)
+        reply = conn.request(Frame(MsgType.BLOCK_FWD, 0, encode_vector(x),
+                                   layer=3))
+        np.testing.assert_allclose(decode_vector(reply.payload), x * 2.0)
+
+
+class TestMultiplexing(NodeFixture):
+    def test_concurrent_requests_get_their_own_replies(self):
+        """The failure this guards against is silent and catastrophic: two
+        in-flight requests whose replies are swapped produce a plausible token
+        computed from the wrong experts."""
+        conn = self.connect()
+        results = {}
+        errors = []
+
+        def ask(index):
+            try:
+                reply = conn.request(
+                    Frame(MsgType.PING, 0, f"payload-{index}".encode()))
+                results[index] = reply.payload.decode()
+            except Gen9Error as exc:      # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=ask, args=(i,)) for i in range(24)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(results, {i: f"payload-{i}" for i in range(24)})
+
+    def test_request_ids_are_unique_per_connection(self):
+        conn = self.connect()
+        seen = set()
+        for _ in range(100):
+            rid = conn._next_request_id()
+            self.assertNotIn(rid, seen)
+            seen.add(rid)
+
+
+class TestFailures(unittest.TestCase):
+    def test_connecting_to_nothing_is_a_retry_safe_error(self):
+        """Nothing was sent, so retrying cannot duplicate work."""
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            dead_port = probe.getsockname()[1]
+        conn = NodeConnection("ghost", "127.0.0.1", dead_port,
+                              connect_timeout=1.0)
+        with self.assertRaises(ConnectError) as caught:
+            conn.connect()
+        self.assertEqual(caught.exception.unit_id, "ghost")
+        self.assertTrue(caught.exception.retry_safe)
+
+    def test_a_console_disappearing_fails_the_waiters(self):
+        """Every in-flight request must fail promptly rather than hang until
+        its timeout; a shelf blocked on a dead console blocks the pipeline."""
+        store = ShardStore()
+        node = NodeServer(store, unit_id="doomed", host="127.0.0.1", port=0)
+        port = node.start()
+        conn = NodeConnection("doomed", "127.0.0.1", port)
+        conn.connect()
+        self.assertEqual(conn.request(Frame(MsgType.PING, 0)).msg_type,
+                         MsgType.PONG)
+
+        failures = []
+
+        def ask():
+            try:
+                conn.request(Frame(MsgType.PING, 0), timeout=15.0)
+            except Gen9Error as exc:
+                failures.append(exc)
+
+        threads = [threading.Thread(target=ask) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        time.sleep(0.05)
+        node.stop()
+        conn._sock.close() if conn._sock else None
+        for thread in threads:
+            thread.join(timeout=10)
+        conn.close()
+        self.assertFalse(conn.connected)
+
+    def test_a_peer_speaking_nonsense_is_a_protocol_error(self):
+        """Not every listener on port 9713 is a console."""
+        listener = socket.socket()
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        def babble():
+            client, _ = listener.accept()
+            client.sendall(b"HTTP/1.1 200 OK\r\n\r\n" + b"x" * 64)
+            time.sleep(0.2)
+            client.close()
+
+        thread = threading.Thread(target=babble, daemon=True)
+        thread.start()
+        conn = NodeConnection("impostor", "127.0.0.1", port)
+        conn.connect()
+        with self.assertRaises(Gen9Error):
+            conn.request(Frame(MsgType.PING, 0), timeout=5.0)
+        conn.close()
+        listener.close()
+        thread.join(timeout=5)
+
+
+class TestConnectionPool(NodeFixture):
+    def test_one_connection_per_console_is_reused(self):
+        with ConnectionPool() as pool:
+            first = pool.get("ps5-test", "127.0.0.1", self.port)
+            second = pool.get("ps5-test", "127.0.0.1", self.port)
+            self.assertIs(first, second)
+
+    def test_dropping_forces_a_fresh_connection(self):
+        with ConnectionPool() as pool:
+            first = pool.get("ps5-test", "127.0.0.1", self.port)
+            pool.drop("ps5-test")
+            self.assertIsNot(pool.get("ps5-test", "127.0.0.1", self.port),
+                             first)
+
+    def test_closing_the_pool_closes_the_connections(self):
+        pool = ConnectionPool()
+        conn = pool.get("ps5-test", "127.0.0.1", self.port)
+        pool.close()
+        self.assertFalse(conn.connected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gen9-cluster/tests/test_transport.py
+++ b/gen9-cluster/tests/test_transport.py
@@ -16,8 +16,9 @@ import numpy as np
 from gen9_cluster import fp8
 from gen9_cluster.errors import ConnectError, Gen9Error
 from gen9_cluster.node import ExpertWeights, NodeServer, ShardStore
-from gen9_cluster.protocol import (DType, ExpertBatchPayload, Frame, MsgType,
-                                   ShardHeader, decode_vector,
+from gen9_cluster.protocol import (DType, ExpertBatchPayload,
+                                   ExpertRowsPayload, Flags, Frame, MsgType,
+                                   ShardHeader, accumulate, decode_vector,
                                    encode_vector)
 from gen9_cluster.transport import ConnectionPool, NodeConnection
 
@@ -83,22 +84,65 @@ class TestBasicExchange(NodeFixture):
 
 
 class TestExpertExecution(NodeFixture):
-    def test_a_batch_returns_the_gate_weighted_sum(self):
-        conn = self.connect()
-        x = np.arange(HIDDEN, dtype=np.float32) * 0.1
-        ids, gates = (0, 1, 2), (0.5, 0.25, 0.25)
-        payload = ExpertBatchPayload(ids, gates, x).encode()
-        reply = conn.request(Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0))
-        got = decode_vector(reply.payload)
-
-        expected = np.zeros(HIDDEN, dtype=np.float32)
+    def _reference_rows(self, x, ids, gates):
+        rows = []
         for expert, gate in zip(ids, gates):
             weights = self.store.get(0, expert)
             hidden = x @ weights.gate.T
             hidden = hidden * (1.0 / (1.0 + np.exp(-hidden)))
             hidden = hidden * (x @ weights.up.T)
-            expected += gate * (hidden @ weights.down.T)
-        np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+            rows.append(np.float32(gate) * (hidden @ weights.down.T))
+        return rows
+
+    def test_a_batch_returns_one_tagged_row_per_expert(self):
+        """The default reply is per-expert, so the caller owns the order."""
+        conn = self.connect()
+        x = np.arange(HIDDEN, dtype=np.float32) * 0.1
+        ids, gates = (0, 1, 2), (0.5, 0.25, 0.25)
+        payload = ExpertBatchPayload(ids, gates, x).encode()
+        reply = conn.request(Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0))
+
+        self.assertTrue(reply.flags & Flags.PER_EXPERT)
+        self.assertFalse(reply.flags & Flags.PARTIAL)
+        rows = ExpertRowsPayload.decode(reply.payload)
+        self.assertEqual(rows.expert_ids, ids)
+        for index, want in enumerate(self._reference_rows(x, ids, gates)):
+            np.testing.assert_allclose(rows.rows[index], want, rtol=1e-5,
+                                       atol=1e-6)
+
+    def test_fast_collapses_the_batch_only_when_asked(self):
+        conn = self.connect()
+        x = np.arange(HIDDEN, dtype=np.float32) * 0.1
+        ids, gates = (0, 1, 2), (0.5, 0.25, 0.25)
+        payload = ExpertBatchPayload(ids, gates, x).encode()
+        reply = conn.request(Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0,
+                                   flags=Flags.FAST))
+
+        self.assertTrue(reply.flags & Flags.PARTIAL)
+        self.assertFalse(reply.flags & Flags.PER_EXPERT)
+        got = decode_vector(reply.payload)
+        self.assertEqual(got.shape, (HIDDEN,))
+        # Same folding order as the node uses, so this is exact, not close.
+        np.testing.assert_array_equal(
+            got, accumulate(self._reference_rows(x, ids, gates)))
+
+    def test_a_retry_of_the_same_batch_id_is_replayed_not_recomputed(self):
+        conn = self.connect()
+        x = np.arange(HIDDEN, dtype=np.float32) * 0.1
+        payload = ExpertBatchPayload((0, 1), (0.5, 0.5), x, 4242).encode()
+        frame = Frame(MsgType.EXPERT_BATCH, 0, payload, layer=0)
+
+        first = conn.request(frame)
+        ran = self.node.experts_run
+        second = conn.request(frame)
+
+        self.assertEqual(self.node.experts_run, ran,
+                         "the retry re-ran the experts")
+        self.assertTrue(second.flags & Flags.REPLAYED)
+        self.assertFalse(first.flags & Flags.REPLAYED)
+        np.testing.assert_array_equal(
+            ExpertRowsPayload.decode(second.payload).rows,
+            ExpertRowsPayload.decode(first.payload).rows)
 
     def test_a_missing_shard_is_an_error_reply_not_a_dropped_connection(self):
         """The console keeps serving: one bad request must not cost the

--- a/x86-64/Makefile
+++ b/x86-64/Makefile
@@ -1,0 +1,28 @@
+# Elyan Labs — x86-64 AES-NI collapse
+#
+#   make        build and nothing else
+#   make bench  build and run the checks and the benchmark
+#
+# AES-NI is the only hard requirement. SSE4.1 is for blendv and ptest in the
+# hybrid collapse and the tests; every AES-NI part has it.
+
+CC ?= cc
+CFLAGS ?= -O2 -maes -msse4.1 -Wall -Wextra
+LDFLAGS = -lm
+
+# -march=native picks up VAES on Zen 3 / Ice Lake and later. It is deliberately
+# not the default: the fleet this lives next to is Zen 2, which has AES-NI and
+# no VAES, and a binary built here must still run there.
+
+.PHONY: all bench clean
+
+all: bench-aes-collapse
+
+bench-aes-collapse: bench-aes-collapse.c aes-collapse.h
+	$(CC) $(CFLAGS) -I. -o $@ bench-aes-collapse.c $(LDFLAGS)
+
+bench: bench-aes-collapse
+	./bench-aes-collapse
+
+clean:
+	rm -f bench-aes-collapse

--- a/x86-64/README.md
+++ b/x86-64/README.md
@@ -1,0 +1,107 @@
+# x86-64 PSE — Non-Bijunctive Collapse via AES-NI
+
+Third port of the collapse, after POWER8 (`ggml-vcipher-collapse.h`) and ARM
+(`apple-silicon/aes-entropy-collapse.h`).
+
+```
+make bench
+```
+
+## Architecture mapping
+
+| POWER8 | x86-64 | Purpose |
+|--------|--------|---------|
+| `vcipher` | `_mm_aesenc_si128` | AES round — **exactly the same function** |
+| `vcipherlast` | `_mm_aesenclast_si128` | AES round without MixColumns |
+| `vec_perm(a,a,p)` | `_mm_shuffle_epi8` | Single-source byte permute |
+| `vec_perm(a,b,p)` | two `pshufb` + `blendv` | Dual-source permute (not needed here) |
+| `vec_cmpgt` / `vec_sel` | `_mm_cmpgt_ps` / `_mm_blendv_ps` | Threshold and select |
+| `mftb` | `rdtsc` | Hardware counter (off by default, see below) |
+
+## x86 is the exact port; ARM is not
+
+`aesenc` and `vcipher` both compute
+
+```
+MixColumns(ShiftRows(SubBytes(state))) XOR key
+```
+
+so every mode transcribes literally, and `bench-aes-collapse.c` checks it
+against a scalar AES round written from FIPS-197 rather than against another
+intrinsic.
+
+ARM is the odd one out. `AESE` applies the key *first* and `AESMC` adds no
+final XOR, so `vaeseq_u8` + `vaesmcq_u8` computes `aesenc(state XOR key, 0)` —
+a different function of `(state, key)`, agreeing only when the key is zero.
+The diffusion is just as good, it is still a full AES round, but the three
+ports do not produce the same bytes for the same inputs, so a pattern
+generated on POWER8 cannot be reproduced on an M2. `x86_aes_arm_order()`
+exists for when you need to match the Apple port instead.
+
+The mapping table in `apple-silicon/PAPER-architecture-general-pse.md`
+(Appendix C) lists the ARM pair as equivalent to `vcipher`. It isn't; two of
+the checks in the bench demonstrate that.
+
+## Two deliberate divergences from POWER8
+
+**Round keys are deterministic by default.** The POWER8 header reseeds from
+`mftb` on every call, so no two runs produce the same patterns. That suits
+entropy injection and rules out everything that has to be reproducible.
+Here the key comes from `(layer, position, counter)`; build with
+`-DX86_AES_COLLAPSE_ENTROPY=1` for the original behaviour.
+
+**Byte order.** `vec_perm` numbers bytes from the most significant end on
+big-endian POWER, `pshufb` from the least significant, so patterns are
+mirrored between the two. `x86_aes_beswap()` converts.
+
+## Cost
+
+Measured by `make bench` on a Xeon Platinum 8559C (Emerald Rapids):
+
+| | ns per AES round |
+|---|---|
+| Dependent chain (latency bound) | 0.75 |
+| Four chains in flight (throughput bound) | 0.19 — 5.2 G rounds/s |
+| `pshufb`, dependent, for scale | 0.27 |
+
+So a round costs about three `pshufb` latencies and is free on throughput,
+which is the same argument the POWER8 header makes. Eight independent chains
+saturate the unit; `x86_aes_collapse_8way` is built around that.
+
+Numbers from one machine. Zen 2 has AES-NI but no VAES, and its own latency
+and port count, so it will differ — remeasure before quoting.
+
+## Mode 4 does not work
+
+`x86_aes_attention_score` is ported for parity and is **not** a similarity
+metric, despite what the POWER8 comment claims for it. Over 200k Q/K pairs its
+correlation with cosine similarity is **+0.002**, and the score for `Q == K`
+sits in the middle of the range it produces for unrelated pairs.
+
+The avalanche property is the cause: it is what the mode is built on and it is
+exactly what destroys any monotonic relationship between input distance and
+output byte-sum. A near-zero XOR is not a near-zero round output, because
+SubBytes maps `0x00` to `0x63`.
+
+What it is: a fast deterministic 12-bit hash of `Q XOR K`, which detects
+equality and nothing weaker. Kept and tested as such rather than deleted,
+because the other two ports ship it and a silent divergence would be worse
+than a loud caveat.
+
+## Not used by gen9-cluster
+
+The DeepSeek V4 Pro fleet in `gen9-cluster/` does not call any of this, on
+purpose:
+
+- Its attention runs GPU-side on RDNA2 through Vulkan/RADV, and RDNA2 has no
+  AES instruction. A collapse there means pinning attention to the CPU or
+  doing S-box lookups in GLSL, either of which costs more than it saves.
+- Every node in that fleet — PS5, Series X/S, 4700S, 4800S, BC-250 — is Zen 2,
+  so AES-NI is universal and VAES is unavailable. Only a Steam Machine class
+  box would get the four-wide rounds.
+- `G9XC` makes exact per-expert reduction the default. Anything that injects
+  entropy into the numerics belongs behind the `FAST` opt-in, not in the
+  default path.
+
+This directory is the portable primitive. Wiring it into a model is a separate
+decision.

--- a/x86-64/aes-collapse.h
+++ b/x86-64/aes-collapse.h
@@ -1,0 +1,419 @@
+/*
+ * aes-collapse.h — AES-NI Non-Bijunctive Collapse for x86-64
+ *
+ * The x86 counterpart of ggml-vcipher-collapse.h (POWER8) and
+ * apple-silicon/aes-entropy-collapse.h (ARM).
+ *
+ * Of the three, x86 is the *exact* one. AESENC and vcipher compute the same
+ * function:
+ *
+ *     aesenc(s, k)  = MixColumns(ShiftRows(SubBytes(s))) XOR k
+ *     vcipher(s, k) = MixColumns(ShiftRows(SubBytes(s))) XOR k
+ *
+ * so every mode below is a literal transcription, and bench-aes-collapse.c
+ * checks that against a scalar AES round rather than taking it on faith.
+ *
+ * ARM is the odd one out, and the porting table in
+ * apple-silicon/PAPER-architecture-general-pse.md is wrong to list it as
+ * equivalent. AESE applies the key *first* and AESMC adds no final XOR:
+ *
+ *     aese(s, k) ; aesmc  = MixColumns(ShiftRows(SubBytes(s XOR k)))
+ *                         = aesenc(s XOR k, 0)
+ *
+ * which is a different function of (s, k). Diffusion quality is unaffected —
+ * it is still a full AES round — but the three ports do not produce the same
+ * bytes for the same inputs, so a pattern generated on POWER8 cannot be
+ * reproduced on an M2. See x86_aes_arm_order() if you need to match the
+ * existing ARM port instead of POWER8.
+ *
+ * Two further things this header does *not* inherit from the POWER8 original:
+ *
+ *   - Round keys are derived from (layer, position, counter) by default, not
+ *     from the timebase. mftb/rdtsc keying makes every run produce different
+ *     patterns, which is fine for entropy injection and useless for anything
+ *     that has to be reproducible. Define X86_AES_COLLAPSE_ENTROPY=1 for the
+ *     original nondeterministic behaviour.
+ *   - Byte order. vec_perm numbers bytes from the most significant end on
+ *     big-endian POWER; pshufb numbers from the least significant. Patterns
+ *     are therefore mirrored between the two. x86_aes_beswap() converts.
+ *
+ * Not used by gen9-cluster: that fleet is Zen 2 with attention on RDNA2 via
+ * Vulkan, and RDNA2 has no AES instruction, so a collapse there would mean
+ * either pinning attention to the CPU or doing S-box lookups in GLSL.
+ *
+ * Requires: -maes -mssse3 (SSE4.1 for the blend path, optional VAES)
+ */
+
+#ifndef X86_AES_COLLAPSE_H
+#define X86_AES_COLLAPSE_H
+
+#if !defined(__x86_64__) && !defined(__i386__)
+#error "aes-collapse.h is the x86 port; see ggml-vcipher-collapse.h for POWER8"
+#endif
+
+#include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/*===========================================================================
+ * Configuration — names and defaults mirror the POWER8 header
+ *===========================================================================*/
+
+#ifndef X86_AES_COLLAPSE_ROUNDS
+#define X86_AES_COLLAPSE_ROUNDS 2
+#endif
+
+#ifndef X86_AES_COLLAPSE_TOP_K
+#define X86_AES_COLLAPSE_TOP_K 8
+#endif
+
+#ifndef X86_AES_COLLAPSE_AMPLIFY
+#define X86_AES_COLLAPSE_AMPLIFY 1.15f
+#endif
+
+/* 1 = full aesenc (MixColumns diffuses across lanes), 0 = aesenclast. */
+#ifndef X86_AES_CROSS_HEAD_FUSE
+#define X86_AES_CROSS_HEAD_FUSE 1
+#endif
+
+/* 1 = key from rdtsc, as POWER8 does with mftb. 0 = reproducible. */
+#ifndef X86_AES_COLLAPSE_ENTROPY
+#define X86_AES_COLLAPSE_ENTROPY 0
+#endif
+
+/*===========================================================================
+ * Runtime dispatch
+ *
+ * Every CPU this project targets has AES-NI — the consoles and salvage boards
+ * are all Zen 2 — but a header that assumes an instruction set is a header
+ * that SIGILLs on someone's Nehalem, so ask.
+ *
+ * VAES (four rounds per instruction on a 512-bit register) is Zen 3 and Ice
+ * Lake and later, which excludes every ninth-generation console.
+ *===========================================================================*/
+
+static inline int x86_aes_available(void) {
+    __builtin_cpu_init();
+    return __builtin_cpu_supports("aes");
+}
+
+static inline int x86_vaes_available(void) {
+    __builtin_cpu_init();
+#if defined(__VAES__) || defined(__AVX512F__)
+    return __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("aes");
+#else
+    return 0;
+#endif
+}
+
+/*===========================================================================
+ * Entropy and round keys
+ *===========================================================================*/
+
+static inline uint64_t x86_aes_read_tsc(void) {
+    return __rdtsc();
+}
+
+/*
+ * The counter exists so that the deterministic path still varies the key
+ * between the rounds of one collapse, which is what the POWER8 version got
+ * from mftb advancing underneath it.
+ */
+static inline __m128i x86_aes_make_round_key(int layer_id, int position,
+                                             uint64_t counter) {
+#if X86_AES_COLLAPSE_ENTROPY
+    uint64_t seed = x86_aes_read_tsc();
+#else
+    uint64_t seed = counter * 0xD1342543DE82EF95ULL;
+#endif
+    uint64_t lo = seed ^ ((uint64_t)layer_id * 0x9E3779B97F4A7C15ULL);
+    uint64_t hi = seed ^ ((uint64_t)position * 0x517CC1B727220A95ULL);
+    return _mm_set_epi64x((long long)hi, (long long)lo);
+}
+
+/*===========================================================================
+ * The round itself
+ *===========================================================================*/
+
+/* Identical to POWER8 __builtin_crypto_vcipher. */
+static inline __m128i x86_aes_round(__m128i state, __m128i key) {
+    return _mm_aesenc_si128(state, key);
+}
+
+/* Identical to POWER8 __builtin_crypto_vcipherlast (no MixColumns). */
+static inline __m128i x86_aes_round_last(__m128i state, __m128i key) {
+    return _mm_aesenclast_si128(state, key);
+}
+
+/*
+ * What ARM's aese+aesmc pair actually computes, for when you need to match
+ * the Apple port rather than the POWER8 one. Not used below.
+ */
+static inline __m128i x86_aes_arm_order(__m128i state, __m128i key) {
+    return _mm_aesenc_si128(_mm_xor_si128(state, key), _mm_setzero_si128());
+}
+
+/* Mirror a 16-byte lane, converting between vec_perm and pshufb numbering. */
+static inline __m128i x86_aes_beswap(__m128i v) {
+    const __m128i rev = _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,
+                                     8, 9, 10, 11, 12, 13, 14, 15);
+    return _mm_shuffle_epi8(v, rev);
+}
+
+/*===========================================================================
+ * MODE 1: Non-linear pattern generation
+ *
+ * Note what the pattern is: byte indices for pshufb, so it permutes the bytes
+ * *inside* the floats, not the floats. That is what the POWER8 version does
+ * too; it is a scrambler, not a gather.
+ *===========================================================================*/
+
+static inline __m128i x86_aes_generate_pattern(int layer_id, int position,
+                                               int top_k) {
+    __m128i state = _mm_set_epi64x(
+        (long long)((uint64_t)position * 0xBB67AE8584CAA73BULL),
+        (long long)((uint64_t)layer_id * 0x6A09E667F3BCC908ULL));
+
+    for (int r = 0; r < X86_AES_COLLAPSE_ROUNDS; r++) {
+        state = x86_aes_round(
+            state, x86_aes_make_round_key(layer_id + r, position, (uint64_t)r));
+    }
+    state = x86_aes_round_last(
+        state, x86_aes_make_round_key(layer_id, position + 1,
+                                      X86_AES_COLLAPSE_ROUNDS));
+
+    unsigned char raw[16], pattern[16];
+    _mm_storeu_si128((__m128i *)raw, state);
+
+    if (top_k < 1) top_k = 1;
+    if (top_k > 16) top_k = 16;
+    for (int i = 0; i < top_k; i++) pattern[i] = (unsigned char)i;
+    for (int i = top_k; i < 16; i++)
+        pattern[i] = (unsigned char)(raw[i] % (unsigned)top_k);
+
+    return _mm_loadu_si128((const __m128i *)pattern);
+}
+
+/*===========================================================================
+ * MODE 2: Score ranking via S-box non-linearity
+ *===========================================================================*/
+
+static inline void x86_aes_rank_scores(const float *scores, uint8_t *rank_keys,
+                                       int layer_id, int position) {
+    __m128i state = _mm_loadu_si128((const __m128i *)scores);
+    __m128i rk = x86_aes_make_round_key(layer_id, position, 0);
+
+#if X86_AES_CROSS_HEAD_FUSE
+    state = x86_aes_round(state, rk);       /* MixColumns crosses the lanes */
+#else
+    state = x86_aes_round_last(state, rk);  /* each score ranked alone */
+#endif
+
+    _mm_storeu_si128((__m128i *)rank_keys, state);
+}
+
+/*===========================================================================
+ * MODE 3: Cross-head fusion
+ *===========================================================================*/
+
+static inline __m128i x86_aes_fuse_heads(__m128i head_scores, int layer_id,
+                                         int position) {
+    return x86_aes_round(head_scores,
+                         x86_aes_make_round_key(layer_id, position, 0));
+}
+
+/*===========================================================================
+ * 8-way pipelined collapse
+ *
+ * AESENC is ~4 cycles of latency at one or two per cycle of throughput, so
+ * the same pipelining argument as POWER8 applies and eight independent chains
+ * saturate it. Measured on an Emerald Rapids Xeon: 0.76 ns/round dependent
+ * against 0.20 ns/round with four chains in flight.
+ *
+ * Unlike the POWER8 original, this processes all eight vectors. That one
+ * advances the loop by 8 while only ever touching vector 0.
+ *===========================================================================*/
+
+static inline void x86_aes_collapse_8way(float *scores, int n_vectors,
+                                         int layer_id, int position) {
+    __m128i rk[8];
+    for (int j = 0; j < 8; j++)
+        rk[j] = x86_aes_make_round_key(layer_id + (j >> 2), position + (j & 3),
+                                       (uint64_t)j);
+
+    const float amp = X86_AES_COLLAPSE_AMPLIFY;
+    int i = 0;
+    for (; i + 7 < n_vectors; i += 8) {
+        __m128i s[8], c[8];
+        for (int j = 0; j < 8; j++)
+            s[j] = _mm_loadu_si128((const __m128i *)&scores[(i + j) * 4]);
+        /* Issued back to back; the eight chains are independent. */
+        for (int j = 0; j < 8; j++) c[j] = x86_aes_round(s[j], rk[j]);
+
+        for (int j = 0; j < 8; j++) {
+            unsigned char r[16];
+            _mm_storeu_si128((__m128i *)r, c[j]);
+            for (int lane = 0; lane < 4; lane++) {
+                /* Energy of one float's four transformed bytes. */
+                unsigned energy = (unsigned)r[lane] + r[lane + 4]
+                                + r[lane + 8] + r[lane + 12];
+                float *slot = &scores[(i + j) * 4 + lane];
+                if (energy < 512u) *slot = 0.0f;
+                else               *slot *= amp;
+            }
+        }
+    }
+
+    /* Remainder: same rule, one vector at a time. */
+    for (; i < n_vectors; i++) {
+        float *vec = scores + (ptrdiff_t)i * 4;
+        __m128i c = x86_aes_round(_mm_loadu_si128((const __m128i *)vec),
+                                  rk[i & 7]);
+        unsigned char r[16];
+        _mm_storeu_si128((__m128i *)r, c);
+        for (int lane = 0; lane < 4; lane++) {
+            unsigned energy = (unsigned)r[lane] + r[lane + 4]
+                            + r[lane + 8] + r[lane + 12];
+            if (energy < 512u) vec[lane] = 0.0f;
+            else               vec[lane] *= amp;
+        }
+    }
+}
+
+/*===========================================================================
+ * CORE: hybrid AES + pshufb collapse
+ *
+ * AES ranks, pshufb routes. The split exists because the S-box destroys IEEE
+ * 754 encoding, so it can say which scores win but must not touch their
+ * values; pshufb moves bytes without altering them but cannot rank.
+ *===========================================================================*/
+
+static inline void x86_aes_hybrid_collapse(float *scores, int n, int top_k,
+                                           int layer_id, int position) {
+    if (n < 4 || top_k < 1) return;
+    if (top_k > 16) top_k = 16;
+
+    /* Step 1: top-K threshold, AES-assisted ranking over groups of four. */
+    float top_vals[16];
+    for (int i = 0; i < 16; i++) top_vals[i] = -1e30f;
+
+    for (int i = 0; i + 3 < n; i += 4) {
+        __m128i state = _mm_loadu_si128((const __m128i *)&scores[i]);
+        __m128i ranked = x86_aes_round(
+            state, x86_aes_make_round_key(layer_id, position + i, (uint64_t)i));
+        unsigned char rb[16];
+        _mm_storeu_si128((__m128i *)rb, ranked);
+
+        for (int j = 0; j < 4; j++) {
+            float score = scores[i + j];
+            if (score > top_vals[top_k - 1]) {
+                top_vals[top_k - 1] = score;
+                for (int k = top_k - 1;
+                     k > 0 && top_vals[k] > top_vals[k - 1]; k--) {
+                    float tmp = top_vals[k];
+                    top_vals[k] = top_vals[k - 1];
+                    top_vals[k - 1] = tmp;
+                }
+            }
+        }
+    }
+
+    const float threshold = top_vals[top_k - 1];
+    const __m128 thresh_vec = _mm_set1_ps(threshold);
+    const __m128 amp_vec = _mm_set1_ps(X86_AES_COLLAPSE_AMPLIFY);
+    const __m128 zero_vec = _mm_setzero_ps();
+
+    /* Step 2: the permute pattern. */
+    const __m128i pattern = x86_aes_generate_pattern(layer_id, position, top_k);
+
+    /*
+     * Step 3: route, mask, amplify.
+     *
+     * The POWER8 version calls vec_perm(v0, v1, pattern), a two-source
+     * permute. Every index the generator produces is below 16, so it only
+     * ever selects from v0 and one pshufb is exactly equivalent — no blend
+     * needed, despite what the porting table implies.
+     */
+    int i = 0;
+    for (; i + 15 < n; i += 16) {
+        for (int b = 0; b < 4; b++) {
+            __m128 v = _mm_loadu_ps(&scores[i + b * 4]);
+            __m128 c = _mm_castsi128_ps(
+                _mm_shuffle_epi8(_mm_castps_si128(v), pattern));
+            __m128 keep = _mm_cmpgt_ps(c, thresh_vec);
+            c = _mm_mul_ps(_mm_blendv_ps(zero_vec, c, keep), amp_vec);
+            _mm_storeu_ps(&scores[i + b * 4], c);
+        }
+    }
+
+    for (; i < n; i++) {
+        if (scores[i] >= threshold) scores[i] *= X86_AES_COLLAPSE_AMPLIFY;
+        else                        scores[i] = 0.0f;
+    }
+}
+
+/*===========================================================================
+ * MODE 4: AES as the similarity metric (experimental — and it does not work)
+ *
+ * Ported for parity with the POWER8 header, whose claim is that XORing Q with
+ * K and running a round gives a similarity measure, because similar vectors
+ * XOR to near zero and dissimilar ones diffuse. Measured over 200k Q/K pairs
+ * on Emerald Rapids, the correlation between this score and the actual cosine
+ * similarity is **+0.002**, and the score for Q == K (2496) sits in the middle
+ * of the range the function produces for unrelated pairs (849..3318).
+ *
+ * The reason is the avalanche property itself: it is what the mode is built
+ * on, and it is exactly what destroys any monotonic relationship between
+ * input distance and output byte-sum. A near-zero XOR is not a near-zero
+ * round output — SubBytes maps 0x00 to 0x63 — so "low energy" tracks nothing.
+ *
+ * What the function *is*: a fast, deterministic 12-bit hash of Q XOR K. It
+ * detects equality and nothing weaker. Kept, tested and documented as such
+ * rather than deleted, because the POWER8 and Apple ports both ship it and a
+ * silent divergence would be worse than a loud caveat.
+ *===========================================================================*/
+
+static inline uint32_t x86_aes_attention_score(const float *Q_vec,
+                                               const float *K_vec,
+                                               int layer_id, int position) {
+    __m128i q = _mm_loadu_si128((const __m128i *)Q_vec);
+    __m128i k = _mm_loadu_si128((const __m128i *)K_vec);
+    __m128i state = x86_aes_round(_mm_xor_si128(q, k),
+                                  x86_aes_make_round_key(layer_id, position, 0));
+
+    /* Byte-sum the result: low energy means Q and K agreed. */
+    __m128i sums = _mm_sad_epu8(state, _mm_setzero_si128());
+    uint32_t energy = (uint32_t)(_mm_cvtsi128_si32(sums)
+                                 + _mm_extract_epi16(sums, 4));
+    return 4080u - energy;   /* 16 * 255 */
+}
+
+/*===========================================================================
+ * Banner
+ *===========================================================================*/
+
+static inline void x86_aes_collapse_banner(void) {
+    fprintf(stderr, "\n");
+    fprintf(stderr, "════════════════════════════════════════════════════════════\n");
+    fprintf(stderr, "  PSE AES Collapse — x86-64 AES-NI (aesenc == vcipher)\n");
+    fprintf(stderr, "────────────────────────────────────────────────────────────\n");
+    fprintf(stderr, "   AES rounds:       %d (SubBytes+ShiftRows+MixColumns+XOR)\n",
+            X86_AES_COLLAPSE_ROUNDS);
+    fprintf(stderr, "   Top-K:            %d\n", X86_AES_COLLAPSE_TOP_K);
+    fprintf(stderr, "   Amplify:          %.2f\n",
+            (double)X86_AES_COLLAPSE_AMPLIFY);
+    fprintf(stderr, "   Cross-head fuse:  %s (MixColumns GF(2^8) diffusion)\n",
+            X86_AES_CROSS_HEAD_FUSE ? "ENABLED" : "disabled");
+    fprintf(stderr, "   Round key:        %s\n",
+            X86_AES_COLLAPSE_ENTROPY ? "rdtsc (nondeterministic)"
+                                     : "counter (reproducible)");
+    fprintf(stderr, "   AES-NI:           %s\n",
+            x86_aes_available() ? "present" : "ABSENT — do not call");
+    fprintf(stderr, "   VAES (4x wide):   %s\n",
+            x86_vaes_available() ? "present" : "absent (Zen 3 / Ice Lake+)");
+    fprintf(stderr, "════════════════════════════════════════════════════════════\n");
+}
+
+#endif /* X86_AES_COLLAPSE_H */

--- a/x86-64/bench-aes-collapse.c
+++ b/x86-64/bench-aes-collapse.c
@@ -1,0 +1,356 @@
+/*
+ * bench-aes-collapse.c — correctness and cost of the x86 AES collapse.
+ *
+ * The correctness half matters more than the benchmark. The whole claim of
+ * aes-collapse.h is that AESENC is the same function as POWER8's vcipher, so
+ * that claim is checked against a scalar AES round written from FIPS-197
+ * rather than against another intrinsic. The same scalar reference then shows
+ * that ARM's aese+aesmc is *not* that function, which is the bug in the
+ * porting table in apple-silicon/PAPER-architecture-general-pse.md.
+ *
+ *   cc -O2 -maes -msse4.1 -o bench-aes-collapse bench-aes-collapse.c
+ */
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "aes-collapse.h"
+
+/*===========================================================================
+ * Scalar AES round, FIPS-197, as the reference
+ *===========================================================================*/
+
+static const uint8_t SBOX[256] = {
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+};
+
+static uint8_t xtime(uint8_t x) {
+    return (uint8_t)((x << 1) ^ ((x >> 7) * 0x1b));
+}
+
+/* One AES round on a 16-byte column-major state: SubBytes, ShiftRows,
+ * MixColumns, AddRoundKey — in that order, key last. */
+static void aes_round_ref(const uint8_t in[16], const uint8_t key[16],
+                          uint8_t out[16]) {
+    uint8_t s[16];
+    for (int i = 0; i < 16; i++) s[i] = SBOX[in[i]];
+
+    /* ShiftRows: row r rotates left by r. State is column-major, so the byte
+     * at (row, col) lives at index col * 4 + row. */
+    uint8_t t[16];
+    for (int c = 0; c < 4; c++)
+        for (int r = 0; r < 4; r++)
+            t[c * 4 + r] = s[((c + r) % 4) * 4 + r];
+
+    for (int c = 0; c < 4; c++) {
+        const uint8_t *a = &t[c * 4];
+        uint8_t b[4];
+        b[0] = (uint8_t)(xtime(a[0]) ^ (xtime(a[1]) ^ a[1]) ^ a[2] ^ a[3]);
+        b[1] = (uint8_t)(a[0] ^ xtime(a[1]) ^ (xtime(a[2]) ^ a[2]) ^ a[3]);
+        b[2] = (uint8_t)(a[0] ^ a[1] ^ xtime(a[2]) ^ (xtime(a[3]) ^ a[3]));
+        b[3] = (uint8_t)((xtime(a[0]) ^ a[0]) ^ a[1] ^ a[2] ^ xtime(a[3]));
+        for (int r = 0; r < 4; r++) out[c * 4 + r] = (uint8_t)(b[r] ^ key[c * 4 + r]);
+    }
+}
+
+/*===========================================================================
+ * Tests
+ *===========================================================================*/
+
+static uint64_t rng_state = 0x243F6A8885A308D3ULL;
+
+static uint64_t rng(void) {
+    rng_state ^= rng_state << 13;
+    rng_state ^= rng_state >> 7;
+    rng_state ^= rng_state << 17;
+    return rng_state;
+}
+
+static void fill_random(uint8_t *p, int n) {
+    for (int i = 0; i < n; i++) p[i] = (uint8_t)(rng() >> 24);
+}
+
+static int failures;
+
+static void check(const char *what, int ok) {
+    printf("  %-52s %s\n", what, ok ? "ok" : "FAILED");
+    if (!ok) failures++;
+}
+
+/* aesenc must equal the scalar round, i.e. must equal vcipher. */
+static int test_aesenc_is_vcipher(void) {
+    for (int trial = 0; trial < 4096; trial++) {
+        uint8_t s[16], k[16], want[16], got[16];
+        fill_random(s, 16);
+        fill_random(k, 16);
+        aes_round_ref(s, k, want);
+        _mm_storeu_si128((__m128i *)got,
+                         x86_aes_round(_mm_loadu_si128((const __m128i *)s),
+                                       _mm_loadu_si128((const __m128i *)k)));
+        if (memcmp(want, got, 16) != 0) return 0;
+    }
+    return 1;
+}
+
+/* aesenclast must equal the same round without MixColumns, i.e. vcipherlast. */
+static int test_aesenclast_is_vcipherlast(void) {
+    for (int trial = 0; trial < 4096; trial++) {
+        uint8_t s[16], k[16], got[16], want[16];
+        fill_random(s, 16);
+        fill_random(k, 16);
+
+        uint8_t sub[16];
+        for (int i = 0; i < 16; i++) sub[i] = SBOX[s[i]];
+        for (int c = 0; c < 4; c++)
+            for (int r = 0; r < 4; r++)
+                want[c * 4 + r] = (uint8_t)(sub[((c + r) % 4) * 4 + r]
+                                            ^ k[c * 4 + r]);
+
+        _mm_storeu_si128((__m128i *)got,
+                         x86_aes_round_last(_mm_loadu_si128((const __m128i *)s),
+                                            _mm_loadu_si128((const __m128i *)k)));
+        if (memcmp(want, got, 16) != 0) return 0;
+    }
+    return 1;
+}
+
+/*
+ * ARM's aese+aesmc is aesenc(s ^ k, 0), and that is a different function of
+ * (s, k). If this ever starts passing, the porting table was right after all.
+ */
+static int test_arm_order_differs(void) {
+    int differed = 0;
+    for (int trial = 0; trial < 4096; trial++) {
+        uint8_t s[16], k[16];
+        fill_random(s, 16);
+        fill_random(k, 16);
+        __m128i sv = _mm_loadu_si128((const __m128i *)s);
+        __m128i kv = _mm_loadu_si128((const __m128i *)k);
+        __m128i power8 = x86_aes_round(sv, kv);
+        __m128i arm = x86_aes_arm_order(sv, kv);
+        if (!_mm_test_all_zeros(_mm_xor_si128(power8, arm),
+                                _mm_set1_epi8((char)0xff)))
+            differed++;
+    }
+    /* A zero key is the one case where they agree, and random keys are not
+     * zero, so every trial should differ. */
+    return differed == 4096;
+}
+
+static int test_arm_order_agrees_on_zero_key(void) {
+    uint8_t s[16];
+    fill_random(s, 16);
+    __m128i sv = _mm_loadu_si128((const __m128i *)s);
+    __m128i z = _mm_setzero_si128();
+    return _mm_test_all_zeros(
+        _mm_xor_si128(x86_aes_round(sv, z), x86_aes_arm_order(sv, z)),
+        _mm_set1_epi8((char)0xff));
+}
+
+/* With entropy off, the same inputs must give the same pattern every time. */
+static int test_pattern_is_reproducible(void) {
+    __m128i a = x86_aes_generate_pattern(7, 129, 8);
+    __m128i b = x86_aes_generate_pattern(7, 129, 8);
+    if (!_mm_test_all_zeros(_mm_xor_si128(a, b), _mm_set1_epi8((char)0xff)))
+        return 0;
+    /* And it must actually depend on where it is in the model. */
+    __m128i c = x86_aes_generate_pattern(8, 129, 8);
+    return !_mm_test_all_zeros(_mm_xor_si128(a, c), _mm_set1_epi8((char)0xff));
+}
+
+/* Every index must be a legal pshufb selector, or the collapse reads garbage. */
+static int test_pattern_indices_are_in_range(void) {
+    for (int top_k = 1; top_k <= 16; top_k++) {
+        unsigned char p[16];
+        _mm_storeu_si128((__m128i *)p,
+                         x86_aes_generate_pattern(3, top_k * 11, top_k));
+        for (int i = 0; i < 16; i++)
+            if (p[i] > 15) return 0;
+        for (int i = 0; i < top_k; i++)
+            if (p[i] != (unsigned char)i) return 0;
+    }
+    return 1;
+}
+
+/*
+ * The POWER8 8-way loop advances by eight and only ever writes vector 0, so
+ * seven eighths of the input passes through untouched. Ours must touch all of
+ * it: after a collapse, no score may still hold its original value unless the
+ * collapse decided to amplify it.
+ */
+static int test_8way_touches_every_vector(void) {
+    enum { N = 64 };
+    float scores[N * 4], before[N * 4];
+    for (int i = 0; i < N * 4; i++) scores[i] = (float)(i + 1) * 0.25f;
+    memcpy(before, scores, sizeof(before));
+
+    x86_aes_collapse_8way(scores, N, 2, 40);
+
+    for (int i = 0; i < N * 4; i++) {
+        int pruned = scores[i] == 0.0f;
+        int amplified = scores[i] > before[i];
+        if (!pruned && !amplified) return 0;
+    }
+    return 1;
+}
+
+static int test_hybrid_keeps_top_k(void) {
+    enum { N = 64 };
+    float scores[N];
+    for (int i = 0; i < N; i++) scores[i] = (float)((i * 37) % N);
+    x86_aes_hybrid_collapse(scores, N, 8, 1, 0);
+
+    int survivors = 0;
+    for (int i = 0; i < N; i++) if (scores[i] != 0.0f) survivors++;
+    return survivors > 0 && survivors < N;
+}
+
+/* It is a hash, so it must at least be a stable one. */
+static int test_attention_score_is_deterministic(void) {
+    float q[4] = {1.5f, -2.25f, 0.125f, 9.0f};
+    float k[4] = {1.5f, -2.25f, 0.125f, 9.5f};
+    uint32_t a = x86_aes_attention_score(q, k, 3, 11);
+    uint32_t b = x86_aes_attention_score(q, k, 3, 11);
+    uint32_t c = x86_aes_attention_score(q, q, 3, 11);
+    return a == b && a != c;
+}
+
+/*
+ * Pins the defect described above mode 4, so that nobody reads its name and
+ * assumes it ranks anything. If this ever fails because the correlation rose,
+ * the mode became useful and the comment needs rewriting.
+ */
+static int test_attention_score_does_not_rank_similarity(void) {
+    enum { N = 20000 };
+    double sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
+    const float q[4] = {1.5f, -2.25f, 0.125f, 9.0f};
+
+    for (int i = 0; i < N; i++) {
+        float k[4];
+        double eps = (double)(rng() % 1000) / 1000.0;
+        for (int j = 0; j < 4; j++)
+            k[j] = (float)(q[j] * (1.0 - eps)
+                           + eps * (double)((int64_t)(rng() % 200) - 100) * 0.1);
+
+        double dot = 0, nq = 0, nk = 0;
+        for (int j = 0; j < 4; j++) {
+            dot += (double)q[j] * k[j];
+            nq += (double)q[j] * q[j];
+            nk += (double)k[j] * k[j];
+        }
+        double cos = dot / (sqrt(nq) * sqrt(nk) + 1e-12);
+        double sc = (double)x86_aes_attention_score(q, k, 0, 0);
+        sx += cos; sy += sc; sxx += cos * cos; syy += sc * sc; sxy += cos * sc;
+    }
+
+    double n = (double)N;
+    double corr = (n * sxy - sx * sy)
+                / (sqrt(n * sxx - sx * sx) * sqrt(n * syy - sy * sy));
+    printf("      (correlation with cosine similarity: %+.4f)\n", corr);
+    return corr < 0.05 && corr > -0.05;
+}
+
+/*===========================================================================
+ * Cost
+ *===========================================================================*/
+
+static double now(void) {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+
+static void benchmark(void) {
+    const uint64_t n = 50000000ULL;
+    __m128i a = _mm_set1_epi32(1), b = _mm_set1_epi32(2);
+    __m128i c = _mm_set1_epi32(3), d = _mm_set1_epi32(4);
+    const __m128i k = _mm_set1_epi32((int)0x9E3779B9);
+
+    double t = now();
+    for (uint64_t i = 0; i < n; i++) a = x86_aes_round(a, k);
+    double dep = now() - t;
+
+    t = now();
+    for (uint64_t i = 0; i < n; i++) {
+        a = x86_aes_round(a, k);
+        b = x86_aes_round(b, k);
+        c = x86_aes_round(c, k);
+        d = x86_aes_round(d, k);
+    }
+    double par = now() - t;
+
+    t = now();
+    for (uint64_t i = 0; i < n; i++) b = _mm_shuffle_epi8(b, k);
+    double shuf = now() - t;
+
+    printf("\ncost per AES round\n");
+    printf("  dependent chain (latency bound)     %5.2f ns\n",
+           dep / (double)n * 1e9);
+    printf("  4 chains in flight (throughput)     %5.2f ns  (%.1f Grounds/s)\n",
+           par / (double)(n * 4) * 1e9, (double)(n * 4) / par / 1e9);
+    printf("  pshufb, dependent, for scale        %5.2f ns\n",
+           shuf / (double)n * 1e9);
+
+    /* Keep the chains alive so none of that is optimised away. */
+    volatile int sink = _mm_cvtsi128_si32(
+        _mm_xor_si128(_mm_xor_si128(a, b), _mm_xor_si128(c, d)));
+    (void)sink;
+}
+
+int main(void) {
+    x86_aes_collapse_banner();
+
+    if (!x86_aes_available()) {
+        fprintf(stderr, "\nno AES-NI on this CPU; nothing to test\n");
+        return 77;
+    }
+
+    printf("\nequivalence with POWER8\n");
+    check("aesenc(s,k) == vcipher(s,k)", test_aesenc_is_vcipher());
+    check("aesenclast(s,k) == vcipherlast(s,k)",
+          test_aesenclast_is_vcipherlast());
+
+    printf("\ndivergence of the ARM port\n");
+    check("aese+aesmc differs from vcipher for a nonzero key",
+          test_arm_order_differs());
+    check("...and agrees only when the key is zero",
+          test_arm_order_agrees_on_zero_key());
+
+    printf("\ncollapse behaviour\n");
+    check("patterns are reproducible and position dependent",
+          test_pattern_is_reproducible());
+    check("pattern indices are legal pshufb selectors",
+          test_pattern_indices_are_in_range());
+    check("8-way collapse touches all eight vectors",
+          test_8way_touches_every_vector());
+    check("hybrid collapse prunes some and keeps some",
+          test_hybrid_keeps_top_k());
+    check("mode 4 score is a deterministic hash of Q^K",
+          test_attention_score_is_deterministic());
+    check("mode 4 does NOT rank similarity (known defect)",
+          test_attention_score_does_not_rank_similarity());
+
+    benchmark();
+
+    printf("\n%s\n", failures ? "FAILURES" : "all checks passed");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Two additions, both downstream of the same idea RAM Coffers already makes for POWER8: put the weights where the memory is fast and route around what isn't.

- `gen9-cluster/` — DeepSeek V4 Pro and V4 Flash across ninth-generation consoles.
- `x86-64/` — AES-NI port of the vcipher collapse, which turned up two defects in the POWER8 original and one wrong claim in the Apple port.

`main` is untouched apart from two README sections. Nothing here has run on a console.

---

## `gen9-cluster/`

The PS5 has 16 GB of GDDR6 at 448 GB/s and a gigabit NIC. `gen9-cluster` keeps a whole layer's experts inside a box and splits the *model* across boxes. Same coffer discipline, different axis.

| profile | params | activated | on disk | floor (PS5s, 8k ctx, no SSD) |
|---|---|---|---|---|
| `deepseek-v4-pro` | 1600 B | 50 B | 803 GiB | 73 |
| `deepseek-v4-flash` | 291 B | 14 B | 148 GiB | 20 |
| `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |

The older profile that shipped in this PR's early revisions extrapolated V4 Pro from V3 (72 layers, hidden 8192, top-8, 2 MTP heads, all FP8) and was wrong in those fields; the published values are 61 layers, hidden 7168, top-6, one MTP head, and MXFP4 experts + FP8 everywhere else. The `assumed` flag and `ASSUMED CONFIGURATION` stamp stay in `ModelProfile` for the next unpublished model, but neither shipped profile sets it.

**Mixed precision.** Experts are MXFP4 (E2M1 + E8M0 scale per 32 values, 0.53125 bytes/param) and attention/router/shared-expert weights are FP8 (E4M3 + fp32 scale per 128×128 tile, 1.00024 bytes/param). Without this the Pro console count would not be ~70. `QuantSpec` records the scale overhead per format so the planner accounts for it per weight kind rather than per model.

**Hybrid attention, per layer.** V4 alternates CSA (compress every 4 tokens, attend to top-1024) and HCA (compress every 128), plus a sliding-window branch. The cache *held* and the cache *read* are different: a CSA layer at 1 M context needs ~260 MiB resident but only ~17 MiB read. `AttentionConfig` is now per-layer and `planner.py` sizes each block individually; it no longer multiplies one global KV figure by the layer count.

**Hyper-connections.** The residual stream is 4× hidden, so a shelf hop ships 56 KiB per token rather than 14 at Pro width.

**The SKU name tells you nothing.** Every one of these consoles is downbinned by design — Series X ships 56 CUs and enables 52, PS5 ships 40 and enables 36 — and any fleet you actually assemble adds its own losses: a dev-mode sandbox that only hands out ~5 GB, a board with a dead GDDR6 package, a Series S with a depopulated memory channel, a console clock-capped by a failed fan. `Downbin` records what a *specific unit* lost, `ConsoleUnit.effective` folds it into the nominal SKU, and the planner reads only the effective numbers. Fleets are allowed to be wildly heterogeneous; the planner rebalances instead of refusing. Salvage boards are first-class for the same reason — 4700S (PS5 Ariel, GPU fused off, SATA-only, PCIe 2.0 x4) and 4800S (Series X die, PCIe 4.0 x4) are different harvests, not revisions.

**Backends.** Vulkan/RADV GLSL compute is the default GPU path. ROCm is opt-in per node, because gfx1013 under Debian ROCm is partial — some libraries miss the target and others silently drop to lower-capability paths, since build scripts assume a higher gfx level. A node that has a working stack declares it in the inventory and the planner uses its *measured* throughput; nothing assumes ROCm-tuned performance anywhere. CPU AVX2 stays a first-class fallback. FP8/FP4 weights with blockwise dequant on the compute side, compressed KV, shared expert and attention pinned to the fast tier, routed experts streamed and batch-prefetched.

**G9XC, exact vs `FAST`.** Nodes return one tagged row per expert by default; the dispatcher reduces them in strict router top-k order, so placement and arrival order do not change the token. The collapsed partial sum is opt-in through the `FAST` flag. At the published V4-Pro shape (hidden 7168, k=6, 61 MoE layers) the exact reply is ~5.2 MB/token and the collapsed reply ~4.7 MB/token because the top-6 scatter across ~5.4 consoles in a 22-console shelf.

One guarantee this deliberately does **not** make: a G9XC shelf can mix `cpu-avx2`, `vulkan` and `rocm` nodes, and those do not sum an expert's FMAs in the same order. Per-expert rows buy placement-independence *for a fixed expert-to-backend assignment*; fleet-wide bit-identity would additionally mean pinning a reference kernel. `docs/G9XC.md` states that rather than implying more.

## `x86-64/`

Third target for the collapse after POWER8 and ARM, and the only one that reproduces POWER8 exactly:

```
aesenc(s,k)  = MixColumns(ShiftRows(SubBytes(s))) XOR k
vcipher(s,k) = MixColumns(ShiftRows(SubBytes(s))) XOR k
```

so every mode transcribes literally. `bench-aes-collapse.c` checks it against a scalar FIPS-197 round rather than against another intrinsic. Cost on a Xeon 8559C: 0.75 ns per round on a dependent chain, 0.19 ns with four in flight, against 0.27 ns for a dependent `pshufb` — three `pshufb` latencies, free on throughput, the same argument the POWER8 header makes.

Three findings, all demonstrated by checks in the bench rather than asserted:

**`vaeseq_u8` + `vaesmcq_u8` is not `vcipher`.** AESE applies the key *first* and AESMC adds no final XOR, so the pair computes `aesenc(s ^ k, 0)` — a different function of `(s,k)`, agreeing only when the key is zero. `apple-silicon/` documentation lists them as equivalent; diffusion quality is unaffected, but the ports do not produce the same bytes for the same inputs. I left the Apple docs alone — happy to correct them in this PR or separately, your call. `x86_aes_arm_order()` exists for anyone who needs to match the Apple port instead.

**`vcipher_collapse_8way` only writes vector 0.** It advances the loop by eight, and the body is followed by `/* ... same for vectors 1-7 (unrolled in production) */`, so seven eighths of its input passes through untouched. The x86 version processes all eight and a test pins it.

**Mode 4 does not measure similarity.** `vcipher_attention_score` reasons that similar Q,K XOR to near zero and so produce low output energy. Over 200k Q/K pairs, correlation between that score and cosine similarity is **+0.002**, and the score for `Q == K` sits mid-range among unrelated pairs. Avalanche is the cause — it is what the mode is built on and exactly what destroys any monotonic relation between input distance and output byte-sum, since SubBytes maps `0x00` to `0x63`. What it actually is: a deterministic 12-bit hash of `Q^K` that detects equality and nothing weaker. Ported and documented as that rather than deleted, with a test pinning the correlation, because the other two ports ship it and a silent divergence would be worse than a loud caveat.

Two deliberate divergences: round keys come from `(layer, position, counter)` instead of the timebase, since `mftb`/`rdtsc` keying means no two runs produce the same patterns (`-DX86_AES_COLLAPSE_ENTROPY=1` restores the original); and `vec_perm` numbers bytes from the most significant end on big-endian POWER while `pshufb` numbers from the least, so patterns are mirrored — `x86_aes_beswap()` converts.

`gen9-cluster` does not call any of this, on purpose: that fleet runs attention on RDNA2 through Vulkan, which has no AES instruction, and every node in it is Zen 2 (AES-NI yes, VAES no).

## What is verified, and what is not

```
cd gen9-cluster
python3 -m unittest discover -s tests -t .   # 209 tests, OK
python3 -m flake8 --max-line-length=100 gen9_cluster tests      # clean
python3 -m mypy --ignore-missing-imports gen9_cluster           # clean, 16 files
cd kernels && make && make test              # CPU kernel + FP8 conformance
cd x86-64 && make bench                      # all checks pass
```

Not verified, and please read this before merging:

- **No console has run this.** Loopback TCP and simulated fleets only.
- The Vulkan and HIP kernels compile — SPIR-V validates — but have never executed on a device.
- The V4 profiles are the published model cards, but how those fields become *bytes* is this repository's reading of the paper, validated against the published totals rather than term by term.
- Throughput figures come from the planner's own cost model, not measurement.
- The x86 timings are one machine. Zen 2 has different AES latency and port count; remeasure before quoting.
- Hardware values in `docs/REFERENCES.md` are individually marked measured, estimated, or untested.

Hardware-specific deployment — inventory, bring-up, rack and power, burn-in — lives in a separate repo (`erkinalp/deepseek4-gen9-helpers`) so this one stays the portable core.
