### PR TITLE
ci: add lychee link-check workflow for markdown docs (#693)

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,0 +1,36 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check relative links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --include-fragments
+            --exclude-all-private
+            --exclude "https?://(twitter|x)\.com"
+            --exclude "https://github.com/Scottcjn/Rustchain/actions"
+            --exclude "https?://(www\.)?(linkedin|facebook|instagram|tiktok)"
+            --exclude "https?://(127\.0\.0\.1|localhost)(:\d+)?"
+            --exclude "https?://50\.28\.86\.131(:\d+)?"
+            --exclude "https://rustchain.org/faq"
+            -- './**/*.md' './**/*.html'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail on broken relative links
+        if: failure()
+        run: exit 1


### PR DESCRIPTION
## Summary

Adds a lychee-based link-check CI workflow to prevent silent documentation regressions.

Closes #693

## Changes

- Adds `.github/workflows/lychee.yml` mirroring the configuration from `Scottcjn/Rustchain`
- Triggers on PRs touching `**.md` or `docs/**`, weekly schedule (Monday 04:00 UTC), and manual dispatch
- Excludes private IPs, localhost, social media platforms, and known false positives (`rustchain.org/faq`)
- Fails CI explicitly on broken relative links

## Validation

Workflow syntax validated against lychee-action@v2 schema. Configuration matches the proven Rustchain setup that caught the original broken links in this repo.

## Bounty

For bounty verification — GitHub: rafaio1
Wallet: RTC1e9bf7a2a60aac9bcbc5a0df0c65e9501e932861