### PR TITLE
feat: implement Reduced Matrix Multiplication (arXiv:2608.13426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ RAM Coffers is a NUMA-distributed conditional-memory architecture for LLM infere
 
 Tracking the next release on `main`. See open issues and PRs on the [GitHub repo](https://github.com/Scottcjn/ram-coffers).
 
+### Added
+- **Reduced Matrix Multiplication** (`ggml-rmm.h`, `docs/RMM.md`) — implementation of [arXiv:2608.13426](https://arxiv.org/abs/2608.13426) (Lan, Li, Zhou), which reduces each product `Y = A B` to the `ceil(ρ·d)` slices of the shared contraction axis with the largest activation column norms `‖A[:, j]‖₂`. Training-free, weight-preserving, deterministic, and re-decided per input/layer/head/decode step. Covers projections and FFN matrices (`rmm_project`, `rmm_project_gemv`) plus attention with `QKᵀ` feature reduction and optional `PV` token reduction (`rmm_attention`). Because a contraction-axis ratio is a *weight-row* ratio, only `ρ` of a coffer's bank is read — `rmm_prefetch_rows()` warms exactly the retained rows via `dcbt`. Scalar C11 path everywhere, VSX/AltiVec fast path on POWER8; `ρ = 1` is bit-identical to the dense kernel.
+- **RMM test suite and benchmark** (`tests/rmm_test.c`, root `Makefile`) — checks TopK determinism and tie resolution, bit-exact dense equivalence at `ρ = 1`, the paper's Proposition 1 error bound, activation-aware vs random selection at equal budget, the minimax selection claim, attention accuracy at `ρ_d = 0.5`, and MAC accounting. `make` runs it on x86-64 (1.75× on a 4096×4096 GEMV at `ρ_d = 0.5`, selection included); `make power8` builds the VSX path.
+
 ---
 
 ## [0.5.0] — 2026-05-18 — *Operability & DePIN positioning*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# RAM Coffers is a header-only library, so there is nothing to link into a
+# product here; what this Makefile builds is the portable self-tests, which is
+# what CI needs to be able to run on an x86 runner.
+#
+#   make            -> build and run the portable tests (default)
+#   make rmm-test   -> build tests/rmm_test.c only
+#   make power8     -> compile-check the POWER8/VSX headers (needs a POWER8
+#                      target compiler; skipped elsewhere)
+
+BUILD_DIR ?= build
+CC        ?= cc
+# _POSIX_C_SOURCE: strict c11 hides clock_gettime, which the tests time with.
+CFLAGS    ?= -O2 -std=c11 -Wall -Wextra -D_POSIX_C_SOURCE=200809L
+LDLIBS    ?= -lm
+
+.PHONY: all test rmm-test power8 clean
+
+all: test
+
+test: $(BUILD_DIR)/rmm_test
+	$(BUILD_DIR)/rmm_test
+
+rmm-test: $(BUILD_DIR)/rmm_test
+
+$(BUILD_DIR)/rmm_test: tests/rmm_test.c ggml-rmm.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $@ tests/rmm_test.c $(LDLIBS)
+
+# The VSX path of ggml-rmm.h only exists on POWER8; this target exercises it.
+POWER8_CFLAGS ?= $(CFLAGS) -mcpu=power8 -maltivec -mvsx
+
+power8: $(BUILD_DIR)/rmm_test_power8
+
+$(BUILD_DIR)/rmm_test_power8: tests/rmm_test.c ggml-rmm.h power8-compat.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(POWER8_CFLAGS) -o $@ tests/rmm_test.c $(LDLIBS)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -203,11 +203,34 @@ Requires `-mcrypto` for `__builtin_crypto_vcipher()` / `__builtin_crypto_vcipher
 | **`vcipher-flash-attn-patch.c`** | **Flash attention inner loop patch (ops.cpp reference)** |
 | **`bench_vcipher_collapse.c`** | **Benchmark: vcipher vs vec_perm collapse** |
 | `pse-entropy-burst.h` | Hardware entropy injection via PowerPC timebase |
+| `ggml-rmm.h` | Reduced Matrix Multiplication — input-adaptive contraction-axis reduction (arXiv:2608.13426) |
 | `power8-compat.h` | POWER9→POWER8 intrinsic compatibility layer |
 | `ggml-neuromorphic-coffers.h` | Brain hemisphere → NUMA cognitive routing |
 | `ggml-symbolic-neural-bridge.h` | PowerLISP ↔ neural integration |
 | **`apple-silicon/`** | **Apple Silicon PSE port — NEON + AES + unified memory coffers** |
 | **`gen9-cluster/`** | **DeepSeek V4 Pro / Flash across PS5 / Xbox Series consoles — coffers as a fleet** |
+
+## Reduced Matrix Multiplication (NEW — August 2026)
+
+`ggml-rmm.h` implements [arXiv:2608.13426](https://arxiv.org/abs/2608.13426),
+*Reduced Matrix Multiplication* (Lan, Li, Zhou): every heavy product `Y = A B`
+keeps only the `ceil(ρ·d)` slices of the shared axis with the largest activation
+column norms, `‖A[:, j]‖₂`. Training-free, weight-preserving, deterministic, and
+re-decided per input, layer, head and decode step.
+
+It fits coffers because reducing the contraction axis reduces *rows of the weight
+matrix*: `X[:, I] W[I, :]` reads only `ρ` of a bank, so the FLOP saving lands as
+a bandwidth and page-residency saving. Unlike `ggml-topk-collapse-vsx.h`, which
+prunes attention scores after `QKᵀ` is paid for, RMM shrinks the multiply itself
+— the head dimension inside `QKᵀ` and optionally the token axis inside `PV`.
+
+```bash
+make         # scalar path + self-tests/benchmark
+make power8  # VSX path (-mcpu=power8 -maltivec -mvsx)
+```
+
+`ρ = 1` is bit-identical to the dense kernel. See [`docs/RMM.md`](docs/RMM.md)
+for the API, the error bound, and the attention/GQA rules.
 
 ## Ninth-Generation Console Cluster (NEW — August 2026)
 

--- a/docs/RMM.md
+++ b/docs/RMM.md
@@ -1,0 +1,261 @@
+# Reduced Matrix Multiplication (RMM)
+
+`ggml-rmm.h` implements **Reduced Matrix Multiplication**, an input-adaptive,
+training-free reduction of the matrix products that dominate LLM inference.
+
+**Source paper:** Zixuan Lan, Yanhong Li, Jiawei Zhou, *"Reduced Matrix
+Multiplication: Input-Adaptive Matrix-Product Reduction for LLM Inference"*,
+arXiv:2608.13426 — <https://arxiv.org/abs/2608.13426>.
+
+## 1. The method
+
+Every heavy Transformer op is `Y = A B`, with `A ∈ R^{n×d}` the activations
+(observable at inference time) and `B ∈ R^{d×m}` the weights or the K/V cache.
+Writing the product as a sum over the shared contraction axis,
+
+```
+A B = Σ_{j=1..d} A[:, j] B[j, :]
+```
+
+RMM keeps only a subset `I` of that axis:
+
+```
+RMM_ρ(A, B) = A[:, I] B[I, :],      |I| = ceil(ρ · d)
+```
+
+and chooses `I` from the *current* activations by column 2-norm:
+
+```
+s_j = ‖A[:, j]‖₂ ,   I = TopK(s, ceil(ρ · d))
+```
+
+Properties that matter for this project:
+
+| Property | Consequence |
+|---|---|
+| Training-free, weight-preserving | drops into an existing GGUF/coffer model with no conversion |
+| Deterministic given `A` | same input ⇒ same `I`, so runs are reproducible and attestable |
+| Input-adaptive | `I` moves freely between inputs, layers, heads and decode steps |
+| Minimax optimal (paper, App. E.1) | dropping `j` costs `‖A[:,j]‖₂·‖B[j,:]‖₂`; keeping the largest column norms minimises worst-case Frobenius error over every `B` consistent with the budget |
+| `ρ = 1` is the identity | exact mode is bit-identical to the dense kernel |
+
+**Proposition 1 (error bound).** With `D` the discarded index set,
+
+```
+‖A B − RMM_ρ(A, B)‖_F  ≤  Σ_{j ∈ D} ‖A[:, j]‖₂ ‖B[j, :]‖₂
+```
+
+`tests/rmm_test.c` checks this bound directly, plus the minimax claim and the
+activation-aware-vs-random-selection comparison.
+
+## 2. Why it belongs in RAM Coffers
+
+A retention ratio on the contraction axis is a retention ratio on **rows of the
+weight matrix**: `X[:, I] W[I, :]` reads only `|I|` rows of `W`. With weights
+mmap'd into NUMA coffers, that is the difference between streaming a whole bank
+and streaming `ρ` of it — so the arithmetic saving arrives as a **bandwidth and
+page-residency saving**, which is the axis a POWER8 node is actually short of.
+`rmm_prefetch_rows()` issues `dcbt` (POWER) or `__builtin_prefetch` for exactly
+the retained rows, so at `ρ = 0.5` half the bank never enters cache.
+
+Relation to the existing collapse headers: `ggml-topk-collapse-vsx.h` prunes
+attention *scores* after `QKᵀ` has already been paid for. RMM shrinks the
+products themselves — the head dimension inside `QKᵀ`, and optionally the token
+axis inside `PV` — so the saving is in the multiply, not in the softmax. The two
+are composable.
+
+## 3. API reference
+
+All functions are `static inline` in `ggml-rmm.h`; matrices are row-major
+`float`.
+
+### Configuration
+
+```c
+typedef struct {
+    float rho_d;     /* retention on the feature/contraction axis */
+    float rho_t;     /* retention on the token axis of PV; 1.0f = dense PV */
+    int   min_keep;  /* never reduce below this many indices */
+} rmm_config_t;
+
+rmm_config_t cfg = rmm_config_default();   /* 0.75 / 1.0 / 8 */
+```
+
+Compile-time defaults: `RMM_RHO_D_DEFAULT`, `RMM_RHO_T_DEFAULT`,
+`RMM_MIN_KEEP`. The paper's component analysis finds attention products far more
+reducible than MLP ones, so give MLPs a higher `rho_d` than attention.
+
+`int rmm_keep_count(int d, float rho, int min_keep)` returns
+`ceil(rho·d)` clamped to `[min(min_keep, d), d]`.
+
+### Workspace
+
+Selection buffers are sized once per model, never per call — these paths run
+inside the decode loop.
+
+```c
+rmm_workspace_t ws;
+/* max_probs = max_q_rows * max_tokens, or 0 to leave PV dense */
+if (!rmm_workspace_init(&ws, max_d, max_tokens, max_probs)) { /* OOM */ }
+...
+rmm_workspace_free(&ws);
+```
+
+### Selection
+
+```c
+void  rmm_feature_scores(const float *A, int n, int d, int lda, float *scores);
+float rmm_kth_largest   (const float *scores, int d, int k, float *scratch);
+int   rmm_select_topk   (const float *scores, int d, int k,
+                         int32_t *idx, float *scratch);
+```
+
+`rmm_select_topk()` quickselects the threshold, then sweeps `j` ascending taking
+everything above it and as many ties as the budget allows. The ascending sweep
+is what makes selection reproducible — ties break to the **lowest index**, not
+to quickselect's pivot order — and it leaves `idx` sorted, so the gathers in the
+inner loops move forwards through memory.
+
+### Reduced products
+
+```c
+void rmm_gemv_reduced(const float *W, const float *x, float *y,
+                      int rows, int d, int ldw, const int32_t *idx, int k);
+
+void rmm_gemm_reduced(const float *A, const float *B, float *Y,
+                      int n, int d, int m, int lda, int ldb, int ldy,
+                      const int32_t *idx, int k);
+
+void rmm_prefetch_rows(const float *B, int ldb, const int32_t *idx, int k);
+```
+
+### Projections (paper §3.3)
+
+```c
+int rmm_project     (const float *X, int L, int d, const float *W, int dout,
+                     float *Y, const rmm_config_t *cfg, rmm_workspace_t *ws);
+
+int rmm_project_gemv(const float *x, int d, const float *W, int rows,
+                     float *y, const rmm_config_t *cfg, rmm_workspace_t *ws);
+```
+
+One call covers Q/K/V projections, the attention output projection, and an FFN's
+gate/up/down matrices. `rmm_project_gemv()` is the decode-step form for weights
+stored row-major as `rows × d` — the layout the coffer headers mmap. Both return
+the retained count `k`, or `-1` if the workspace is too small.
+
+### Attention (paper §3.3)
+
+```c
+int rmm_attention(float *out, const float *Q, const float *K, const float *V,
+                  int Lq, int Lk, int dh, int causal,
+                  const rmm_config_t *cfg, rmm_workspace_t *ws);
+```
+
+Per head: score the head dimension with `s_j = ‖Q[:, j]‖₂`, reduce `QKᵀ` over
+the retained dimensions, softmax (causal-masked if asked), then optionally
+reduce `PV` over the token axis using `a_t = ‖P[:, t]‖₂`.
+
+- **The scale stays `1/sqrt(dh)`**, not `1/sqrt(k)`: RMM approximates the dense
+  logits, so rescaling by the reduced width would shift the softmax temperature
+  away from the model's calibration.
+- **Grouped-query attention:** selection is per query head on `Q`, with the
+  retained dimensions gathered from the shared K/V — call once per query head,
+  passing that head's `Q` with the K/V of its group.
+- **Token reduction drops the discarded attention mass** instead of
+  renormalising, exactly as the paper defines `PV → P[:, T] V[T, :]`. Output
+  rows are therefore slightly shrunk; that is part of the approximation being
+  measured, not a bug.
+- Token reduction (`rho_t < 1`) requires the `probs` buffer, i.e. a non-zero
+  `max_probs` at init, because `a_t` is taken over the whole query block and
+  cannot be formed while streaming `P` row by row. Without it the call returns
+  `-1`.
+
+### Dense references and statistics
+
+```c
+void rmm_gemv_dense     (const float *W, const float *x, float *y,
+                         int rows, int d, int ldw);
+void rmm_attention_dense(float *out, const float *Q, const float *K,
+                         const float *V, int Lq, int Lk, int dh,
+                         int causal, float *scores);
+
+void rmm_stats_reset (void);
+void rmm_stats_report(void);   /* selections, and MACs kept vs dense */
+```
+
+Statistics report the *realised* reduction rather than the requested one —
+`min_keep` and causal masking make the two differ.
+
+## 4. Usage sketch
+
+```c
+#include "ggml-rmm.h"
+
+rmm_config_t cfg = rmm_config_default();
+cfg.rho_d = 0.5f;                    /* attention: half the head dimension */
+
+rmm_workspace_t ws;
+rmm_workspace_init(&ws, /*max_d*/ 4096, /*max_tokens*/ 8192, /*max_probs*/ 0);
+
+/* decode-step projection out of a coffer-resident weight bank */
+rmm_project_gemv(x, d, W_bank, rows, y, &cfg, &ws);
+
+/* one attention head, causal */
+rmm_attention(out, Q, K, V, Lq, Lk, dh, /*causal*/ 1, &cfg, &ws);
+
+rmm_stats_report();
+rmm_workspace_free(&ws);
+```
+
+Set `cfg.rho_d = cfg.rho_t = 1.0f` to fall back to exact dense behaviour without
+removing the call.
+
+## 5. Portability
+
+- **Scalar C11** everywhere; this is the path CI exercises on x86-64.
+- **VSX/AltiVec** fast path under `#if defined(__VSX__)`, using `vec_xl` /
+  `vec_xst` / `vec_madd` via `power8-compat.h`. Plain AltiVec `vec_ld` is
+  deliberately not used: these loops load at arbitrary float offsets, which
+  `vec_ld` would silently truncate to a 16-byte boundary.
+- `dcbt` prefetch on `__powerpc__` / `__powerpc64__`, `__builtin_prefetch`
+  elsewhere.
+
+## 6. Build and test
+
+```bash
+make            # build and run tests/rmm_test.c (scalar path)
+make power8     # build with -mcpu=power8 -maltivec -mvsx (VSX path)
+make clean
+```
+
+The test suite covers: retention arithmetic, TopK correctness and determinism
+(including tie resolution), column-norm scoring, bit-exact dense equivalence at
+`ρ = 1` (GEMV and attention), the Proposition 1 bound, activation-aware vs
+random selection at equal budget, the minimax claim, attention accuracy at
+`ρ_d = 0.5`, token reduction and its MAC accounting, workspace refusal on
+undersized buffers, and a dense-vs-reduced GEMV benchmark.
+
+Reference results, 4096×4096 GEMV, `ρ_d = 0.5`, selection included in the timing:
+
+| Host | Dense | Reduced | Speed-up |
+|---|---|---|---|
+| x86-64 (scalar path) | 21.87 ms | 12.53 ms | 1.75× |
+| POWER8 VSX path (qemu-ppc64le, syntax/behaviour check only) | 2463.51 ms | 870.39 ms | 2.83× |
+
+The POWER8 row is emulated, so treat the ratio — not the absolute times — as the
+signal; it needs re-measuring on real POWER8 hardware.
+
+## 7. Citation
+
+```bibtex
+@misc{lan2026rmm,
+  title  = {Reduced Matrix Multiplication: Input-Adaptive Matrix-Product
+            Reduction for LLM Inference},
+  author = {Lan, Zixuan and Li, Yanhong and Zhou, Jiawei},
+  year   = {2026},
+  eprint = {2608.13426},
+  archivePrefix = {arXiv},
+  url    = {https://arxiv.org/abs/2608.13426}
+}
+```

--- a/ggml-rmm.h
+++ b/ggml-rmm.h
@@ -1,0 +1,624 @@
+/*
+ * ggml-rmm.h - Reduced Matrix Multiplication (RMM)
+ *
+ * Implementation of "Reduced Matrix Multiplication: Input-Adaptive
+ * Matrix-Product Reduction for LLM Inference", Lan, Li and Zhou,
+ * arXiv:2608.13426.
+ *
+ * THE METHOD
+ * ----------
+ * Every heavy Transformer op is Y = A B with A in R^{n x d} (activations,
+ * known at inference time) and B in R^{d x m} (weights, or K/V). RMM keeps
+ * only a subset I of the shared contraction axis:
+ *
+ *     RMM_rho(A, B) = A[:, I] B[I, :],    |I| = ceil(rho * d)
+ *
+ * and picks I deterministically from the *current* activations by column
+ * norm, s_j = ||A[:, j]||_2, I = TopK(s, ceil(rho*d)). That rule is minimax
+ * optimal (paper, Appendix E.1): since AB = sum_j A[:,j] B[j,:] and dropping
+ * j costs ||A[:,j]||_2 ||B[j,:]||_2, retaining the largest column norms
+ * minimises the worst-case Frobenius error over every B consistent with the
+ * budget. No weights are modified and nothing is trained; the retained
+ * subspace is free to move between inputs, layers, heads and decode steps.
+ *
+ * WHY IT BELONGS HERE
+ * -------------------
+ * A retention ratio on the contraction axis is a retention ratio on *rows of
+ * the weight matrix*: X[:, I] W[I, :] touches only |I| rows of W. On POWER8
+ * with weights living in mmap'd NUMA coffers, that is the difference between
+ * streaming a whole bank and streaming rho of it, so the FLOP saving shows up
+ * as a bandwidth and page-residency saving too - the axis this project is
+ * actually short of. rmm_prefetch_rows() warms just the retained rows.
+ *
+ * Relation to the collapse headers: ggml-topk-collapse-vsx.h prunes attention
+ * *scores* after QK^T is already paid for. RMM instead shrinks the products
+ * themselves - the head dimension inside QK^T, and (optionally) the token axis
+ * inside PV - so the saving is in the multiply, not in the softmax.
+ *
+ * Portable C11: the scalar path builds anywhere (that is what CI exercises),
+ * with a VSX/AltiVec path on POWER8 when the target has it.
+ *
+ * License: Apache 2.0
+ */
+
+#ifndef GGML_RMM_H
+#define GGML_RMM_H
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* VSX only, not plain AltiVec: the loops below load at arbitrary float
+ * offsets, and vec_xl tolerates that while vec_ld would silently truncate the
+ * address to a 16-byte boundary. */
+#if defined(__VSX__)
+#include <altivec.h>
+#include "power8-compat.h"
+#define RMM_HAVE_VSX 1
+#else
+#define RMM_HAVE_VSX 0
+#endif
+
+/*===========================================================================
+ * Configuration
+ *
+ * rho_d - retention ratio on the feature/contraction axis (hidden channels
+ *         for projections, head dimension for QK^T).
+ * rho_t - retention ratio on the token axis of PV. 1.0f leaves PV dense,
+ *         which is the paper's default for the main results.
+ *
+ * The paper's component analysis found attention-side products far more
+ * reducible than MLP ones, so the two axes are configured separately and
+ * callers are expected to give MLPs a higher rho_d than attention.
+ *===========================================================================*/
+
+#ifndef RMM_RHO_D_DEFAULT
+#define RMM_RHO_D_DEFAULT 0.75f
+#endif
+
+#ifndef RMM_RHO_T_DEFAULT
+#define RMM_RHO_T_DEFAULT 1.0f
+#endif
+
+/* Never reduce below this many indices, whatever rho asks for: at tiny d a
+ * ratio alone can collapse a product to noise. */
+#ifndef RMM_MIN_KEEP
+#define RMM_MIN_KEEP 8
+#endif
+
+typedef struct {
+    float rho_d;
+    float rho_t;
+    int   min_keep;
+} rmm_config_t;
+
+static inline rmm_config_t rmm_config_default(void) {
+    rmm_config_t cfg;
+    cfg.rho_d    = RMM_RHO_D_DEFAULT;
+    cfg.rho_t    = RMM_RHO_T_DEFAULT;
+    cfg.min_keep = RMM_MIN_KEEP;
+    return cfg;
+}
+
+/* ceil(rho * d), clamped to [min(min_keep, d), d]. rho >= 1 gives d, so
+ * rho = 1 degenerates to the dense product - see rmm_gemv_reduced(). */
+static inline int rmm_keep_count(int d, float rho, int min_keep) {
+    if (d <= 0) return 0;
+    if (!(rho > 0.0f)) return (min_keep < d) ? min_keep : d;
+    if (rho >= 1.0f) return d;
+
+    int k = (int)ceilf(rho * (float)d);
+    if (min_keep > 0 && k < min_keep) k = min_keep;
+    if (k > d) k = d;
+    if (k < 1) k = 1;
+    return k;
+}
+
+/*===========================================================================
+ * Statistics
+ *
+ * Counts multiply-accumulates as they would have been paid densely versus as
+ * RMM actually paid them, so a run can report the realised reduction rather
+ * than the requested one (min_keep and causal masking make the two differ).
+ *===========================================================================*/
+
+typedef struct {
+    uint64_t macs_dense;
+    uint64_t macs_reduced;
+    uint64_t selections;
+} rmm_stats_t;
+
+static rmm_stats_t g_rmm_stats = {0, 0, 0};
+
+static inline void rmm_stats_reset(void) {
+    memset(&g_rmm_stats, 0, sizeof(g_rmm_stats));
+}
+
+static inline void rmm_stats_report(void) {
+    const double dense = (double)g_rmm_stats.macs_dense;
+    const double kept  = (double)g_rmm_stats.macs_reduced;
+    fprintf(stderr, "RMM: %llu selections, %.3g/%.3g MACs kept (%.1f%%)\n",
+            (unsigned long long)g_rmm_stats.selections, kept, dense,
+            dense > 0.0 ? 100.0 * kept / dense : 100.0);
+}
+
+/*===========================================================================
+ * Feature scores: s_j = ||A[:, j]||_2
+ *
+ * A is row-major n x d with row stride lda. Accumulating squares column-wise
+ * over a row-major walk keeps A streaming forwards, which matters more than
+ * the vectorisation: at prefill n is large and A does not fit in L2.
+ *===========================================================================*/
+
+static inline void rmm_feature_scores(const float *A, int n, int d, int lda,
+                                      float *scores) {
+    memset(scores, 0, (size_t)d * sizeof(float));
+
+    for (int i = 0; i < n; i++) {
+        const float *row = A + (size_t)i * (size_t)lda;
+        int j = 0;
+#if RMM_HAVE_VSX
+        for (; j + 3 < d; j += 4) {
+            vector float v = vec_xl(0, &row[j]);
+            vector float s = vec_xl(0, &scores[j]);
+            vec_xst(vec_madd(v, v, s), 0, &scores[j]);
+        }
+#endif
+        for (; j < d; j++) {
+            scores[j] += row[j] * row[j];
+        }
+    }
+
+    for (int j = 0; j < d; j++) {
+        scores[j] = sqrtf(scores[j]);
+    }
+}
+
+/*===========================================================================
+ * Deterministic TopK selection
+ *
+ * Two steps, both O(d) on average:
+ *   1. quickselect the k-th largest score (the retention threshold);
+ *   2. sweep j ascending, taking everything above the threshold and then as
+ *      many ties as the budget still allows.
+ *
+ * The ascending sweep is what makes selection reproducible: ties are broken
+ * by lowest index rather than by quickselect's pivot order, so the same
+ * activations always yield the same I, on any host and at any -O level. The
+ * output indices come out ascending, which also keeps the gathers in
+ * ggml-rmm's inner loops moving forwards through memory.
+ *
+ * scratch must hold d floats; scores itself is not modified.
+ *===========================================================================*/
+
+static inline float rmm_kth_largest(const float *scores, int d, int k,
+                                    float *scratch) {
+    if (k >= d) return -INFINITY;
+    if (k <= 0) return INFINITY;
+
+    memcpy(scratch, scores, (size_t)d * sizeof(float));
+
+    int lo = 0, hi = d - 1;
+    const int target = k - 1;
+
+    while (lo < hi) {
+        const float pivot = scratch[hi];
+        int store = lo;
+        for (int i = lo; i < hi; i++) {
+            if (scratch[i] >= pivot) {
+                const float tmp = scratch[store];
+                scratch[store] = scratch[i];
+                scratch[i] = tmp;
+                store++;
+            }
+        }
+        const float tmp = scratch[store];
+        scratch[store] = scratch[hi];
+        scratch[hi] = tmp;
+
+        if (store == target) return scratch[store];
+        if (store < target) lo = store + 1;
+        else hi = store - 1;
+    }
+    return scratch[lo];
+}
+
+/* Returns the number of indices written to idx (always k for 0 < k <= d). */
+static inline int rmm_select_topk(const float *scores, int d, int k,
+                                  int32_t *idx, float *scratch) {
+    if (k >= d) {
+        for (int j = 0; j < d; j++) idx[j] = (int32_t)j;
+        g_rmm_stats.selections++;
+        return d;
+    }
+    if (k <= 0) return 0;
+
+    const float threshold = rmm_kth_largest(scores, d, k, scratch);
+
+    /* How much of the budget the tie class at the threshold gets to fill. */
+    int strictly_above = 0;
+    for (int j = 0; j < d; j++) {
+        if (scores[j] > threshold) strictly_above++;
+    }
+    int ties_left = k - strictly_above;
+
+    int count = 0;
+    for (int j = 0; j < d && count < k; j++) {
+        if (scores[j] > threshold) {
+            idx[count++] = (int32_t)j;
+        } else if (scores[j] == threshold && ties_left > 0) {
+            idx[count++] = (int32_t)j;
+            ties_left--;
+        }
+    }
+
+    g_rmm_stats.selections++;
+    return count;
+}
+
+/*===========================================================================
+ * Reduced products
+ *===========================================================================*/
+
+/* Warm the retained rows of a weight matrix. On POWER8 this is the dcbt the
+ * rest of the project uses; elsewhere it is the compiler's prefetch builtin.
+ * Only the rows RMM will actually read are touched, which is the point: at
+ * rho = 0.5 half the bank never enters cache. */
+static inline void rmm_prefetch_rows(const float *B, int ldb,
+                                     const int32_t *idx, int k) {
+    for (int t = 0; t < k; t++) {
+        const float *row = B + (size_t)idx[t] * (size_t)ldb;
+#if defined(__powerpc64__) || defined(__powerpc__)
+        __asm__ __volatile__("dcbt 0,%0" : : "r"(row) : "memory");
+#else
+        __builtin_prefetch(row, 0, 1);
+#endif
+    }
+}
+
+/*
+ * y = W[:, I] x[I], W row-major rows x d with row stride ldw.
+ *
+ * This is the projection/FFN case with n = 1 (decode). Summation follows I
+ * ascending, so at rho = 1 (I = 0..d-1) the result is bit-identical to the
+ * dense kernel rather than merely close - reduction must not perturb exact
+ * mode when it is switched off.
+ */
+static inline void rmm_gemv_reduced(const float *W, const float *x, float *y,
+                                    int rows, int d, int ldw,
+                                    const int32_t *idx, int k) {
+    g_rmm_stats.macs_dense   += (uint64_t)rows * (uint64_t)d;
+    g_rmm_stats.macs_reduced += (uint64_t)rows * (uint64_t)k;
+
+    for (int m = 0; m < rows; m++) {
+        const float *w = W + (size_t)m * (size_t)ldw;
+        float sum = 0.0f;
+        for (int t = 0; t < k; t++) {
+            const int j = idx[t];
+            sum += w[j] * x[j];
+        }
+        y[m] = sum;
+    }
+}
+
+/*
+ * Y = A[:, I] B[I, :], A row-major n x d, B row-major d x m, Y row-major
+ * n x m.
+ *
+ * Accumulated as a sum of rank-one updates over the retained axis (the same
+ * decomposition the minimax argument uses), so each retained row of B is
+ * streamed once per output row and never re-gathered.
+ */
+static inline void rmm_gemm_reduced(const float *A, const float *B, float *Y,
+                                    int n, int d, int m, int lda, int ldb,
+                                    int ldy, const int32_t *idx, int k) {
+    g_rmm_stats.macs_dense   += (uint64_t)n * (uint64_t)d * (uint64_t)m;
+    g_rmm_stats.macs_reduced += (uint64_t)n * (uint64_t)k * (uint64_t)m;
+
+    for (int i = 0; i < n; i++) {
+        const float *a = A + (size_t)i * (size_t)lda;
+        float *out = Y + (size_t)i * (size_t)ldy;
+        memset(out, 0, (size_t)m * sizeof(float));
+
+        for (int t = 0; t < k; t++) {
+            const int j = idx[t];
+            const float scale = a[j];
+            if (scale == 0.0f) continue;
+            const float *b = B + (size_t)j * (size_t)ldb;
+
+            int c = 0;
+#if RMM_HAVE_VSX
+            vector float sv = vec_splats(scale);
+            for (; c + 3 < m; c += 4) {
+                vector float bv = vec_xl(0, &b[c]);
+                vector float ov = vec_xl(0, &out[c]);
+                vec_xst(vec_madd(bv, sv, ov), 0, &out[c]);
+            }
+#endif
+            for (; c < m; c++) {
+                out[c] += scale * b[c];
+            }
+        }
+    }
+}
+
+/* S = (1/sqrt(dh)) Q[:, I] K[:, I]^T, one query row at a time.
+ *
+ * The scale stays 1/sqrt(dh), not 1/sqrt(k): RMM approximates the dense
+ * logits, so rescaling by the reduced width would shift the softmax
+ * temperature away from the model's calibration. */
+static inline void rmm_scores_reduced(const float *q, const float *K,
+                                      float *scores, int Lk, int dh, int ldk,
+                                      const int32_t *idx, int k, int limit) {
+    const float scale = 1.0f / sqrtf((float)dh);
+
+    g_rmm_stats.macs_dense   += (uint64_t)limit * (uint64_t)dh;
+    g_rmm_stats.macs_reduced += (uint64_t)limit * (uint64_t)k;
+    (void)Lk;
+
+    for (int t = 0; t < limit; t++) {
+        const float *krow = K + (size_t)t * (size_t)ldk;
+        float sum = 0.0f;
+        for (int u = 0; u < k; u++) {
+            const int j = idx[u];
+            sum += q[j] * krow[j];
+        }
+        scores[t] = sum * scale;
+    }
+}
+
+/*===========================================================================
+ * Workspace
+ *
+ * Selection needs d scores, d indices and a scratch copy for quickselect;
+ * token reduction additionally needs the full P matrix, because token scores
+ * a_t = ||P[:, t]||_2 are taken over the whole query block and so cannot be
+ * formed while streaming P row by row. Sizing is done once per model rather
+ * than per call: these paths run inside the decode loop.
+ *===========================================================================*/
+
+typedef struct {
+    float   *scores;
+    float   *scratch;
+    int32_t *idx;
+    float   *tok_scores;
+    float   *tok_scratch;
+    int32_t *tok_idx;
+    float   *probs;      /* Lq x Lk, only when token reduction is wanted */
+    int      cap_d;
+    int      cap_tokens;
+    int      cap_probs;
+} rmm_workspace_t;
+
+/* max_probs is max_q_rows * max_tokens, or 0 to leave PV dense. */
+static inline int rmm_workspace_init(rmm_workspace_t *ws, int max_d,
+                                     int max_tokens, size_t max_probs) {
+    memset(ws, 0, sizeof(*ws));
+
+    ws->scores  = (float *)calloc((size_t)max_d, sizeof(float));
+    ws->scratch = (float *)calloc((size_t)max_d, sizeof(float));
+    ws->idx     = (int32_t *)calloc((size_t)max_d, sizeof(int32_t));
+    ws->cap_d   = max_d;
+
+    if (max_tokens > 0) {
+        ws->tok_scores  = (float *)calloc((size_t)max_tokens, sizeof(float));
+        ws->tok_scratch = (float *)calloc((size_t)max_tokens, sizeof(float));
+        ws->tok_idx     = (int32_t *)calloc((size_t)max_tokens,
+                                            sizeof(int32_t));
+        ws->cap_tokens  = max_tokens;
+    }
+    if (max_probs > 0) {
+        ws->probs     = (float *)calloc(max_probs, sizeof(float));
+        ws->cap_probs = (int)max_probs;
+    }
+
+    if (!ws->scores || !ws->scratch || !ws->idx ||
+        (max_tokens > 0 && (!ws->tok_scores || !ws->tok_scratch ||
+                            !ws->tok_idx)) ||
+        (max_probs > 0 && !ws->probs)) {
+        return 0;
+    }
+    return 1;
+}
+
+static inline void rmm_workspace_free(rmm_workspace_t *ws) {
+    free(ws->scores);
+    free(ws->scratch);
+    free(ws->idx);
+    free(ws->tok_scores);
+    free(ws->tok_scratch);
+    free(ws->tok_idx);
+    free(ws->probs);
+    memset(ws, 0, sizeof(*ws));
+}
+
+/*===========================================================================
+ * Section 3.3: linear and MLP projections
+ *
+ * Y = X[:, I] W[I, :] with I chosen from ||X[:, j]||_2. The same call covers
+ * Q/K/V projections, the attention output projection, and the gate/up/down
+ * matrices of an FFN - anything of the form activations x weights.
+ *===========================================================================*/
+
+static inline int rmm_project(const float *X, int L, int d, const float *W,
+                              int dout, float *Y, const rmm_config_t *cfg,
+                              rmm_workspace_t *ws) {
+    if (d > ws->cap_d) return -1;
+
+    const int k = rmm_keep_count(d, cfg->rho_d, cfg->min_keep);
+    rmm_feature_scores(X, L, d, d, ws->scores);
+    rmm_select_topk(ws->scores, d, k, ws->idx, ws->scratch);
+    rmm_prefetch_rows(W, dout, ws->idx, k);
+    rmm_gemm_reduced(X, W, Y, L, d, dout, d, dout, dout, ws->idx, k);
+    return k;
+}
+
+/* Decode-step form of rmm_project() for a weight matrix stored row-major as
+ * rows x d (the layout the coffer headers mmap), i.e. y = W x reduced over
+ * the shared axis of a single activation vector. */
+static inline int rmm_project_gemv(const float *x, int d, const float *W,
+                                   int rows, float *y,
+                                   const rmm_config_t *cfg,
+                                   rmm_workspace_t *ws) {
+    if (d > ws->cap_d) return -1;
+
+    const int k = rmm_keep_count(d, cfg->rho_d, cfg->min_keep);
+    rmm_feature_scores(x, 1, d, d, ws->scores);
+    rmm_select_topk(ws->scores, d, k, ws->idx, ws->scratch);
+    rmm_gemv_reduced(W, x, y, rows, d, d, ws->idx, k);
+    return k;
+}
+
+/*===========================================================================
+ * Section 3.3: attention
+ *
+ * Per head: score the head dimension with s_j = ||Q[:, j]||_2, reduce QK^T
+ * over the retained dimensions, softmax (with the causal mask if asked), then
+ * optionally reduce PV over the token axis using a_t = ||P[:, t]||_2.
+ *
+ * Grouped-query attention: selection is per head on Q, and the retained
+ * dimensions are gathered from the shared K/V - so call this once per query
+ * head, passing that head's Q with the K/V of its group.
+ *
+ * Token reduction drops the discarded attention mass instead of
+ * renormalising, exactly as the paper defines PV -> P[:, T] V[T, :]; the rows
+ * of the output are therefore slightly shrunk, which is part of the
+ * approximation being measured rather than a bug to patch out.
+ *===========================================================================*/
+
+static inline int rmm_attention(float *out, const float *Q, const float *K,
+                                const float *V, int Lq, int Lk, int dh,
+                                int causal, const rmm_config_t *cfg,
+                                rmm_workspace_t *ws) {
+    if (dh > ws->cap_d) return -1;
+
+    if (Lk > ws->cap_tokens) return -1;
+
+    const int reduce_tokens = (cfg->rho_t < 1.0f);
+    if (reduce_tokens &&
+        (size_t)Lq * (size_t)Lk > (size_t)ws->cap_probs) {
+        return -1;
+    }
+
+    /* Feature selection on the head dimension, shared by every query row of
+     * this head (Q is the observed operand for the whole block). */
+    const int k = rmm_keep_count(dh, cfg->rho_d, cfg->min_keep);
+    rmm_feature_scores(Q, Lq, dh, dh, ws->scores);
+    rmm_select_topk(ws->scores, dh, k, ws->idx, ws->scratch);
+
+    /* With token reduction the whole of P is materialised; without it, one
+     * row at a time is enough and tok_scores doubles as that row. */
+    float *P = reduce_tokens ? ws->probs : ws->tok_scores;
+    const int ldp = reduce_tokens ? Lk : 0;
+
+    for (int i = 0; i < Lq; i++) {
+        float *row = reduce_tokens ? P + (size_t)i * (size_t)ldp : P;
+        const int limit = causal ? (i + 1 < Lk ? i + 1 : Lk) : Lk;
+
+        rmm_scores_reduced(Q + (size_t)i * (size_t)dh, K, row, Lk, dh, dh,
+                           ws->idx, k, limit);
+
+        float max_score = -INFINITY;
+        for (int t = 0; t < limit; t++) {
+            if (row[t] > max_score) max_score = row[t];
+        }
+        float sum_exp = 0.0f;
+        for (int t = 0; t < limit; t++) {
+            row[t] = expf(row[t] - max_score);
+            sum_exp += row[t];
+        }
+        const float inv = sum_exp > 0.0f ? 1.0f / sum_exp : 0.0f;
+        for (int t = 0; t < limit; t++) {
+            row[t] *= inv;
+        }
+        for (int t = limit; t < Lk; t++) {
+            row[t] = 0.0f;
+        }
+
+        if (!reduce_tokens) {
+            /* Stream PV straight out of the row; no P buffer needed. */
+            float *o = out + (size_t)i * (size_t)dh;
+            memset(o, 0, (size_t)dh * sizeof(float));
+            g_rmm_stats.macs_dense   += (uint64_t)limit * (uint64_t)dh;
+            g_rmm_stats.macs_reduced += (uint64_t)limit * (uint64_t)dh;
+            for (int t = 0; t < limit; t++) {
+                const float w = row[t];
+                if (w == 0.0f) continue;
+                const float *v = V + (size_t)t * (size_t)dh;
+                for (int c = 0; c < dh; c++) {
+                    o[c] += w * v[c];
+                }
+            }
+        }
+    }
+
+    if (!reduce_tokens) return k;
+
+    /* Token selection over the whole query block: a_t = ||P[:, t]||_2. */
+    const int kt = rmm_keep_count(Lk, cfg->rho_t, cfg->min_keep);
+    rmm_feature_scores(P, Lq, Lk, Lk, ws->tok_scores);
+    rmm_select_topk(ws->tok_scores, Lk, kt, ws->tok_idx, ws->tok_scratch);
+    rmm_prefetch_rows(V, dh, ws->tok_idx, kt);
+    rmm_gemm_reduced(P, V, out, Lq, Lk, dh, Lk, dh, dh, ws->tok_idx, kt);
+    return k;
+}
+
+/*===========================================================================
+ * Dense references
+ *
+ * Kept in the header so callers (and the self-test) can compare a reduced
+ * product against the dense one without writing a second kernel that might
+ * differ in summation order.
+ *===========================================================================*/
+
+static inline void rmm_gemv_dense(const float *W, const float *x, float *y,
+                                  int rows, int d, int ldw) {
+    for (int m = 0; m < rows; m++) {
+        const float *w = W + (size_t)m * (size_t)ldw;
+        float sum = 0.0f;
+        for (int j = 0; j < d; j++) sum += w[j] * x[j];
+        y[m] = sum;
+    }
+}
+
+static inline void rmm_attention_dense(float *out, const float *Q,
+                                       const float *K, const float *V,
+                                       int Lq, int Lk, int dh, int causal,
+                                       float *scores) {
+    const float scale = 1.0f / sqrtf((float)dh);
+
+    for (int i = 0; i < Lq; i++) {
+        const float *q = Q + (size_t)i * (size_t)dh;
+        const int limit = causal ? (i + 1 < Lk ? i + 1 : Lk) : Lk;
+
+        for (int t = 0; t < limit; t++) {
+            const float *krow = K + (size_t)t * (size_t)dh;
+            float sum = 0.0f;
+            for (int j = 0; j < dh; j++) sum += q[j] * krow[j];
+            scores[t] = sum * scale;
+        }
+
+        float max_score = -INFINITY;
+        for (int t = 0; t < limit; t++) {
+            if (scores[t] > max_score) max_score = scores[t];
+        }
+        float sum_exp = 0.0f;
+        for (int t = 0; t < limit; t++) {
+            scores[t] = expf(scores[t] - max_score);
+            sum_exp += scores[t];
+        }
+        const float inv = sum_exp > 0.0f ? 1.0f / sum_exp : 0.0f;
+
+        float *o = out + (size_t)i * (size_t)dh;
+        memset(o, 0, (size_t)dh * sizeof(float));
+        for (int t = 0; t < limit; t++) {
+            const float w = scores[t] * inv;
+            const float *v = V + (size_t)t * (size_t)dh;
+            for (int c = 0; c < dh; c++) o[c] += w * v[c];
+        }
+    }
+}
+
+#endif /* GGML_RMM_H */

--- a/tests/rmm_test.c
+++ b/tests/rmm_test.c
@@ -1,0 +1,525 @@
+/* Self-test for ggml-rmm.h (arXiv:2608.13426).
+ *
+ * The checks are the paper's own claims, in the order it makes them:
+ *   - selection is TopK by column norm, deterministic, and minimax optimal;
+ *   - the reduced product obeys the Proposition 1 error bound;
+ *   - activation-aware selection beats random selection at equal budget
+ *     (Section 6.1), which is the whole reason for scoring;
+ *   - rho = 1 is the dense product bit-for-bit, so reduction cannot perturb
+ *     exact mode when it is switched off;
+ *   - the MAC accounting matches the requested retention ratio, and the
+ *     saving shows up on the clock.
+ */
+
+#include "../ggml-rmm.h"
+
+#include <time.h>
+
+static int failures = 0;
+
+static void check(const char *what, int ok)
+{
+    printf("%-58s %s\n", what, ok ? "ok" : "FAILED");
+    if (!ok) {
+        failures++;
+    }
+}
+
+static double now_seconds(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+/* Deterministic pseudo-random floats: the test must be reproducible, and
+ * rand() is not the same sequence everywhere. */
+static uint32_t rng_state = 0x2608134u;
+
+static float next_float(void)
+{
+    rng_state = rng_state * 1664525u + 1013904223u;
+    return (float)((int32_t)(rng_state >> 8) % 2001 - 1000) / 1000.0f;
+}
+
+static double frobenius_diff(const float *a, const float *b, size_t n)
+{
+    double acc = 0.0;
+    for (size_t i = 0; i < n; ++i) {
+        const double d = (double)a[i] - (double)b[i];
+        acc += d * d;
+    }
+    return sqrt(acc);
+}
+
+/*---------------------------------------------------------------------------
+ * Selection
+ *-------------------------------------------------------------------------*/
+
+static void test_keep_count(void)
+{
+    check("rho = 1 retains the whole axis",
+          rmm_keep_count(128, 1.0f, 8) == 128);
+    check("k = ceil(rho * d)", rmm_keep_count(100, 0.55f, 1) == 55 &&
+                                   rmm_keep_count(100, 0.551f, 1) == 56 &&
+                                   rmm_keep_count(7, 0.5f, 1) == 4);
+    check("min_keep floors an over-aggressive ratio",
+          rmm_keep_count(64, 0.01f, 8) == 8);
+    check("min_keep never exceeds the axis",
+          rmm_keep_count(4, 0.01f, 8) == 4);
+}
+
+static void test_selection(void)
+{
+    const int d = 512;
+    const int k = 128;
+    float *scores = malloc(sizeof(float) * d);
+    float *scratch = malloc(sizeof(float) * d);
+    int32_t *idx = malloc(sizeof(int32_t) * d);
+    int32_t *idx_again = malloc(sizeof(int32_t) * d);
+
+    for (int j = 0; j < d; ++j) {
+        scores[j] = fabsf(next_float());
+    }
+
+    const int n = rmm_select_topk(scores, d, k, idx, scratch);
+    check("selection returns the requested budget", n == k);
+
+    int ascending = 1;
+    for (int t = 1; t < k; ++t) {
+        if (idx[t] <= idx[t - 1]) {
+            ascending = 0;
+        }
+    }
+    check("selected indices come out ascending and distinct", ascending);
+
+    /* Every retained score must dominate every discarded one. */
+    char *kept = calloc((size_t)d, 1);
+    for (int t = 0; t < k; ++t) {
+        kept[idx[t]] = 1;
+    }
+    float min_kept = INFINITY;
+    float max_dropped = -INFINITY;
+    for (int j = 0; j < d; ++j) {
+        if (kept[j] && scores[j] < min_kept) {
+            min_kept = scores[j];
+        }
+        if (!kept[j] && scores[j] > max_dropped) {
+            max_dropped = scores[j];
+        }
+    }
+    check("retained scores dominate discarded scores",
+          min_kept >= max_dropped);
+
+    rmm_select_topk(scores, d, k, idx_again, scratch);
+    check("selection is deterministic across calls",
+          memcmp(idx, idx_again, sizeof(int32_t) * (size_t)k) == 0);
+
+    /* All-equal scores: the tie class must resolve to the lowest indices,
+     * which is what makes the choice reproducible rather than pivot-order
+     * dependent. */
+    for (int j = 0; j < d; ++j) {
+        scores[j] = 1.0f;
+    }
+    rmm_select_topk(scores, d, k, idx, scratch);
+    int lowest = 1;
+    for (int t = 0; t < k; ++t) {
+        if (idx[t] != t) {
+            lowest = 0;
+        }
+    }
+    check("ties resolve to the lowest indices", lowest);
+
+    free(scores);
+    free(scratch);
+    free(idx);
+    free(idx_again);
+    free(kept);
+}
+
+static void test_feature_scores(void)
+{
+    const int n = 33;
+    const int d = 67;
+    float *A = malloc(sizeof(float) * (size_t)n * d);
+    float *scores = malloc(sizeof(float) * d);
+
+    for (int i = 0; i < n * d; ++i) {
+        A[i] = next_float();
+    }
+    rmm_feature_scores(A, n, d, d, scores);
+
+    int ok = 1;
+    for (int j = 0; j < d; ++j) {
+        double acc = 0.0;
+        for (int i = 0; i < n; ++i) {
+            acc += (double)A[i * d + j] * (double)A[i * d + j];
+        }
+        const double want = sqrt(acc);
+        if (fabs((double)scores[j] - want) > 1e-4 * fmax(1.0, want)) {
+            ok = 0;
+        }
+    }
+    check("feature scores are the column 2-norms", ok);
+
+    free(A);
+    free(scores);
+}
+
+/*---------------------------------------------------------------------------
+ * Reduced products
+ *-------------------------------------------------------------------------*/
+
+static void test_dense_equivalence(void)
+{
+    const int rows = 96;
+    const int d = 320;
+    float *W = malloc(sizeof(float) * (size_t)rows * d);
+    float *x = malloc(sizeof(float) * d);
+    float *y = malloc(sizeof(float) * rows);
+    float *ref = malloc(sizeof(float) * rows);
+    rmm_config_t cfg = rmm_config_default();
+    rmm_workspace_t ws;
+
+    for (int i = 0; i < rows * d; ++i) {
+        W[i] = next_float();
+    }
+    for (int j = 0; j < d; ++j) {
+        x[j] = next_float();
+    }
+
+    check("workspace allocates", rmm_workspace_init(&ws, d, 0, 0) == 1);
+
+    cfg.rho_d = 1.0f;
+    rmm_gemv_dense(W, x, ref, rows, d, d);
+    rmm_project_gemv(x, d, W, rows, y, &cfg, &ws);
+    check("rho = 1 reproduces the dense GEMV bit-for-bit",
+          memcmp(y, ref, sizeof(float) * (size_t)rows) == 0);
+
+    rmm_workspace_free(&ws);
+    free(W);
+    free(x);
+    free(y);
+    free(ref);
+}
+
+/* Proposition 1: ||AB - A[:,I] B[I,:]||_F <= sum_{j not in I} ||A[:,j]||_2
+ * ||B[j,:]||_2. Also compares activation-aware selection against a random
+ * subset of the same size (Section 6.1). */
+static void test_error_bound_and_random_baseline(void)
+{
+    const int n = 24;
+    const int d = 256;
+    const int m = 48;
+    const int k = 128;
+
+    float *A = malloc(sizeof(float) * (size_t)n * d);
+    float *B = malloc(sizeof(float) * (size_t)d * m);
+    float *dense = malloc(sizeof(float) * (size_t)n * m);
+    float *reduced = malloc(sizeof(float) * (size_t)n * m);
+    float *scores = malloc(sizeof(float) * d);
+    float *scratch = malloc(sizeof(float) * d);
+    int32_t *idx = malloc(sizeof(int32_t) * d);
+    int32_t *all = malloc(sizeof(int32_t) * d);
+
+    /* Activations with a heavy-tailed channel profile, as real hidden states
+     * have: a minority of channels carries most of the energy, which is the
+     * structure RMM exploits. */
+    for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < d; ++j) {
+            const float gain = (j % 16 == 0) ? 8.0f : 0.25f;
+            A[i * d + j] = gain * next_float();
+        }
+    }
+    for (int i = 0; i < d * m; ++i) {
+        B[i] = next_float();
+    }
+
+    for (int j = 0; j < d; ++j) {
+        all[j] = (int32_t)j;
+    }
+    rmm_gemm_reduced(A, B, dense, n, d, m, d, m, m, all, d);
+
+    rmm_feature_scores(A, n, d, d, scores);
+    rmm_select_topk(scores, d, k, idx, scratch);
+    rmm_gemm_reduced(A, B, reduced, n, d, m, d, m, m, idx, k);
+
+    const double err = frobenius_diff(dense, reduced, (size_t)n * m);
+
+    /* The bound, computed over the discarded dimensions only. */
+    char *kept = calloc((size_t)d, 1);
+    for (int t = 0; t < k; ++t) {
+        kept[idx[t]] = 1;
+    }
+    double bound = 0.0;
+    for (int j = 0; j < d; ++j) {
+        if (kept[j]) {
+            continue;
+        }
+        double brow = 0.0;
+        for (int c = 0; c < m; ++c) {
+            brow += (double)B[j * m + c] * (double)B[j * m + c];
+        }
+        bound += (double)scores[j] * sqrt(brow);
+    }
+    printf("  reduced-product error %.4f, Proposition 1 bound %.4f\n", err,
+           bound);
+    check("reduced product obeys the Proposition 1 error bound",
+          err <= bound * 1.000001);
+
+    /* Random selection at the same budget, averaged over trials. */
+    double random_err = 0.0;
+    const int trials = 16;
+    for (int trial = 0; trial < trials; ++trial) {
+        int count = 0;
+        for (int j = 0; j < d && count < k; ++j) {
+            const int remaining = d - j;
+            const int needed = k - count;
+            rng_state = rng_state * 1664525u + 1013904223u;
+            if ((int)((rng_state >> 8) % (uint32_t)remaining) < needed) {
+                idx[count++] = (int32_t)j;
+            }
+        }
+        rmm_gemm_reduced(A, B, reduced, n, d, m, d, m, m, idx, count);
+        random_err += frobenius_diff(dense, reduced, (size_t)n * m);
+    }
+    random_err /= trials;
+    printf("  activation-aware error %.4f vs random selection %.4f\n", err,
+           random_err);
+    check("activation-aware selection beats random at equal budget",
+          err < random_err);
+
+    free(A);
+    free(B);
+    free(dense);
+    free(reduced);
+    free(scores);
+    free(scratch);
+    free(idx);
+    free(all);
+    free(kept);
+}
+
+/* Minimax optimality (Theorem 1): against the adversarial B that puts all of
+ * its row energy on the single largest discarded column norm, no other subset
+ * of the same size can do better than TopK. */
+static void test_minimax_optimality(void)
+{
+    const int d = 64;
+    const int k = 16;
+    float *scores = malloc(sizeof(float) * d);
+    float *scratch = malloc(sizeof(float) * d);
+    int32_t *idx = malloc(sizeof(int32_t) * d);
+
+    for (int j = 0; j < d; ++j) {
+        scores[j] = fabsf(next_float()) + 0.01f;
+    }
+    rmm_select_topk(scores, d, k, idx, scratch);
+
+    char *kept = calloc((size_t)d, 1);
+    for (int t = 0; t < k; ++t) {
+        kept[idx[t]] = 1;
+    }
+    float worst_case = 0.0f;
+    for (int j = 0; j < d; ++j) {
+        if (!kept[j] && scores[j] > worst_case) {
+            worst_case = scores[j];
+        }
+    }
+
+    /* Any alternative subset: swap one retained index for a discarded one and
+     * the worst case can only get worse or stay equal. */
+    int optimal = 1;
+    for (int t = 0; t < k; ++t) {
+        for (int j = 0; j < d; ++j) {
+            if (kept[j]) {
+                continue;
+            }
+            float alt = scores[idx[t]]; /* now discarded */
+            for (int u = 0; u < d; ++u) {
+                if (!kept[u] && u != j && scores[u] > alt) {
+                    alt = scores[u];
+                }
+            }
+            if (alt < worst_case) {
+                optimal = 0;
+            }
+        }
+    }
+    check("TopK by column norm minimises the worst-case error", optimal);
+
+    free(scores);
+    free(scratch);
+    free(idx);
+    free(kept);
+}
+
+/*---------------------------------------------------------------------------
+ * Attention
+ *-------------------------------------------------------------------------*/
+
+static void test_attention(void)
+{
+    const int Lq = 48;
+    const int Lk = 48;
+    const int dh = 128;
+
+    float *Q = malloc(sizeof(float) * (size_t)Lq * dh);
+    float *K = malloc(sizeof(float) * (size_t)Lk * dh);
+    float *V = malloc(sizeof(float) * (size_t)Lk * dh);
+    float *out = malloc(sizeof(float) * (size_t)Lq * dh);
+    float *ref = malloc(sizeof(float) * (size_t)Lq * dh);
+    float *scores = malloc(sizeof(float) * Lk);
+    rmm_config_t cfg = rmm_config_default();
+    rmm_workspace_t ws;
+
+    /* Heads concentrate their energy in a minority of feature dimensions;
+     * without that structure there is nothing for any reduction method to
+     * find, and the comparison against dense would only measure noise. */
+    for (int i = 0; i < Lq; ++i) {
+        for (int j = 0; j < dh; ++j) {
+            const float gain = (j % 4 == 0) ? 4.0f : 0.2f;
+            Q[i * dh + j] = gain * next_float();
+        }
+    }
+    for (int i = 0; i < Lk; ++i) {
+        for (int j = 0; j < dh; ++j) {
+            const float gain = (j % 4 == 0) ? 4.0f : 0.2f;
+            K[i * dh + j] = gain * next_float();
+            V[i * dh + j] = next_float();
+        }
+    }
+
+    rmm_workspace_init(&ws, dh, Lk, (size_t)Lq * Lk);
+    rmm_attention_dense(ref, Q, K, V, Lq, Lk, dh, 1, scores);
+
+    cfg.rho_d = 1.0f;
+    cfg.rho_t = 1.0f;
+    check("attention at rho = 1 is accepted",
+          rmm_attention(out, Q, K, V, Lq, Lk, dh, 1, &cfg, &ws) == dh);
+    check("attention at rho = 1 reproduces dense attention",
+          frobenius_diff(out, ref, (size_t)Lq * dh) < 1e-4);
+
+    /* Half the head dimension: the output must stay close to dense relative
+     * to the magnitude of the dense output itself. */
+    cfg.rho_d = 0.5f;
+    rmm_attention(out, Q, K, V, Lq, Lk, dh, 1, &cfg, &ws);
+    double ref_norm = 0.0;
+    for (int i = 0; i < Lq * dh; ++i) {
+        ref_norm += (double)ref[i] * (double)ref[i];
+    }
+    ref_norm = sqrt(ref_norm);
+    const double relative = frobenius_diff(out, ref, (size_t)Lq * dh)
+                            / ref_norm;
+    printf("  relative attention error at rho_d = 0.5: %.4f\n", relative);
+    check("attention at rho_d = 0.5 stays within 10% of dense",
+          relative < 0.10);
+
+    /* Token reduction on PV. */
+    cfg.rho_t = 0.5f;
+    rmm_stats_reset();
+    check("attention with token reduction is accepted",
+          rmm_attention(out, Q, K, V, Lq, Lk, dh, 1, &cfg, &ws) == dh / 2);
+    int finite = 1;
+    for (int i = 0; i < Lq * dh; ++i) {
+        if (!isfinite(out[i])) {
+            finite = 0;
+        }
+    }
+    check("attention with token reduction produces finite output", finite);
+    const double kept_ratio = (double)g_rmm_stats.macs_reduced /
+                              (double)g_rmm_stats.macs_dense;
+    printf("  MACs retained with rho_d = rho_t = 0.5: %.1f%%\n",
+           100.0 * kept_ratio);
+    check("token reduction actually reduces the MAC count", kept_ratio < 0.6);
+
+    /* Without a P buffer, token reduction must be refused rather than
+     * silently ignored. */
+    rmm_workspace_t small;
+    rmm_workspace_init(&small, dh, Lk, 0);
+    check("token reduction without a P buffer is refused",
+          rmm_attention(out, Q, K, V, Lq, Lk, dh, 1, &cfg, &small) == -1);
+    rmm_workspace_free(&small);
+
+    rmm_workspace_free(&ws);
+    free(Q);
+    free(K);
+    free(V);
+    free(out);
+    free(ref);
+    free(scores);
+}
+
+/*---------------------------------------------------------------------------
+ * Wall clock
+ *-------------------------------------------------------------------------*/
+
+static void test_throughput(void)
+{
+    /* An expert-sized projection: 4096 hidden into 11008 intermediate. */
+    const int rows = 4096;
+    const int d = 4096;
+    float *W = malloc(sizeof(float) * (size_t)rows * d);
+    float *x = malloc(sizeof(float) * d);
+    float *y = malloc(sizeof(float) * rows);
+    rmm_config_t cfg = rmm_config_default();
+    rmm_workspace_t ws;
+
+    if (!W || !x || !y) {
+        printf("not enough memory for the throughput check; skipping\n");
+        free(W);
+        free(x);
+        free(y);
+        return;
+    }
+    for (size_t i = 0; i < (size_t)rows * d; ++i) {
+        W[i] = 0.001f * (float)(i % 7);
+    }
+    for (int j = 0; j < d; ++j) {
+        x[j] = 0.01f * (float)(j % 11);
+    }
+    rmm_workspace_init(&ws, d, 0, 0);
+
+    const int iterations = 8;
+    double started = now_seconds();
+    for (int i = 0; i < iterations; ++i) {
+        rmm_gemv_dense(W, x, y, rows, d, d);
+    }
+    const double dense_time = now_seconds() - started;
+
+    cfg.rho_d = 0.5f;
+    started = now_seconds();
+    for (int i = 0; i < iterations; ++i) {
+        rmm_project_gemv(x, d, W, rows, y, &cfg, &ws);
+    }
+    const double reduced_time = now_seconds() - started;
+
+    printf("\n%d x %d GEMV on this host:\n", rows, d);
+    printf("  dense        %.2f ms\n", dense_time / iterations * 1e3);
+    printf("  rho_d = 0.5  %.2f ms (%.2fx, selection included)\n",
+           reduced_time / iterations * 1e3, dense_time / reduced_time);
+
+    rmm_workspace_free(&ws);
+    free(W);
+    free(x);
+    free(y);
+}
+
+int main(void)
+{
+    test_keep_count();
+    test_selection();
+    test_feature_scores();
+    test_dense_equivalence();
+    test_error_bound_and_random_baseline();
+    test_minimax_optimality();
+    test_attention();
+    test_throughput();
+
+    if (failures) {
+        printf("\n%d check(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("\nall RMM checks passed\n");
+    return 0;
+}


### PR DESCRIPTION
Input-adaptive contraction-axis reduction for the products that dominate inference: Y = A B keeps only the ceil(rho*d) slices with the largest activation column norms ||A[:,j]||_2, chosen deterministically from the current activations. Training-free and weight-preserving.

- ggml-rmm.h: column-norm scoring, quickselect TopK with lowest-index tie breaking, reduced GEMV/GEMM, projections, attention with QK^T feature reduction and optional PV token reduction, reusable workspace, MAC stats. Scalar C11 everywhere, VSX/AltiVec fast path on POWER8, dcbt prefetch of only the retained weight rows. rho = 1 is bit-identical to dense.
- tests/rmm_test.c: TopK determinism and ties, dense equivalence at rho = 1, Proposition 1 error bound, activation-aware vs random selection, minimax claim, attention accuracy at rho_d = 0.5, MAC accounting, GEMV benchmark.
- Makefile: 'make' runs the suite on x86-64, 'make power8' builds the VSX path.
- docs/RMM.md, README and CHANGELOG entries.