### PR TITLE
fix: add lychee link-check CI (fixes #693) — ETK2456

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,21 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - "**.md"
+      - "docs/**"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --verbose --no-progress --exclude-mail --exclude "https://twitter.com/*" --exclude "https://x.com/*" --exclude "https://discord.gg/*" "./**/*.md"
+          fail: true


### PR DESCRIPTION
Fixes #693 — reported by me first per your comment on #694

- Adds link-check.yml (same as rustchain)
- Prevents doc link rot
- Excludes Twitter/X/Discord social links

Reporter: ETK2456
Wallet Base: 0x3F4615bF90b2E849a70A1769aD9b99E15f542B3d