### PR TITLE
gen9-cluster: DeepSeek-V4.1-Flash profile (CSA2/CED, Engram, DSpark)

### DIFF
--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -55,12 +55,16 @@ reads. Nothing in this repository has run on a console yet.
 |---|---|---|---|---|
 | `deepseek-v4-pro` | 1599 B | 49 B | 802 GiB | 73 |
 | `deepseek-v4-flash` | 291 B | 13 B | 148 GiB | 20 |
+| `deepseek-v4.1-flash` | 566 B + 197 B aux | 16 B (8 B prefill) | 468 GiB | 27 |
 | `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |
 | `deepseek-tiny` | — | — | 0.5 GiB | 1 (CI only) |
 
-Both V4 profiles are the published configurations, not extrapolations, and the
-tests check them against the published parameter counts. Two of their
-properties change how the planner thinks:
+All three V4-family profiles are the published configurations, not
+extrapolations, and the tests check them against the published parameter
+counts. V4.1's "aux" is the Engram tables and vision tower the card reports
+separately; its floor of 27 counts Engram on shelf-local NVMe, which is where
+those tables are designed to live. Two properties of the V4 architecture
+change how the planner thinks, and V4.1 adds a third row of its own below:
 
 - **Hybrid attention.** V4 alternates CSA (every 4 tokens compress to one
   entry, then attend sparsely to the best 1024 of them) with HCA (every 128
@@ -74,12 +78,33 @@ properties change how the planner thinks:
   ships 56 KiB per token rather than 14. At 250 µs a hop that is still small
   against a 90 ms token, but it is 4x what a V3-shaped model would cost.
 
+V4.1 is a different architecture, and it moves the split again:
+
+- **Causal encoder-decoder, shared KV pools.** Twenty encoder layers compress
+  the context; twenty decoder layers read a global cache projected from the
+  encoder instead of growing their own. CSA2 assigns each layer a static mode
+  — Full, Reindex, Reuse — so only the eight source streams store anything at
+  all: the growing cache concentrates on the four shelf hosts that own them
+  (864 B/token derived, ~890 published — a quarter of V4-Flash's), and a
+  decoder-stage host holds a sliding-window state and little else. Decoder
+  Reindex layers also scan only a 2048-block candidate pool, so their index
+  cost stops growing with context.
+- **Engram conditional memory.** Two hash-addressed n-gram tables, ~196 B
+  parameters at layers 1 and 14, read a few kilobytes per token. That is the
+  coldest weight class the model owns — deterministic addressing means the
+  rows are known before the layer runs — so each table goes straight to the
+  owning stage host's NVMe rather than competing for RAM.
+- **DSpark draft blocks.** Three next-token-prediction blocks at the tail,
+  with their own narrower MoE (128 experts, top-3) — the planner places them
+  like layers but sizes them by the draft config, not the backbone's.
+
 ## Quick start
 
 ```bash
 cd gen9-cluster
 python3 -m gen9_cluster model --model deepseek-v4-pro    # what it costs
 python3 -m gen9_cluster model --model deepseek-v4-flash  # the small one
+python3 -m gen9_cluster model --model deepseek-v4.1-flash # the new arch
 python3 -m gen9_cluster size  --model deepseek-v4-pro --ps5 100 \
         --xbox-series-x 40 --bc-250 30                   # how many consoles
 python3 -m gen9_cluster plan  fleet.json --config cluster.json
@@ -205,13 +230,16 @@ and coordinator paths over real loopback sockets.
 **Estimated**: every throughput figure for a console. They come from datasheet
 bandwidth, the fan-out and hop structure of the plan, and NVMe read rates.
 
-**Read off the model cards**: both V4 configurations. `deepseek-v4-pro` and
-`deepseek-v4-flash` are the published `config.json` files, checked in the tests
-against the published parameter counts (1.6 T / 49 B activated and 284 B / 13 B).
-An earlier revision of this stack extrapolated V4 Pro from V3 and was wrong in
-almost every field; the `assumed` flag and its `ASSUMED CONFIGURATION` stamp
-remain in the code for the next unpublished model, but no shipped profile sets
-it.
+**Read off the model cards**: all three V4-family configurations.
+`deepseek-v4-pro`, `deepseek-v4-flash`, and `deepseek-v4.1-flash` are the
+published `config.json` files, checked in the tests against the published
+parameter counts (1.6 T / 49 B activated, 284 B / 13 B, and 552 B backbone
+/ 16 B decode + ~196 B Engram). V4.1's per-layer weight terms are this
+repository's reading of the config — validated against the card's totals, not
+the sheet, the same standing the V4 readings have. An earlier revision of this
+stack extrapolated V4 Pro from V3 and was wrong in almost every field; the
+`assumed` flag and its `ASSUMED CONFIGURATION` stamp remain in the code for
+the next unpublished model, but no shipped profile sets it.
 
 **Interpreted, not published**: how those fields turn into bytes. The paper
 gives the architecture, not a storage layout, so the per-layer weight counts in
@@ -229,7 +257,7 @@ See [docs/GEN9_SPLITTING.md](docs/GEN9_SPLITTING.md) for the arithmetic and
 ## Tests
 
 ```bash
-python3 -m unittest discover -s tests -t .   # 159 tests
+python3 -m unittest discover -s tests -t .   # 226 tests
 cd kernels && make && make test              # CPU kernel + FP8 conformance
 make vulkan                                  # needs glslang-tools
 make hip                                     # needs hipcc; skipped otherwise

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -55,16 +55,17 @@ reads. Nothing in this repository has run on a console yet.
 |---|---|---|---|---|
 | `deepseek-v4-pro` | 1599 B | 49 B | 802 GiB | 83 |
 | `deepseek-v4-flash` | 291 B | 13 B | 148 GiB | 22 |
-| `deepseek-v4.1-flash` | 566 B + 197 B aux | 16 B (8 B prefill) | 468 GiB | needs NVMe |
+| `deepseek-v4.1-flash` | 566 B + 197 B aux | 16 B (8 B prefill) | 468 GiB | 43 |
 | `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |
 | `deepseek-tiny` | — | — | 0.5 GiB | 1 (CI only) |
 
 All three V4-family profiles are the published configurations, not
 extrapolations, and the tests check them against the published parameter
 counts. V4.1's "aux" is the Engram tables and vision tower the card reports
-separately. Its floor has no RAM-only answer — the Engram row stores are NVMe
-residents by design, so `--no-ssd` planning fails outright — but **24 PS5s**
-suffice once the SSD tier is enabled, versus V4 Pro's 23. Two properties of the V4 architecture
+separately. Its RAM-only floor of **43** shards the ~183 GiB of Engram row
+stores across fleet memory — viable because a lookup is a deterministic hash,
+though every token then gathers rows over the network — and drops to **24**
+once the tables can sit on NVMe, which is where the design intends them. Two properties of the V4 architecture
 change how the planner thinks, and V4.1 adds a third row of its own below:
 
 - **Hybrid attention.** V4 alternates CSA (every 4 tokens compress to one
@@ -258,7 +259,7 @@ See [docs/GEN9_SPLITTING.md](docs/GEN9_SPLITTING.md) for the arithmetic and
 ## Tests
 
 ```bash
-python3 -m unittest discover -s tests -t .   # 231 tests
+python3 -m unittest discover -s tests -t .   # 232 tests
 cd kernels && make && make test              # CPU kernel + FP8 conformance
 make vulkan                                  # needs glslang-tools
 make hip                                     # needs hipcc; skipped otherwise

--- a/gen9-cluster/README.md
+++ b/gen9-cluster/README.md
@@ -44,8 +44,8 @@ Three properties make the fleet work anyway:
    tested against each other over all 256 codes.
 
 The result is a plan, not a benchmark: **~11.1 tok/s estimated** for V4 Pro at
-8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250), and a **73-PS5
-floor** to hold it at all. V4 Flash is a fifth of the size and fits on **20**.
+8k context on 170 consoles (100 PS5 + 40 Series X + 30 BC-250), and an **83-PS5
+floor** to hold it RAM-only. V4 Flash is a fifth of the size and fits on **22**.
 Those figures are arithmetic over memory bandwidth, network hops, and NVMe
 reads. Nothing in this repository has run on a console yet.
 
@@ -53,17 +53,18 @@ reads. Nothing in this repository has run on a console yet.
 
 | profile | params | activated | on disk | PS5s to hold it |
 |---|---|---|---|---|
-| `deepseek-v4-pro` | 1599 B | 49 B | 802 GiB | 73 |
-| `deepseek-v4-flash` | 291 B | 13 B | 148 GiB | 20 |
-| `deepseek-v4.1-flash` | 566 B + 197 B aux | 16 B (8 B prefill) | 468 GiB | 27 |
+| `deepseek-v4-pro` | 1599 B | 49 B | 802 GiB | 83 |
+| `deepseek-v4-flash` | 291 B | 13 B | 148 GiB | 22 |
+| `deepseek-v4.1-flash` | 566 B + 197 B aux | 16 B (8 B prefill) | 468 GiB | needs NVMe |
 | `deepseek-v3` | 683 B | 37 B | 638 GiB | 58 |
 | `deepseek-tiny` | — | — | 0.5 GiB | 1 (CI only) |
 
 All three V4-family profiles are the published configurations, not
 extrapolations, and the tests check them against the published parameter
 counts. V4.1's "aux" is the Engram tables and vision tower the card reports
-separately; its floor of 27 counts Engram on shelf-local NVMe, which is where
-those tables are designed to live. Two properties of the V4 architecture
+separately. Its floor has no RAM-only answer — the Engram row stores are NVMe
+residents by design, so `--no-ssd` planning fails outright — but **24 PS5s**
+suffice once the SSD tier is enabled, versus V4 Pro's 23. Two properties of the V4 architecture
 change how the planner thinks, and V4.1 adds a third row of its own below:
 
 - **Hybrid attention.** V4 alternates CSA (every 4 tokens compress to one
@@ -257,7 +258,7 @@ See [docs/GEN9_SPLITTING.md](docs/GEN9_SPLITTING.md) for the arithmetic and
 ## Tests
 
 ```bash
-python3 -m unittest discover -s tests -t .   # 226 tests
+python3 -m unittest discover -s tests -t .   # 231 tests
 cd kernels && make && make test              # CPU kernel + FP8 conformance
 make vulkan                                  # needs glslang-tools
 make hip                                     # needs hipcc; skipped otherwise

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -147,16 +147,19 @@ just rescaling.
 - **Engram goes straight to NVMe.** Two ~98 B-parameter tables live at layers
   1 and 14, hash-addressed and read a few kilobytes per token — the Engram
   design's point is that deterministic addressing tolerates host memory, and
-  here that means the owning stage host's SSD. At ~92 GiB each they would
-  crowd out several consoles' worth of RAM for a lookup that never needs it.
+  here that means the owning stage host's SSD. At ~92 GiB each the row stores
+  would crowd out several consoles' worth of RAM for a lookup that never needs
+  it; only the small fusion projection (read every token) takes stage-host
+  RAM.
 - **Draft blocks are a different MoE.** The three DSpark blocks place like
   layers but route to 128 experts at top-3 with a Markov-rank projection; the
   planner sizes their hot and cold sides by the draft config, not the
   backbone's 384/top-6.
 
-The floor drops from 73 PS5s (V4 Pro) to 27 — but note the floor now leans on
-NVMe by design: 183 GiB of Engram plus any expert spill means a minimum fleet
-streams more than it holds.
+V4.1 has no RAM-only floor at all: the Engram row stores are NVMe residents
+by design, so `--no-ssd` planning fails at any fleet size — that constraint is
+a property of the request, not a hint. With the SSD tier on, the floor is **24
+PS5s**, one more than V4 Pro's 23 (V4 Pro's own RAM-only floor is 83).
 
 ## Why the planner warns instead of refusing
 
@@ -180,7 +183,7 @@ context).
 ## Status of every number here
 
 **Measured on the x86-64 build host** (not a console): CPU kernel 67 GFLOP/s /
-134 GB/s effective; SPIR-V compiles and passes `spirv-val`; 159 Python tests
+134 GB/s effective; SPIR-V compiles and passes `spirv-val`; 231 Python tests
 pass.
 
 **Estimated**: all console throughput. Datasheet bandwidth, derated, plus hop

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -129,6 +129,35 @@ built from many small consoles: 300 Series S units would be 14 shelves and the
 hops start to matter. It is also the reason the eventual PS6 answer is *fewer,
 larger* nodes rather than more of these.
 
+## What V4.1 changes
+
+V4.1-Flash is a different architecture, and the split moves again rather than
+just rescaling.
+
+- **The KV cache concentrates.** V4 spread a compressed stream over every
+  layer's host; CSA2 keeps a handful of shared pools — four main-KV streams
+  and eight indexer streams, all FP4 at `m=2` — so the only hosts whose cache
+  grows are the ones owning a source layer (2, 8, 14, 20 for main KV, plus 24,
+  28, 32, 36 for the decoder's index). Every other shelf host carries its
+  sliding-window state and nothing more: a decoder-stage host is suddenly a
+  far easier placement. The whole model's growing cache is 864 B/token
+  derived against the card's ~890, a quarter of V4-Flash's, and the decoder's
+  Reindex scans are capped at a 2048-block candidate pool regardless of
+  context length.
+- **Engram goes straight to NVMe.** Two ~98 B-parameter tables live at layers
+  1 and 14, hash-addressed and read a few kilobytes per token — the Engram
+  design's point is that deterministic addressing tolerates host memory, and
+  here that means the owning stage host's SSD. At ~92 GiB each they would
+  crowd out several consoles' worth of RAM for a lookup that never needs it.
+- **Draft blocks are a different MoE.** The three DSpark blocks place like
+  layers but route to 128 experts at top-3 with a Markov-rank projection; the
+  planner sizes their hot and cold sides by the draft config, not the
+  backbone's 384/top-6.
+
+The floor drops from 73 PS5s (V4 Pro) to 27 — but note the floor now leans on
+NVMe by design: 183 GiB of Engram plus any expert spill means a minimum fleet
+streams more than it holds.
+
 ## Why the planner warns instead of refusing
 
 A slow plan is still a plan. Warnings cover: assumed model configuration,

--- a/gen9-cluster/docs/GEN9_SPLITTING.md
+++ b/gen9-cluster/docs/GEN9_SPLITTING.md
@@ -150,16 +150,17 @@ just rescaling.
   here that means the owning stage host's SSD. At ~92 GiB each the row stores
   would crowd out several consoles' worth of RAM for a lookup that never needs
   it; only the small fusion projection (read every token) takes stage-host
-  RAM.
+  RAM. Under `--no-ssd` the row stores shard across fleet RAM instead — hash
+  addressing means any unit can hold any slice, at the price of a network
+  gather on every lookup.
 - **Draft blocks are a different MoE.** The three DSpark blocks place like
   layers but route to 128 experts at top-3 with a Markov-rank projection; the
   planner sizes their hot and cold sides by the draft config, not the
   backbone's 384/top-6.
 
-V4.1 has no RAM-only floor at all: the Engram row stores are NVMe residents
-by design, so `--no-ssd` planning fails at any fleet size — that constraint is
-a property of the request, not a hint. With the SSD tier on, the floor is **24
-PS5s**, one more than V4 Pro's 23 (V4 Pro's own RAM-only floor is 83).
+The floor drops from 83 PS5s (V4 Pro, RAM-only) to **43** — the ~183 GiB of
+Engram rows shard across fleet RAM when no drives are allowed — and to **24**
+with the SSD tier on, one more than V4 Pro's 23.
 
 ## Why the planner warns instead of refusing
 
@@ -183,7 +184,7 @@ context).
 ## Status of every number here
 
 **Measured on the x86-64 build host** (not a console): CPU kernel 67 GFLOP/s /
-134 GB/s effective; SPIR-V compiles and passes `spirv-val`; 231 Python tests
+134 GB/s effective; SPIR-V compiles and passes `spirv-val`; 232 Python tests
 pass.
 
 **Estimated**: all console throughput. Datasheet bandwidth, derated, plus hop

--- a/gen9-cluster/docs/REFERENCES.md
+++ b/gen9-cluster/docs/REFERENCES.md
@@ -24,6 +24,33 @@ What this design borrows, and from whom. Grouped by what it was borrowed *for*.
   pure sliding window. Earlier revisions of this stack extrapolated V4 Pro from
   V3 and were wrong in nearly every field; the profiles are no longer marked
   `assumed`, and the tests pin them to the cards' 1.6 T / 49 B and 284 B / 13 B.
+- **DeepSeek-V4.1-Flash model card.** DeepSeek-AI, 2026.
+  <https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash>.
+  The source of `DEEPSEEK_V4_1_FLASH`: a different architecture rather than a
+  V4 variant — a 20-layer causal encoder feeding a 20-layer decoder whose
+  global KV is projected from the encoder's output, CSA2's Full/Reindex/Reuse
+  layer modes sharing main-KV and indexer pools (`kv_source_layer_ids`,
+  `index_source_layer_ids`), a hierarchical indexer bounding later decoder
+  scans to a 2048-block candidate pool, FP4 (E2M1 + E4M3-per-16) KV cache, and
+  three DSpark draft blocks with their own 128-expert MoE. The mode schedule,
+  source-layer lists, and candidate-pool bounds are verbatim from
+  `config.json`; the per-layer weight terms in `CSA2Config.weight_params` are
+  this repository's reading, checked against the card's 552 B backbone /
+  16 B decode figures and ~890 B of KV per token.
+- **Engram: Conditional Memory via Scalable Lookup.** DeepSeek-AI, 2026.
+  <https://github.com/deepseek-ai/Engram>.
+  The conditional-memory primitive V4.1 embeds: O(1) hash-addressed n-gram
+  tables designed explicitly for offloading to host memory — which is why the
+  planner puts the tables on shelf-local NVMe by design rather than treating
+  them as overflow. V4.1's variant differs in shape (two ~98 B-parameter
+  tables, `engram_head_dim` 256, the compressed vocabulary) but the planning
+  argument — deterministic addresses, lookup-sized reads — is the paper's.
+- **DeepSelect.** DeepSeek-AI, 2026.
+  <https://github.com/deepseek-ai/DeepSelect>.
+  The reference TopK kernels for the sparse-attention indexer (top-k ≤ 4096
+  over bf16). CUDA, so it does not port to gfx1013 directly; it is cited here
+  because it documents what the indexer's selection step actually computes —
+  the operation `CSA2Config.kv_read_bytes` prices as a bounded scan.
 - **DeepSeek-V3 Technical Report.** DeepSeek-AI, 2024.
   [arXiv:2412.19437](https://arxiv.org/abs/2412.19437).
   MLA, DeepSeekMoE with fine-grained routed experts plus an always-on shared

--- a/gen9-cluster/gen9_cluster/model.py
+++ b/gen9-cluster/gen9_cluster/model.py
@@ -358,7 +358,8 @@ class CSA2Config(AttentionConfig):
     #: Blocks that append indexer keys and run their own selection.
     index_source_layers: Tuple[int, ...] = ()
     #: The first decoder layer, whose Full-mode pass builds the candidate pool
-    #: that later decoder indexers are restricted to.
+    #: that later decoder indexers are restricted to. A Reindex layer below it
+    #: has no pool yet and scans its own stream like a Full layer does.
     candidate_source_layer: int = 0
     candidate_topk_blocks: int = 0
     candidate_block_size: int = 0
@@ -450,7 +451,7 @@ class CSA2Config(AttentionConfig):
         """
         entries = context_tokens / self.csa_ratio
         if (self.kind(layer) == "reindex"
-                and layer >= self.n_encoder_layers
+                and layer >= self.candidate_source_layer
                 and self.candidate_topk_blocks):
             entries = min(entries,
                           float(self.candidate_topk_blocks
@@ -511,11 +512,20 @@ class EngramConfig:
     def total_bytes(self, hidden_size: int, quant: QuantSpec) -> int:
         return int(round(self.params(hidden_size) * quant.bytes_per_param))
 
+    def table_row_bytes(self, table: int, quant: QuantSpec) -> int:
+        """The hash-addressed row store: the NVMe-resident part of a table."""
+        return int(round(self.table_params(table) * quant.bytes_per_param))
+
+    def fusion_bytes(self, hidden_size: int, quant: QuantSpec) -> int:
+        """The per-table projection back into hidden — read every token, so
+        it belongs in the stage host's RAM, not on the drive."""
+        return int(round(hidden_size * self.n_heads * self.head_dim
+                         * quant.bytes_per_param))
+
     def table_bytes(self, table: int, hidden_size: int,
                     quant: QuantSpec) -> int:
-        params = (self.table_params(table)
-                  + hidden_size * self.n_heads * self.head_dim)
-        return int(round(params * quant.bytes_per_param))
+        return (self.table_row_bytes(table, quant)
+                + self.fusion_bytes(hidden_size, quant))
 
     def read_bytes_per_token(self, quant: QuantSpec) -> int:
         """One token's lookup: at most one row per head per n-gram size —

--- a/gen9-cluster/gen9_cluster/model.py
+++ b/gen9-cluster/gen9_cluster/model.py
@@ -73,8 +73,15 @@ class QuantSpec:
 FP8_BLOCK128 = QuantSpec("fp8", scale_bytes=4.0, scale_block=128 * 128)
 #: FP8 E4M3 with a ue8m0 scale per 128x128 tile, as V4 ships it.
 FP8_UE8M0 = QuantSpec("fp8", scale_bytes=1.0, scale_block=128 * 128)
+#: FP8 E4M3 with a ue8m0 scale per 32x32 tile, as V4.1 ships it. Finer tiles
+#: are ~0.1% of scales rather than ~0.006% — still nothing next to the FP4
+#: experts.
+FP8_UE8M0_32 = QuantSpec("fp8", scale_bytes=1.0, scale_block=32 * 32)
 #: OCP MXFP4: E2M1 values with one E8M0 scale per 32-element tile.
 MXFP4 = QuantSpec("mxfp4", scale_bytes=1.0, scale_block=32)
+#: V4.1's KV-cache format: E2M1 values with one E4M3 scale per 16 channels.
+#: Not the OCP tile shape — 0.5625 bytes per cached element.
+FP4_E4M3_16 = QuantSpec("fp4", scale_bytes=1.0, scale_block=16)
 
 
 class AttentionConfig:
@@ -297,6 +304,259 @@ class HybridAttentionConfig(AttentionConfig):
 
 
 @dataclass(frozen=True)
+class CSA2Config(AttentionConfig):
+    """V4.1's CSA2 attention: static Full / Reindex / Reuse layers over shared
+    KV pools, inside a causal encoder-decoder stack.
+
+    V4 gave every layer its own compressed stream. CSA2 instead keeps a small
+    number of shared pools: a layer listed in ``kv_source_layers`` appends
+    main-KV entries to its stream, a layer in ``index_source_layers`` appends
+    indexer keys and computes its own top-k selection over the shared pool,
+    and every other compressed layer reuses the most recent selection and
+    stores nothing at all. The decoder's pool is *global*: its entries are
+    projected from the encoder's final hidden states rather than grown per
+    layer, which is why a decoder layer's ``compress_ratios`` entry reads 1 —
+    it never writes a stream of its own.
+
+    Two properties matter to the planner:
+
+    - The whole model's growing KV cache lives on the few shelf hosts that own
+      a source layer, not spread one stream per layer — at a million tokens
+      the derived figure is ~864 B/token against the card's ~890 (a ~3%
+      under-read this planner accepts; see the profile comment).
+    - Later decoder indexers are confined to the candidate pool built by
+      ``candidate_source_layer`` — ``candidate_topk_blocks`` x
+      ``candidate_block_size`` entries — so their scan cost is bounded
+      independently of context length, unlike an encoder-side scan.
+
+    ``compress_ratios`` is verbatim from the checkpoint, one entry per block
+    including the draft blocks: 0 marks a pure sliding-window block.
+    """
+
+    n_heads: int
+    #: ``c``: width of a shared KV entry, and of each query head.
+    head_dim: int
+    q_lora_rank: int
+    #: The output projection's per-group low-rank bottleneck.
+    o_lora_rank: int
+    o_groups: int
+    #: Partial RoPE: a subset of ``head_dim`` is rotated.
+    qk_rope_head_dim: int
+    index_n_heads: int
+    index_head_dim: int
+    index_topk: int
+    sliding_window: int
+    #: ``m``: every shared stream advances one entry per this many tokens.
+    csa_ratio: int
+    #: Per-block schedule, verbatim from ``compress_ratios``: ``csa_ratio`` for
+    #: encoder compressed layers, 1 for decoder layers (they write no stream),
+    #: 0 for pure sliding-window blocks including the DSpark draft blocks.
+    compress_ratios: Tuple[int, ...] = ()
+    #: Blocks that append main-KV entries to the shared pool (Full, when also
+    #: in ``index_source_layers``).
+    kv_source_layers: Tuple[int, ...] = ()
+    #: Blocks that append indexer keys and run their own selection.
+    index_source_layers: Tuple[int, ...] = ()
+    #: The first decoder layer, whose Full-mode pass builds the candidate pool
+    #: that later decoder indexers are restricted to.
+    candidate_source_layer: int = 0
+    candidate_topk_blocks: int = 0
+    candidate_block_size: int = 0
+    #: Encoder/decoder boundary of the CED stack; blocks below this are the
+    #: causal encoder.
+    n_encoder_layers: int = 0
+    #: V4.1 caches the shared pools in FP4, not FP8.
+    kv_quant: QuantSpec = FP4_E4M3_16
+    index_quant: QuantSpec = FP4_E4M3_16
+
+    def ratio(self, layer: int = 0) -> int:
+        if not self.compress_ratios:
+            return self.csa_ratio
+        index = min(layer, len(self.compress_ratios) - 1)
+        return self.compress_ratios[index]
+
+    def kind(self, layer: int = 0) -> str:
+        if self.ratio(layer) == 0:
+            return "swa"
+        if layer in self.kv_source_layers:
+            return "full" if layer in self.index_source_layers else "kv-src"
+        if layer in self.index_source_layers:
+            return "reindex"
+        return "reuse"
+
+    def weight_params(self, hidden_size: int, layer: int = 0) -> int:
+        d, c, nh = hidden_size, self.head_dim, self.n_heads
+        # Queries: down to q_lora_rank, then up to one c-wide query per head.
+        q = d * self.q_lora_rank + self.q_lora_rank * nh * c
+        # The sliding-window branch exists on every block, including draft
+        # blocks and layers that otherwise share a pool.
+        kv_base = d * c
+        # Grouped low-rank output: heads collapse to o_lora_rank per group and
+        # each group projects back to d.
+        out = nh * c * self.o_lora_rank + self.o_groups * self.o_lora_rank * d
+        params = q + kv_base + out + self.q_lora_rank + c + nh
+        kind = self.kind(layer)
+        if kind in ("swa", "reuse"):
+            # Reuse layers produce no stream of their own: queries, the window
+            # branch, and the output projection are the whole block.
+            return params
+        # An indexer: queries off the q bottleneck, per-head weights off the
+        # hidden state, and its own compressor terms (same shape as V4's).
+        idx_c = self.index_head_dim
+        params += (self.q_lora_rank * self.index_n_heads * idx_c
+                   + d * self.index_n_heads
+                   + 2 * d * idx_c + 2 * d * idx_c
+                   + self.csa_ratio * 2 * idx_c + idx_c)
+        if kind in ("full", "kv-src"):
+            # A main-KV producer adds the compression projections that fold
+            # every csa_ratio tokens into one pooled entry.
+            params += 2 * d * c + 2 * d * c + self.csa_ratio * 2 * c + c
+        return params
+
+    def kv_entry_bytes(self) -> float:
+        """Bytes of one pooled KV entry: FP4 end to end, RoPE dims included."""
+        return self.head_dim * self.kv_quant.bytes_per_param
+
+    def index_entry_bytes(self) -> float:
+        return self.index_head_dim * self.index_quant.bytes_per_param
+
+    def kv_cache_bytes_per_token(self, dtype: str = "fp4",
+                                 layer: int = 0) -> int:
+        """What one more token appends to this layer's streams — zero for the
+        many layers that only read a shared pool."""
+        stored = 0.0
+        if layer in self.kv_source_layers:
+            stored += self.kv_entry_bytes() / self.csa_ratio
+        if layer in self.index_source_layers:
+            stored += self.index_entry_bytes() / self.csa_ratio
+        return int(round(stored))
+
+    def state_bytes(self, dtype: str = "fp4", layer: int = 0) -> int:
+        """The sliding-window branch, which every block carries.
+
+        V4.1's bounded-replay rule rebuilds this window instead of persisting
+        it, but while a sequence is live the window still occupies the shelf
+        host — sizing is unchanged, eviction is what changed.
+        """
+        return int(round(self.sliding_window * self.kv_entry_bytes()))
+
+    def _index_scan_bytes(self, context_tokens: int, layer: int) -> float:
+        """What this layer's own selection costs, where it has one.
+
+        A Full layer scans its whole stream. A Reindex layer in the decoder
+        scans only the candidate pool — the hierarchical indexer's point is
+        that this stops growing with context — and an encoder Reindex layer,
+        had one existed in this schedule, scans its stream like a Full layer.
+        """
+        entries = context_tokens / self.csa_ratio
+        if (self.kind(layer) == "reindex"
+                and layer >= self.n_encoder_layers
+                and self.candidate_topk_blocks):
+            entries = min(entries,
+                          float(self.candidate_topk_blocks
+                                * self.candidate_block_size))
+        return entries * self.index_entry_bytes()
+
+    def kv_read_bytes(self, context_tokens: int, dtype: str = "fp4",
+                      layer: int = 0) -> int:
+        """Cache one decoded token reads — selected entries, plus this layer's
+        own index scan if it performs one."""
+        state = self.state_bytes(dtype, layer)
+        if self.kind(layer) == "swa":
+            return state
+        entries = context_tokens / self.csa_ratio
+        selected = min(entries, float(self.index_topk)) * self.kv_entry_bytes()
+        scan = 0.0
+        if self.kind(layer) in ("full", "reindex"):
+            scan = self._index_scan_bytes(context_tokens, layer)
+        return int(round(selected + scan + state))
+
+
+@dataclass(frozen=True)
+class EngramConfig:
+    """Conditional-memory n-gram tables (deepseek-ai/Engram, V4.1 variant).
+
+    A table is a hash-addressed store of ``head_dim``-wide rows: each token
+    looks up a handful of rows by n-gram and the result is fused into the
+    hidden state at ``layer_ids``. Deterministic addressing is the property
+    the planner cares about — the rows a token will touch are known *before*
+    the layer runs, so the table can live on the slowest tier that still
+    answers a lookup, which on this hardware is shelf-local NVMe. The tables
+    are the coldest weights the model owns: ~196 B parameters read a few
+    kilobytes at a time.
+    """
+
+    #: Blocks whose hidden state takes an Engram fusion.
+    layer_ids: Tuple[int, ...]
+    #: Rows per table, one entry per ``layer_ids`` element.
+    num_embeddings: Tuple[int, ...]
+    n_heads: int
+    head_dim: int
+    #: The n-gram hash space the rows are addressed from.
+    vocab_size: int
+    compressed_vocab_size: int
+    max_ngram_size: int
+
+    def table_params(self, table: int) -> int:
+        return self.num_embeddings[table] * self.head_dim
+
+    def params(self, hidden_size: int) -> int:
+        """Rows, plus a per-table fusion projection back into hidden."""
+        tables = sum(self.table_params(i)
+                     for i in range(len(self.num_embeddings)))
+        fuse = len(self.num_embeddings) * hidden_size * self.n_heads \
+            * self.head_dim
+        return tables + fuse
+
+    def total_bytes(self, hidden_size: int, quant: QuantSpec) -> int:
+        return int(round(self.params(hidden_size) * quant.bytes_per_param))
+
+    def table_bytes(self, table: int, hidden_size: int,
+                    quant: QuantSpec) -> int:
+        params = (self.table_params(table)
+                  + hidden_size * self.n_heads * self.head_dim)
+        return int(round(params * quant.bytes_per_param))
+
+    def read_bytes_per_token(self, quant: QuantSpec) -> int:
+        """One token's lookup: at most one row per head per n-gram size —
+        kilobytes, which is why the tables can sit on NVMe at all."""
+        rows = self.n_heads * self.max_ngram_size
+        return int(round(rows * self.head_dim * quant.bytes_per_param))
+
+
+@dataclass(frozen=True)
+class VisionConfig:
+    """The vision tower of a multimodal checkpoint: a ViT plus projector.
+
+    Small, dense, and cold in the planning sense that matters — it runs once
+    per image, not once per token — so it is placed as a single piece like the
+    embedding tables rather than split like a decoder layer.
+    """
+
+    n_layers: int
+    hidden_size: int
+    n_heads: int
+    intermediate_size: int
+    patch_size: int
+    #: Pixel-unshuffle factor before the projector (3 means 3x3 patches merge).
+    downsample_ratio: int
+
+    def params(self, out_hidden_size: int) -> int:
+        h = self.hidden_size
+        per_layer = 4 * h * h + 2 * h * self.intermediate_size + 2 * h
+        patch_embed = 3 * self.patch_size * self.patch_size * h
+        # Two-layer projector: merged patches to model width, then model width
+        # to model width.
+        merged = h * self.downsample_ratio * self.downsample_ratio
+        projector = merged * out_hidden_size + out_hidden_size * out_hidden_size
+        return self.n_layers * per_layer + patch_embed + projector
+
+    def total_bytes(self, out_hidden_size: int, quant: QuantSpec) -> int:
+        return int(round(self.params(out_hidden_size)
+                         * quant.bytes_per_param))
+
+
+@dataclass(frozen=True)
 class MoEConfig:
     """DeepSeekMoE shape: many narrow routed experts plus shared experts."""
 
@@ -340,9 +600,19 @@ class ModelProfile:
     weights: QuantSpec = FP8_BLOCK128
     #: Format of the routed and shared expert weights, when it differs.
     expert_weights: Optional[QuantSpec] = None
-    #: Multi-token-prediction heads (V3 ships one). Each is a whole extra
-    #: decoder block plus a head, so it is placed like a layer, not folded in.
+    #: Multi-token-prediction heads (V3 ships one; V4.1 ships three DSpark
+    #: draft blocks). Each is a whole extra decoder block plus a head, so it
+    #: is placed like a layer, not folded in.
     n_mtp_heads: int = 1
+    #: The draft blocks' MoE when it differs from the backbone's — V4.1's
+    #: DSpark blocks route to a narrower expert set.
+    draft_moe: Optional[MoEConfig] = None
+    #: DSpark's Markov-rank projection width per draft block; 0 for plain MTP.
+    draft_markov_rank: int = 0
+    #: Conditional-memory tables, when the checkpoint has them (V4.1).
+    engram: Optional[EngramConfig] = None
+    #: The vision tower, when the checkpoint is multimodal (V4.1).
+    vision: Optional[VisionConfig] = None
     #: Hyper-connection expansion: the residual stream is this many times
     #: hidden-wide, which is what crosses a pipeline boundary.
     hc_mult: int = 1
@@ -384,13 +654,22 @@ class ModelProfile:
         """
         return self.n_layers + self.n_mtp_heads
 
-    def expert_bytes(self) -> int:
+    def moe_for_block(self, index: int) -> MoEConfig:
+        """The MoE governing block ``index``: the draft MoE for blocks past
+        ``n_layers`` when one is configured, else the backbone's."""
+        if index >= self.n_layers and self.draft_moe is not None:
+            return self.draft_moe
+        return self.moe
+
+    def expert_bytes(self, index: Optional[int] = None) -> int:
         """One routed expert, packed, block scales included."""
-        params = self.moe.expert_params() * self.hidden_size
+        moe = self.moe if index is None else self.moe_for_block(index)
+        params = moe.expert_params() * self.hidden_size
         return int(round(params * self.expert_quant.bytes_per_param))
 
-    def shared_expert_bytes(self) -> int:
-        return self.expert_bytes() * self.moe.n_shared_experts
+    def shared_expert_bytes(self, index: Optional[int] = None) -> int:
+        moe = self.moe if index is None else self.moe_for_block(index)
+        return self.expert_bytes(index) * moe.n_shared_experts
 
     def attention_bytes(self, layer: int = 0) -> int:
         params = self.attention.weight_params(self.hidden_size, layer)
@@ -435,9 +714,10 @@ class ModelProfile:
         return int(round(3 * self.hidden_size * DTYPE_BYTES["bf16"]
                          + hc_params * self.bytes_per_param))
 
-    def router_bytes(self) -> int:
+    def router_bytes(self, index: Optional[int] = None) -> int:
         """Router matrix; the bias/hash table is added per-layer."""
-        return int(round(self.hidden_size * self.moe.n_routed_experts
+        moe = self.moe if index is None else self.moe_for_block(index)
+        return int(round(self.hidden_size * moe.n_routed_experts
                          * self.bytes_per_param))
 
     def dense_mlp_bytes(self) -> int:
@@ -453,20 +733,22 @@ class ModelProfile:
         remainder.
         """
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
+        moe = self.moe_for_block(layer)
         gate_extras = 0
-        if layer >= self.moe.n_dense_layers:
-            if layer < self.moe.n_hash_layers:
-                gate_extras = int(round(self.vocab_size * self.moe.top_k * 4))
+        if layer >= moe.n_dense_layers:
+            if layer < moe.n_hash_layers:
+                gate_extras = int(round(self.vocab_size * moe.top_k * 4))
             else:
-                gate_extras = int(round(self.moe.n_routed_experts
+                gate_extras = int(round(moe.n_routed_experts
                                         * self.bytes_per_param))
         hc = self._hc_bytes() if self.hc_mult > 1 else 0
-        return (self.attention_bytes(layer) + self.router_bytes()
-                + gate_extras + self.shared_expert_bytes()
+        return (self.attention_bytes(layer) + self.router_bytes(layer)
+                + gate_extras + self.shared_expert_bytes(layer)
                 + norms + hc)
 
-    def cold_bytes_per_moe_layer(self) -> int:
-        return self.expert_bytes() * self.moe.n_routed_experts
+    def cold_bytes_per_moe_layer(self, index: Optional[int] = None) -> int:
+        moe = self.moe if index is None else self.moe_for_block(index)
+        return self.expert_bytes(index) * moe.n_routed_experts
 
     def dense_layer_bytes(self, layer: int = 0) -> int:
         norms = int(round(2 * self.hidden_size * DTYPE_BYTES["bf16"]))
@@ -486,15 +768,20 @@ class ModelProfile:
                          * self.bytes_per_param))
 
     def mtp_hot_bytes(self, head: int = 0) -> int:
-        """Per-token weights of one MTP head: its hot block plus projection."""
+        """Per-token weights of one draft block: its hot block, projection,
+        and — for DSpark — the Markov-rank projection."""
+        dspark = int(round(self.draft_markov_rank * self.hidden_size
+                           * self.bytes_per_param))
         return (self.hot_bytes_per_moe_layer(self.n_layers + head)
-                + self.mtp_projection_bytes() + self._mtp_extra_bytes())
+                + self.mtp_projection_bytes() + self._mtp_extra_bytes()
+                + dspark)
 
     def mtp_bytes(self) -> int:
-        """All MTP heads, weights in full."""
+        """All draft blocks, weights in full."""
         if self.n_mtp_heads == 0:
             return 0
-        return sum(self.mtp_hot_bytes(head) + self.cold_bytes_per_moe_layer()
+        return sum(self.mtp_hot_bytes(head)
+                   + self.cold_bytes_per_moe_layer(self.n_layers + head)
                    for head in range(self.n_mtp_heads))
 
     def block_bytes(self, index: int) -> int:
@@ -505,48 +792,67 @@ class ModelProfile:
             return self.hot_bytes_per_moe_layer(index)
         return self.mtp_hot_bytes(index - self.n_layers)
 
+    def engram_bytes(self) -> int:
+        """All conditional-memory tables, packed at the weight format."""
+        if self.engram is None:
+            return 0
+        return self.engram.total_bytes(self.hidden_size, self.weights)
+
+    def vision_bytes(self) -> int:
+        if self.vision is None:
+            return 0
+        return self.vision.total_bytes(self.hidden_size, self.weights)
+
     def total_bytes(self) -> int:
+        """Everything the fleet has to store — backbone, draft blocks, Engram
+        tables, and the vision tower."""
         weights = (self.embedding_bytes() + self.lm_head_bytes()
-                   + self._final_head_bytes() + self.mtp_bytes())
+                   + self._final_head_bytes() + self.mtp_bytes()
+                   + self.engram_bytes() + self.vision_bytes())
         for index in range(self.n_layers):
             if index < self.moe.n_dense_layers:
                 weights += self.dense_layer_bytes(index)
             else:
                 weights += (self.hot_bytes_per_moe_layer(index)
-                            + self.cold_bytes_per_moe_layer())
+                            + self.cold_bytes_per_moe_layer(index))
         return weights
 
     def total_params(self, include_mtp: bool = True) -> int:
         """Parameter count, for checking a profile against a model card.
 
-        DeepSeek's published totals exclude the MTP head, so ``include_mtp``
-        has to be off to compare against a card and on to size a fleet, which
-        does have to store it.
+        Counts the backbone blocks plus, when ``include_mtp`` is on, the draft
+        blocks — matching the card convention of quoting the backbone and
+        leaving auxiliary stores (Engram tables, the vision tower) to their own
+        lines. DeepSeek's published totals exclude the MTP head, so
+        ``include_mtp`` has to be off to compare against a card and on to size
+        a fleet, which does have to store it.
         """
-        per_expert = self.moe.expert_params() * self.hidden_size
         params = 2 * self.vocab_size * self.hidden_size
         params += self._final_head_params()
         blocks = self.planning_layers if include_mtp else self.n_layers
         for index in range(blocks):
+            moe = self.moe_for_block(index)
+            per_expert = moe.expert_params() * self.hidden_size
             attn = self.attention.weight_params(self.hidden_size, index)
             params += attn
             # input and post-attention RMSNorms
             params += 2 * self.hidden_size
             if self.hc_mult > 1:
                 params += self._hc_params()
-            if index < self.moe.n_dense_layers:
-                params += self.moe.dense_mlp_params(self.hidden_size)
+            if index < moe.n_dense_layers and index < self.n_layers:
+                params += moe.dense_mlp_params(self.hidden_size)
                 continue
-            params += self.hidden_size * self.moe.n_routed_experts
-            if index < self.moe.n_hash_layers:
-                params += self.vocab_size * self.moe.top_k
+            params += self.hidden_size * moe.n_routed_experts
+            if index < moe.n_hash_layers:
+                params += self.vocab_size * moe.top_k
             else:
-                params += self.moe.n_routed_experts
-            params += per_expert * (self.moe.n_routed_experts
-                                    + self.moe.n_shared_experts)
+                params += moe.n_routed_experts
+            params += per_expert * (moe.n_routed_experts
+                                    + moe.n_shared_experts)
             if index >= self.n_layers:
                 params += 2 * self.hidden_size * self.hidden_size
                 params += self._mtp_extra_params()
+                params += self.draft_markov_rank * self.hidden_size
         return int(params)
 
     def activated_params(self) -> int:
@@ -706,6 +1012,62 @@ DEEPSEEK_V4_FLASH = ModelProfile(
     source="deepseek-ai/DeepSeek-V4-Flash config.json; arXiv:2606.19348 §4.2.1",
 )
 
+#: Per-block attention schedule of DeepSeek-V4.1-Flash, verbatim from the
+#: checkpoint's ``compress_ratios``: two sliding-window blocks, eighteen
+#: compressed encoder blocks at m=2, twenty decoder blocks that write no
+#: stream of their own (entry 1), then the three DSpark draft blocks.
+_V4_1_FLASH_RATIOS: Tuple[int, ...] = tuple(
+    [0, 0] + [2] * 18 + [1] * 20 + [0, 0, 0])
+
+#: DeepSeek-V4.1-Flash, from the published config: 552 B backbone
+#: / 16 B activated on decode (8 B on prefill — the CED split makes the
+#: decoder's cache come pre-built), plus ~196 B of Engram tables and the
+#: vision tower that the card reports separately. 40 layers as a 20-layer
+#: causal encoder + 20-layer decoder, hidden 5120, all-MoE with 384 routed +
+#: 1 shared expert, top-6, CSA2 attention whose whole growing KV cache lives
+#: on the few source layers (4 main-KV streams + 8 indexer streams, all
+#: FP4 at m=2 — 864 B/token derived vs the card's ~890), three DSpark draft
+#: blocks with their own 128-expert top-3 MoE, hyper-connection width 4.
+#: Weights are FP8 at the finer 32x32 tile; experts stay MXFP4.
+DEEPSEEK_V4_1_FLASH = ModelProfile(
+    name="deepseek-v4.1-flash",
+    n_layers=40,
+    hidden_size=5120,
+    vocab_size=129280,
+    attention=CSA2Config(
+        n_heads=64, head_dim=512, q_lora_rank=1280,
+        o_lora_rank=1024, o_groups=8, qk_rope_head_dim=64,
+        index_n_heads=32, index_head_dim=128, index_topk=512,
+        sliding_window=128, csa_ratio=2,
+        compress_ratios=_V4_1_FLASH_RATIOS,
+        kv_source_layers=(2, 8, 14, 20),
+        index_source_layers=(2, 8, 14, 20, 24, 28, 32, 36),
+        candidate_source_layer=20,
+        candidate_topk_blocks=2048, candidate_block_size=8,
+        n_encoder_layers=20),
+    moe=MoEConfig(n_routed_experts=384, n_shared_experts=1, top_k=6,
+                  moe_intermediate_size=2304, n_dense_layers=0,
+                  dense_intermediate_size=0),
+    draft_moe=MoEConfig(n_routed_experts=128, n_shared_experts=1, top_k=3,
+                        moe_intermediate_size=2304, n_dense_layers=0,
+                        dense_intermediate_size=0),
+    draft_markov_rank=256,
+    engram=EngramConfig(
+        layer_ids=(1, 14),
+        num_embeddings=(384006168, 384016682),
+        n_heads=8, head_dim=256,
+        vocab_size=16000000, compressed_vocab_size=99092,
+        max_ngram_size=4),
+    vision=VisionConfig(n_layers=32, hidden_size=1024, n_heads=16,
+                        intermediate_size=2816, patch_size=14,
+                        downsample_ratio=3),
+    weights=FP8_UE8M0_32,
+    expert_weights=MXFP4,
+    n_mtp_heads=3,
+    hc_mult=4,
+    source="deepseek-ai/DeepSeek-V4.1-Flash config.json",
+)
+
 #: A small MoE with the same architecture, for a fleet of two or three consoles
 #: and for CI. Not a real checkpoint; a shape.
 DEEPSEEK_TINY = ModelProfile(
@@ -725,7 +1087,7 @@ DEEPSEEK_TINY = ModelProfile(
 
 PROFILES: Dict[str, ModelProfile] = {
     p.name: p for p in (DEEPSEEK_V3, DEEPSEEK_V4_PRO, DEEPSEEK_V4_FLASH,
-                        DEEPSEEK_TINY)
+                        DEEPSEEK_V4_1_FLASH, DEEPSEEK_TINY)
 }
 
 
@@ -751,10 +1113,15 @@ def describe(profile: ModelProfile) -> List[str]:
     fmt = profile.weights.dtype
     if profile.mixed_precision:
         fmt = f"{profile.expert_quant.dtype} experts / {fmt} elsewhere"
+    n_encoder = getattr(profile.attention, "n_encoder_layers", 0)
+    structure = f"{profile.n_layers}"
+    if n_encoder:
+        structure += (f" ({n_encoder} causal-encoder + "
+                      f"{profile.n_layers - n_encoder} decoder)")
     lines = [
         f"{profile.name}  ({fmt}"
         + (", ASSUMED CONFIGURATION" if profile.assumed else "") + ")",
-        f"  layers                {profile.n_layers} "
+        f"  layers                {structure} "
         f"({profile.moe.n_dense_layers} dense, {profile.n_moe_layers} MoE)",
         f"  attention             {_attention_summary(profile)}",
         f"  hidden                {profile.hidden_size}"
@@ -774,6 +1141,23 @@ def describe(profile: ModelProfile) -> List[str]:
         f"  KV cache @ 8k ctx     "
         f"{profile.kv_cache_bytes(8192) / mib:.0f} MiB",
     ]
+    if profile.draft_moe is not None:
+        lines.append(
+            f"  draft blocks          {profile.n_mtp_heads} "
+            f"({profile.draft_moe.n_routed_experts} experts, "
+            f"top-{profile.draft_moe.top_k})")
+    if profile.engram is not None:
+        lines.append(
+            f"  engram tables         "
+            f"{profile.engram.params(profile.hidden_size) / 1e9:.1f} B "
+            f"({profile.engram_bytes() / gib:.1f} GiB) at layers "
+            + ",".join(str(i) for i in profile.engram.layer_ids)
+            + " — hash-addressed, NVMe-tier by design")
+    if profile.vision is not None:
+        lines.append(
+            f"  vision tower          "
+            f"{profile.vision.params(profile.hidden_size) / 1e9:.2f} B "
+            f"({profile.vision_bytes() / mib:.0f} MiB), once per image")
     if profile.source:
         lines.append(f"  source                {profile.source}")
     if profile.assumed:

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -121,6 +121,9 @@ class UnitPlan:
     fast_expert_bytes: int = 0
     slow_expert_bytes: int = 0
     ssd_expert_bytes: int = 0
+    #: Engram row bytes held in RAM (layer -> bytes) — the --no-ssd fallback,
+    #: where a table shards across the fleet like a read-mostly expert.
+    engram_rows: Dict[int, int] = field(default_factory=dict)
     kv_bytes: int = 0
     capacity_bytes: int = 0
     fast_capacity_bytes: int = 0
@@ -131,7 +134,7 @@ class UnitPlan:
     def resident_bytes(self) -> int:
         """Bytes held in RAM (the SSD tier is not resident)."""
         return (self.hot_bytes + self.fast_expert_bytes + self.slow_expert_bytes
-                + self.kv_bytes)
+                + sum(self.engram_rows.values()) + self.kv_bytes)
 
     @property
     def n_experts(self) -> int:
@@ -152,6 +155,7 @@ class UnitPlan:
             "fast_expert_bytes": self.fast_expert_bytes,
             "slow_expert_bytes": self.slow_expert_bytes,
             "ssd_expert_bytes": self.ssd_expert_bytes,
+            "engram_ram_bytes": sum(self.engram_rows.values()),
             "kv_bytes": self.kv_bytes,
             "resident_bytes": self.resident_bytes,
             "capacity_bytes": self.capacity_bytes,
@@ -267,11 +271,9 @@ def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
     wired as subclusters of 22 behind a head node rather than as one flat farm.
 
     Raises :class:`PlanningError` only when the fleet cannot host the model
-    in the tiers it was allowed to use (so ``allow_ssd_tier=False`` makes a
-    model like V4.1, whose Engram tables are NVMe residents, infeasible
-    outright): a fleet that is merely *slow* gets a plan and a warning,
-    because "this works, at 0.4 tokens/s" is a useful answer and refusing to
-    plan is not.
+    in the tiers it was allowed to use: a fleet that is merely *slow* gets a
+    plan and a warning, because "this works, at 0.4 tokens/s" is a useful
+    answer and refusing to plan is not.
     """
     if not fleet:
         raise PlanningError("empty fleet")
@@ -646,10 +648,11 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
     token, so it sits in the stage host's RAM.
 
     Returns bytes that fit in no unit's allowed storage (0 on success). When
-    ``allow_ssd_tier`` is false every SSD-resident piece — Engram row stores
-    and any RAM-overflowing io piece — counts toward the shortfall instead:
-    the flag is a storage constraint, not a preference, and a plan that
-    quietly used NVMe anyway would lie about being RAM-only.
+    ``allow_ssd_tier`` is false, Engram row stores shard across fleet RAM
+    instead (hash addressing means any unit can hold any slice) and a
+    RAM-overflowing io piece counts toward the shortfall: the flag is a
+    storage constraint, not a preference, and a plan that quietly used NVMe
+    anyway would lie about being RAM-only.
     """
     unplaced = 0
     preferred: Dict[str, str] = {}
@@ -693,6 +696,11 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
             return (caps[uid].storage.capacity_bytes // 2
                     - units[uid].ssd_expert_bytes)
 
+        shelf_by_layer: Dict[int, StagePlan] = {}
+        for stage in stages:
+            for layer in stage.layers:
+                shelf_by_layer[layer] = stage
+
         for table, layer_id in enumerate(profile.engram.layer_ids):
             host = host_by_layer.get(layer_id)
             fuse = profile.engram.fusion_bytes(profile.hidden_size,
@@ -718,7 +726,12 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
 
             rows = profile.engram.table_row_bytes(table, profile.weights)
             if not allow_ssd_tier:
-                unplaced += rows
+                # No NVMe to lean on: the row store shards across fleet RAM
+                # instead — deterministic addressing means a lookup can route
+                # to whichever units hold the rows it needs.
+                unplaced += _place_engram_ram(
+                    layer_id, rows, shelf_by_layer[layer_id].expert_units,
+                    units, warnings)
                 continue
             target_id = host
             if target_id is not None and ssd_room(target_id) < rows:
@@ -737,6 +750,53 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
             target.ssd_expert_bytes += rows
             target.io_pieces.append(f"engram-{layer_id}@ssd")
     return unplaced
+
+
+def _place_engram_ram(layer_id: int, rows: int, shelf: Sequence[str],
+                      units: Dict[str, UnitPlan],
+                      warnings: List[str]) -> int:
+    """Shard a table's row store across RAM — the ``--no-ssd`` path.
+
+    Engram addressing is a hash of the token's n-grams, so the rows a lookup
+    needs are scattered uniformly no matter how the store is cut; sharding is
+    therefore free in exactly one direction that matters — any unit can hold
+    any slice — and costly in the other: every token's lookup gathers from
+    each holder over the network. Rows fill the table's own shelf first (one
+    switch away from the fusion projection), then the roomiest fleet members.
+    """
+    remaining = rows
+    ordered = sorted(shelf, key=lambda u: (-units[u].headroom_bytes, u))
+    for uid in ordered:
+        if remaining <= 0:
+            break
+        take = min(remaining, units[uid].headroom_bytes)
+        if take <= 0:
+            continue
+        units[uid].engram_rows[layer_id] = take
+        units[uid].io_pieces.append(f"engram-{layer_id}-rows")
+        remaining -= take
+    if remaining > 0:
+        outside = sorted((u for u in units if u not in shelf),
+                         key=lambda u: (-units[u].headroom_bytes, u))
+        for uid in outside:
+            if remaining <= 0:
+                break
+            take = min(remaining, units[uid].headroom_bytes)
+            if take <= 0:
+                continue
+            units[uid].engram_rows[layer_id] = take
+            units[uid].io_pieces.append(f"engram-{layer_id}-rows")
+            remaining -= take
+        if remaining < rows:
+            warnings.append(
+                f"engram table at layer {layer_id} is sharded beyond its own "
+                f"shelf; every lookup gathers from those units over the "
+                f"network")
+    if remaining > 0:
+        warnings.append(
+            f"engram table at layer {layer_id} needs {rows / GB:.1f} GiB of "
+            f"RAM with no NVMe to use; {remaining / GB:.1f} GiB found nowhere")
+    return remaining
 
 
 # -- cost model ------------------------------------------------------------
@@ -808,8 +868,8 @@ def _estimate_decode(profile: ModelProfile,
             if (profile.engram is not None
                     and layer in profile.engram.layer_ids):
                 # The lookup is serial with the layer that consumes it: row
-                # reads off the holder's NVMe, then the fusion projection off
-                # the stage host's RAM.
+                # reads off wherever the store landed, then the fusion
+                # projection off the stage host's RAM.
                 holder = engram_holder.get(layer)
                 worst = max(worst, _read_seconds(
                     host_cap,
@@ -823,6 +883,25 @@ def _estimate_decode(profile: ModelProfile,
                         "ssd")
                     if holder != stage.host_unit:
                         worst += 2 * hop_seconds
+                else:
+                    # RAM-sharded store: the token's rows are spread uniformly
+                    # over the holders, each answering its share in parallel,
+                    # and any holder outside the stage adds the gather hop.
+                    shares = [(uid, units[uid].engram_rows[layer])
+                              for uid in units
+                              if layer in units[uid].engram_rows]
+                    held = sum(share for _, share in shares)
+                    if held:
+                        remote_rows = False
+                        for uid, share in shares:
+                            part = (profile.engram.read_bytes_per_token(
+                                profile.weights) * share / held)
+                            worst = max(worst,
+                                        _read_seconds(caps[uid], part, "slow"))
+                            remote_rows = (remote_rows
+                                           or uid != stage.host_unit)
+                        if remote_rows:
+                            worst += 2 * hop_seconds
             total += worst
             active_per_layer.append(touched)
 

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -298,7 +298,7 @@ def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
                                   context_tokens, warnings)
     shortfall = _assign_experts(profile, caps, units, stages, allow_ssd_tier,
                                 warnings)
-    _assign_io(profile, caps, units, warnings)
+    shortfall += _assign_io(profile, caps, units, stages, warnings)
 
     if shortfall > 0:
         raise PlanningError(
@@ -311,8 +311,9 @@ def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
     ssd_bytes = sum(u.ssd_expert_bytes for u in units.values())
     if ssd_bytes:
         warnings.append(
-            f"{ssd_bytes / GB:.1f} GiB of routed experts live on NVMe and are "
-            f"streamed on a routing hit; where that happens the layer is bound "
+            f"{ssd_bytes / GB:.1f} GiB of weights live on NVMe — routed "
+            f"experts streamed on a routing hit, Engram tables and any spilled "
+            f"io pieces read on demand; where that happens the block is bound "
             f"by SSD reads, not by memory bandwidth")
     return SplitPlan(
         model=profile.name, model_assumed=profile.assumed,
@@ -501,7 +502,6 @@ def _assign_experts(profile: ModelProfile,
 
     Returns bytes that could not be placed anywhere (0 when the plan fits).
     """
-    expert = profile.expert_bytes()
     all_units = sorted(units)
     shortfall = 0
     cross_shelf = 0
@@ -511,9 +511,11 @@ def _assign_experts(profile: ModelProfile,
         for layer in stage.layers:
             if not _has_routed_experts(profile, layer):
                 continue
-            remaining = profile.moe.n_routed_experts
+            moe = profile.moe_for_block(layer)
+            expert = profile.expert_bytes(layer)
+            remaining = moe.n_routed_experts
             first = 0
-            shares = _shelf_shares(profile, shelf, units)
+            shares = _shelf_shares(profile, shelf, units, moe)
             for uid in sorted(shelf, key=lambda u: (-units[u].headroom_bytes, u)):
                 if remaining <= 0:
                     break
@@ -571,13 +573,13 @@ def _assign_experts(profile: ModelProfile,
 
 
 def _shelf_shares(profile: ModelProfile, shelf: Sequence[str],
-                  units: Dict[str, UnitPlan]) -> Dict[str, int]:
+                  units: Dict[str, UnitPlan], moe) -> Dict[str, int]:
     """How many of a layer's experts each shelf member should take."""
     total = sum(max(units[uid].gemv_gflops, 1.0) for uid in shelf)
     shares: Dict[str, int] = {}
     for uid in shelf:
         fraction = max(units[uid].gemv_gflops, 1.0) / total
-        shares[uid] = max(1, int(round(profile.moe.n_routed_experts * fraction)))
+        shares[uid] = max(1, int(round(moe.n_routed_experts * fraction)))
     return shares
 
 
@@ -622,16 +624,27 @@ def _place_on_ssd(layer: int, first: int, count: int, expert_bytes: int,
 
 
 def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
-               units: Dict[str, UnitPlan], warnings: List[str]) -> None:
-    """Place the embedding, the LM head, and any MTP heads.
+               units: Dict[str, UnitPlan], stages: Sequence[StagePlan],
+               warnings: List[str]) -> int:
+    """Returns bytes that fit in no unit's allowed storage (0 on success)."""
+    """Place the embedding, the LM head, the vision tower, and Engram tables.
 
     Both ends of the model are read once per token and are large (~2 GiB each at
     V4-Pro width in bf16, since the vocabulary tables are not FP8), so they go
-    wherever there is room, preferring the units that already host the first and
-    last layers so the token starts and ends where it is embedded.
+    wherever there is room. The vision tower joins them: once per image rather
+    than once per token, but still small enough to hold in RAM.
+
+    Engram tables are different: tens of GiB each, hash-addressed, and read a
+    few kilobytes per token, so they are NVMe residents *by design* — the
+    Engram paper's whole point is deterministic addressing that tolerates host
+    memory. Each table goes to the SSD of the shelf host that owns its layer,
+    so the lookup never crosses a shelf boundary ahead of the layer that needs
+    it.
     """
     pieces = [("embedding", profile.embedding_bytes()),
               ("lm_head", profile.lm_head_bytes())]
+    if profile.vision is not None:
+        pieces.append(("vision-encoder", profile.vision_bytes()))
     for name, size in pieces:
         target = max(units.values(),
                      key=lambda p: (p.headroom_bytes, p.unit_id))
@@ -645,6 +658,38 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
             continue
         target.io_pieces.append(name)
         target.hot_bytes += size
+
+    unplaced = 0
+    if profile.engram is not None:
+        host_by_layer: Dict[int, str] = {}
+        for stage in stages:
+            for layer in stage.layers:
+                host_by_layer[layer] = stage.host_unit
+
+        def ssd_room(uid: str) -> int:
+            return (caps[uid].storage.capacity_bytes // 2
+                    - units[uid].ssd_expert_bytes)
+
+        for table, layer_id in enumerate(profile.engram.layer_ids):
+            size = profile.engram.table_bytes(table, profile.hidden_size,
+                                              profile.weights)
+            target_id = host_by_layer.get(layer_id)
+            if target_id is not None and ssd_room(target_id) < size:
+                warnings.append(
+                    f"engram table at layer {layer_id} ({size / GB:.1f} GiB) "
+                    f"does not fit on its stage host's NVMe; looking across "
+                    f"the fleet, so lookups pay a cross-shelf hop")
+                target_id = None
+            if target_id is None:
+                fits = [uid for uid in units if ssd_room(uid) >= size]
+                if not fits:
+                    unplaced += size
+                    continue
+                target_id = max(fits, key=lambda uid: (ssd_room(uid), uid))
+            target = units[target_id]
+            target.ssd_expert_bytes += size
+            target.io_pieces.append(f"engram-{layer_id}@ssd")
+    return unplaced
 
 
 # -- cost model ------------------------------------------------------------
@@ -668,9 +713,6 @@ def _estimate_decode(profile: ModelProfile,
     is what makes a wider shelf faster: the same top-k work spread over more
     readers.
     """
-    expert_bytes = profile.expert_bytes()
-    top_k = profile.moe.top_k
-    n_routed = profile.moe.n_routed_experts
     total = 0.0
     active_per_layer: List[float] = []
 
@@ -683,6 +725,10 @@ def _estimate_decode(profile: ModelProfile,
     for stage in stages:
         host_cap = caps[stage.host_unit]
         for layer in stage.layers:
+            moe = profile.moe_for_block(layer)
+            expert_bytes = profile.expert_bytes(layer)
+            top_k = moe.top_k
+            n_routed = moe.n_routed_experts
             # Under CSA the cache a layer *reads* is a small selection of the
             # cache it holds, so the read is what decode costs, not residency.
             kv_read = profile.block_kv_read_bytes(layer, context_tokens)

--- a/gen9-cluster/gen9_cluster/planner.py
+++ b/gen9-cluster/gen9_cluster/planner.py
@@ -266,10 +266,12 @@ def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
     over the whole fleet — and it is the same reason Condor's PS3 cluster was
     wired as subclusters of 22 behind a head node rather than as one flat farm.
 
-    Raises :class:`PlanningError` only when the fleet cannot host the model even
-    with the SSD tier enabled: a fleet that is merely *slow* gets a plan and a
-    warning, because "this works, at 0.4 tokens/s" is a useful answer and
-    refusing to plan is not.
+    Raises :class:`PlanningError` only when the fleet cannot host the model
+    in the tiers it was allowed to use (so ``allow_ssd_tier=False`` makes a
+    model like V4.1, whose Engram tables are NVMe residents, infeasible
+    outright): a fleet that is merely *slow* gets a plan and a warning,
+    because "this works, at 0.4 tokens/s" is a useful answer and refusing to
+    plan is not.
     """
     if not fleet:
         raise PlanningError("empty fleet")
@@ -298,7 +300,8 @@ def plan_split(profile: ModelProfile, fleet: Sequence[ConsoleUnit], *,
                                   context_tokens, warnings)
     shortfall = _assign_experts(profile, caps, units, stages, allow_ssd_tier,
                                 warnings)
-    shortfall += _assign_io(profile, caps, units, stages, warnings)
+    shortfall += _assign_io(profile, caps, units, stages, allow_ssd_tier,
+                            warnings)
 
     if shortfall > 0:
         raise PlanningError(
@@ -625,41 +628,61 @@ def _place_on_ssd(layer: int, first: int, count: int, expert_bytes: int,
 
 def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
                units: Dict[str, UnitPlan], stages: Sequence[StagePlan],
-               warnings: List[str]) -> int:
-    """Returns bytes that fit in no unit's allowed storage (0 on success)."""
+               allow_ssd_tier: bool, warnings: List[str]) -> int:
     """Place the embedding, the LM head, the vision tower, and Engram tables.
 
     Both ends of the model are read once per token and are large (~2 GiB each at
     V4-Pro width in bf16, since the vocabulary tables are not FP8), so they go
-    wherever there is room. The vision tower joins them: once per image rather
-    than once per token, but still small enough to hold in RAM.
+    wherever there is room. The vision tower joins them — on the first stage's
+    host when it fits, since that is where the embeddings an image produces
+    first land.
 
     Engram tables are different: tens of GiB each, hash-addressed, and read a
-    few kilobytes per token, so they are NVMe residents *by design* — the
-    Engram paper's whole point is deterministic addressing that tolerates host
-    memory. Each table goes to the SSD of the shelf host that owns its layer,
-    so the lookup never crosses a shelf boundary ahead of the layer that needs
-    it.
+    few kilobytes per token, so the row store is NVMe-resident *by design* —
+    the Engram paper's whole point is deterministic addressing that tolerates
+    host memory. Each row store goes to the SSD of the shelf host that owns
+    its layer, so the lookup never crosses a shelf boundary ahead of the layer
+    that needs it. The small fusion projection does the opposite: read every
+    token, so it sits in the stage host's RAM.
+
+    Returns bytes that fit in no unit's allowed storage (0 on success). When
+    ``allow_ssd_tier`` is false every SSD-resident piece — Engram row stores
+    and any RAM-overflowing io piece — counts toward the shortfall instead:
+    the flag is a storage constraint, not a preference, and a plan that
+    quietly used NVMe anyway would lie about being RAM-only.
     """
+    unplaced = 0
+    preferred: Dict[str, str] = {}
+    if stages and profile.vision is not None:
+        preferred["vision-encoder"] = stages[0].host_unit
+
     pieces = [("embedding", profile.embedding_bytes()),
               ("lm_head", profile.lm_head_bytes())]
     if profile.vision is not None:
         pieces.append(("vision-encoder", profile.vision_bytes()))
     for name, size in pieces:
-        target = max(units.values(),
-                     key=lambda p: (p.headroom_bytes, p.unit_id))
-        if target.headroom_bytes < size:
-            warnings.append(
-                f"{name} ({size / GB:.2f} GiB) does not fit in any unit's "
-                f"remaining RAM; it is placed on {target.unit_id}'s NVMe, which "
-                f"costs a streamed read once per token")
-            target.ssd_expert_bytes += size
-            target.io_pieces.append(f"{name}@ssd")
+        first_choice = preferred.get(name)
+        target = units[first_choice] if first_choice is not None else None
+        if target is None or target.headroom_bytes < size:
+            target = max(units.values(),
+                         key=lambda p: (p.headroom_bytes, p.unit_id))
+        if target.headroom_bytes >= size:
+            target.io_pieces.append(name)
+            target.hot_bytes += size
             continue
-        target.io_pieces.append(name)
-        target.hot_bytes += size
+        if not allow_ssd_tier:
+            warnings.append(
+                f"{name} ({size / GB:.2f} GiB) fits in no unit's remaining "
+                f"RAM, and the SSD tier is disabled")
+            unplaced += size
+            continue
+        warnings.append(
+            f"{name} ({size / GB:.2f} GiB) does not fit in any unit's "
+            f"remaining RAM; it is placed on {target.unit_id}'s NVMe, which "
+            f"costs a streamed read once per token")
+        target.ssd_expert_bytes += size
+        target.io_pieces.append(f"{name}@ssd")
 
-    unplaced = 0
     if profile.engram is not None:
         host_by_layer: Dict[int, str] = {}
         for stage in stages:
@@ -671,23 +694,47 @@ def _assign_io(profile: ModelProfile, caps: Dict[str, EffectiveCapability],
                     - units[uid].ssd_expert_bytes)
 
         for table, layer_id in enumerate(profile.engram.layer_ids):
-            size = profile.engram.table_bytes(table, profile.hidden_size,
-                                              profile.weights)
-            target_id = host_by_layer.get(layer_id)
-            if target_id is not None and ssd_room(target_id) < size:
+            host = host_by_layer.get(layer_id)
+            fuse = profile.engram.fusion_bytes(profile.hidden_size,
+                                               profile.weights)
+            fuse_target = units.get(host) if host is not None else None
+            if fuse_target is None or fuse_target.headroom_bytes < fuse:
+                fallback = max(units.values(),
+                               key=lambda p: (p.headroom_bytes, p.unit_id))
+                if fallback.headroom_bytes >= fuse:
+                    warnings.append(
+                        f"engram fusion for layer {layer_id} does not fit on "
+                        f"its stage host's RAM; it rides on "
+                        f"{fallback.unit_id}, so every token pays a cross-shelf "
+                        f"hop for it")
+                    fuse_target = fallback
+                else:
+                    fuse_target = None
+            if fuse_target is None:
+                unplaced += fuse
+            else:
+                fuse_target.hot_bytes += fuse
+                fuse_target.io_pieces.append(f"engram-{layer_id}-fuse")
+
+            rows = profile.engram.table_row_bytes(table, profile.weights)
+            if not allow_ssd_tier:
+                unplaced += rows
+                continue
+            target_id = host
+            if target_id is not None and ssd_room(target_id) < rows:
                 warnings.append(
-                    f"engram table at layer {layer_id} ({size / GB:.1f} GiB) "
+                    f"engram table at layer {layer_id} ({rows / GB:.1f} GiB) "
                     f"does not fit on its stage host's NVMe; looking across "
                     f"the fleet, so lookups pay a cross-shelf hop")
                 target_id = None
             if target_id is None:
-                fits = [uid for uid in units if ssd_room(uid) >= size]
+                fits = [uid for uid in units if ssd_room(uid) >= rows]
                 if not fits:
-                    unplaced += size
+                    unplaced += rows
                     continue
                 target_id = max(fits, key=lambda uid: (ssd_room(uid), uid))
             target = units[target_id]
-            target.ssd_expert_bytes += size
+            target.ssd_expert_bytes += rows
             target.io_pieces.append(f"engram-{layer_id}@ssd")
     return unplaced
 
@@ -722,6 +769,15 @@ def _estimate_decode(profile: ModelProfile,
             shards_by_layer.setdefault(shard.layer, []).append(
                 (plan.unit_id, shard))
 
+    # Which unit holds each Engram table's row store — the lookup reads rows
+    # off that unit's NVMe, plus a cross-shelf hop when it left its stage.
+    engram_holder: Dict[int, str] = {}
+    for plan in units.values():
+        for piece in plan.io_pieces:
+            if piece.startswith("engram-") and piece.endswith("@ssd"):
+                engram_holder[int(piece[len("engram-"):-len("@ssd")])] = (
+                    plan.unit_id)
+
     for stage in stages:
         host_cap = caps[stage.host_unit]
         for layer in stage.layers:
@@ -749,6 +805,24 @@ def _estimate_decode(profile: ModelProfile,
                 remote = remote or uid != stage.host_unit
             if remote:
                 worst += 2 * hop_seconds  # fan out, gather back
+            if (profile.engram is not None
+                    and layer in profile.engram.layer_ids):
+                # The lookup is serial with the layer that consumes it: row
+                # reads off the holder's NVMe, then the fusion projection off
+                # the stage host's RAM.
+                holder = engram_holder.get(layer)
+                worst = max(worst, _read_seconds(
+                    host_cap,
+                    profile.engram.fusion_bytes(profile.hidden_size,
+                                                profile.weights),
+                    "fast"))
+                if holder is not None:
+                    worst += _read_seconds(
+                        caps[holder],
+                        profile.engram.read_bytes_per_token(profile.weights),
+                        "ssd")
+                    if holder != stage.host_unit:
+                        worst += 2 * hop_seconds
             total += worst
             active_per_layer.append(touched)
 

--- a/gen9-cluster/tests/test_model.py
+++ b/gen9-cluster/tests/test_model.py
@@ -1,5 +1,6 @@
 """Model sizing: the arithmetic that decides how many consoles are needed."""
 
+import dataclasses
 import unittest
 
 from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_1_FLASH,
@@ -280,6 +281,32 @@ class TestCSA2LayerModes(unittest.TestCase):
         reuse = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(30, 1_000_000)
         full = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(2, 1_000_000)
         self.assertLess(reuse * 4, full)
+
+    def test_candidate_source_layer_gates_the_bounded_scan(self):
+        """The candidate pool exists only once the first decoder layer's Full
+        pass has built it: a Reindex layer below ``candidate_source_layer``
+        scans its own stream, so moving the boundary un-bounds the scan."""
+        attention = DEEPSEEK_V4_1_FLASH.attention
+        self.assertGreaterEqual(24, attention.candidate_source_layer)
+        shifted = dataclasses.replace(attention, candidate_source_layer=40)
+        bounded = attention.kv_read_bytes(1_000_000, layer=24)
+        unbounded = shifted.kv_read_bytes(1_000_000, layer=24)
+        self.assertGreater(unbounded, bounded * 4)
+
+    def test_engram_splits_into_nvme_rows_and_a_ram_projection(self):
+        """The planner prices the two parts of a table separately: the row
+        store (a drive resident) and the fusion projection (a RAM piece read
+        every token)."""
+        engram = DEEPSEEK_V4_1_FLASH.engram
+        for table in range(len(engram.layer_ids)):
+            whole = engram.table_bytes(table, DEEPSEEK_V4_1_FLASH.hidden_size,
+                                       DEEPSEEK_V4_1_FLASH.weights)
+            rows = engram.table_row_bytes(table, DEEPSEEK_V4_1_FLASH.weights)
+            fuse = engram.fusion_bytes(DEEPSEEK_V4_1_FLASH.hidden_size,
+                                       DEEPSEEK_V4_1_FLASH.weights)
+            self.assertEqual(rows + fuse, whole)
+            self.assertGreater(rows, 50 * GB)
+            self.assertLess(fuse, 64 * MB)
 
 
 class TestV41DraftAndAuxiliary(unittest.TestCase):

--- a/gen9-cluster/tests/test_model.py
+++ b/gen9-cluster/tests/test_model.py
@@ -2,8 +2,10 @@
 
 import unittest
 
-from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_FLASH,
-                                DEEPSEEK_V4_PRO, MXFP4, PROFILES, profile_for)
+from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V3, DEEPSEEK_V4_1_FLASH,
+                                DEEPSEEK_V4_FLASH, DEEPSEEK_V4_PRO,
+                                FP4_E4M3_16, FP8_UE8M0_32, MXFP4, PROFILES,
+                                profile_for)
 
 GB = 1024 ** 3
 MB = 1024 ** 2
@@ -167,6 +169,150 @@ class TestHybridAttention(unittest.TestCase):
         self.assertLess(v4 / v3, 0.15)
 
 
+class TestV41FlashAgainstPublishedFigures(unittest.TestCase):
+    """V4.1-Flash is a different architecture, not a V4 variant: a causal
+    encoder-decoder with shared KV pools, Engram memory, and DSpark drafts.
+    The published numbers it has to land on are 552 B backbone, 16 B
+    activated, ~196 B of Engram, and ~890 B of KV per token."""
+
+    def test_backbone_matches_the_published_552b(self):
+        """The card's 552 B excludes the draft blocks and the auxiliary
+        stores; so does total_params with include_mtp off."""
+        self.assertAlmostEqual(
+            DEEPSEEK_V4_1_FLASH.total_params(include_mtp=False) / 1e9,
+            552.0, delta=4.0)
+        self.assertGreater(DEEPSEEK_V4_1_FLASH.total_params(), 552e9)
+
+    def test_activated_matches_the_published_16b_decode(self):
+        """The card splits activation by phase: 8 B on prefill, 16 B on
+        decode. The planner's figure counts every block a decode token
+        touches, so it is the decode number it must match."""
+        self.assertAlmostEqual(DEEPSEEK_V4_1_FLASH.activated_params() / 1e9,
+                               16.0, delta=1.5)
+
+    def test_engram_tables_match_the_published_196b(self):
+        engram = DEEPSEEK_V4_1_FLASH.engram
+        self.assertIsNotNone(engram)
+        self.assertAlmostEqual(
+            engram.params(DEEPSEEK_V4_1_FLASH.hidden_size) / 1e9, 196.0,
+            delta=3.0)
+
+    def test_global_kv_cache_is_about_890_bytes_per_token(self):
+        """Four main-KV streams and eight indexer streams, all FP4 at m=2.
+        The derivation reads 864; the card claims ~890 — inside 4%, which is
+        the tolerance the whole figure is quoted to."""
+        per_token = sum(
+            DEEPSEEK_V4_1_FLASH.attention.kv_cache_bytes_per_token(layer=layer)
+            for layer in range(DEEPSEEK_V4_1_FLASH.planning_layers))
+        self.assertAlmostEqual(per_token / 890.0, 1.0, delta=0.04)
+
+    def test_the_cache_is_a_quarter_of_v4_flashs(self):
+        """The paper's headline claim for the architecture change."""
+        v4 = DEEPSEEK_V4_FLASH.kv_cache_bytes(1_000_000)
+        v41 = DEEPSEEK_V4_1_FLASH.kv_cache_bytes(1_000_000)
+        self.assertLess(v41 / v4, 0.30)
+
+    def test_not_flagged_as_assumed(self):
+        self.assertFalse(DEEPSEEK_V4_1_FLASH.assumed)
+        self.assertIn("config.json", DEEPSEEK_V4_1_FLASH.source)
+
+    def test_weights_are_fp8_32x32_and_experts_fp4(self):
+        self.assertTrue(DEEPSEEK_V4_1_FLASH.mixed_precision)
+        self.assertEqual(DEEPSEEK_V4_1_FLASH.weights, FP8_UE8M0_32)
+        self.assertEqual(DEEPSEEK_V4_1_FLASH.expert_quant, MXFP4)
+        self.assertAlmostEqual(FP8_UE8M0_32.bytes_per_param,
+                               1.0 + 1.0 / 1024, places=6)
+        self.assertAlmostEqual(FP4_E4M3_16.bytes_per_param, 0.5625, places=6)
+
+
+class TestCSA2LayerModes(unittest.TestCase):
+    """The schedule the checkpoint ships: two SWA prologue blocks, Full
+    source layers at 2/8/14/20, decoder Reindex layers every four blocks,
+    Reuse everywhere else, and SWA draft blocks at the tail."""
+
+    def test_schedule_covers_every_block_including_drafts(self):
+        attention = DEEPSEEK_V4_1_FLASH.attention
+        self.assertEqual(len(attention.compress_ratios),
+                         DEEPSEEK_V4_1_FLASH.planning_layers)
+        self.assertEqual(DEEPSEEK_V4_1_FLASH.planning_layers, 43)
+
+    def test_the_mode_layout(self):
+        kinds = [DEEPSEEK_V4_1_FLASH.attention.kind(i) for i in range(43)]
+        self.assertEqual(kinds[0:2], ["swa", "swa"])
+        for full in (2, 8, 14, 20):
+            self.assertEqual(kinds[full], "full", f"layer {full}")
+        for reindex in (24, 28, 32, 36):
+            self.assertEqual(kinds[reindex], "reindex", f"layer {reindex}")
+        self.assertEqual(kinds[40:], ["swa"] * 3)
+        self.assertEqual(kinds.count("reuse"), 30)
+
+    def test_only_source_layers_grow_the_cache(self):
+        """Under CSA2 most layers store nothing: the growing cache belongs to
+        the eight source streams, so a decoder shelf host holds a window and
+        little else."""
+        attention = DEEPSEEK_V4_1_FLASH.attention
+        for layer in range(43):
+            per_token = attention.kv_cache_bytes_per_token(layer=layer)
+            if layer in attention.kv_source_layers \
+                    or layer in attention.index_source_layers:
+                self.assertGreater(per_token, 0, f"layer {layer}")
+            else:
+                self.assertEqual(per_token, 0, f"layer {layer}")
+
+    def test_decoder_reindex_scan_is_bounded_by_the_candidate_pool(self):
+        """The hierarchical indexer is the reason a million-token decode does
+        not scan a million entries: past the pool size the read stops growing
+        with context."""
+        pool_entries = (DEEPSEEK_V4_1_FLASH.attention.candidate_topk_blocks
+                        * DEEPSEEK_V4_1_FLASH.attention.candidate_block_size)
+        shallow = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(24, 4 * 32768)
+        deep = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(24, 1_000_000)
+        self.assertEqual(shallow, deep)
+        # and a Full layer keeps scanning its whole stream
+        full_shallow = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(2, 65536)
+        full_deep = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(2, 1_000_000)
+        self.assertGreater(full_deep, full_shallow * 4)
+        self.assertGreater(pool_entries, 0)
+
+    def test_reuse_layers_read_only_the_selection(self):
+        """A Reuse layer performs no scan of its own; at long context it
+        reads far less than a Full layer."""
+        reuse = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(30, 1_000_000)
+        full = DEEPSEEK_V4_1_FLASH.kv_read_bytes_for_layer(2, 1_000_000)
+        self.assertLess(reuse * 4, full)
+
+
+class TestV41DraftAndAuxiliary(unittest.TestCase):
+    def test_draft_blocks_use_their_own_moe(self):
+        """DSpark drafts are 128-expert top-3 blocks, not shrunken copies of
+        the backbone's 384-expert top-6 MoE."""
+        draft = DEEPSEEK_V4_1_FLASH.moe_for_block(40)
+        self.assertEqual(draft.n_routed_experts, 128)
+        self.assertEqual(draft.top_k, 3)
+        backbone = DEEPSEEK_V4_1_FLASH.moe_for_block(39)
+        self.assertEqual(backbone.n_routed_experts, 384)
+        self.assertEqual(
+            DEEPSEEK_V4_1_FLASH.cold_bytes_per_moe_layer(40)
+            / DEEPSEEK_V4_1_FLASH.cold_bytes_per_moe_layer(39),
+            128 / 384)
+
+    def test_engram_reads_are_lookup_sized(self):
+        """Kilobytes per token is what makes a 183 GiB table an NVMe
+        resident rather than a refusal."""
+        engram = DEEPSEEK_V4_1_FLASH.engram
+        self.assertLess(engram.read_bytes_per_token(
+            DEEPSEEK_V4_1_FLASH.weights), 64 * 1024)
+        self.assertGreater(DEEPSEEK_V4_1_FLASH.engram_bytes(), 150 * GB)
+
+    def test_auxiliary_stores_count_toward_total_bytes(self):
+        """The fleet stores the Engram tables and the vision tower too, so
+        they are in total_bytes even though they are not in the card's
+        backbone parameter count."""
+        total = DEEPSEEK_V4_1_FLASH.total_bytes()
+        self.assertGreater(total, DEEPSEEK_V4_1_FLASH.engram_bytes())
+        self.assertGreater(DEEPSEEK_V4_1_FLASH.vision_bytes(), 0)
+
+
 class TestHyperConnections(unittest.TestCase):
     def test_a_shelf_hop_carries_the_whole_residual_stream(self):
         """mHC widens the residual to 4x hidden. The layer input stays hidden-
@@ -200,6 +346,7 @@ class TestProfileRegistry(unittest.TestCase):
         self.assertIs(profile_for("deepseek-v3"), DEEPSEEK_V3)
         self.assertIs(profile_for("deepseek-v4-pro"), DEEPSEEK_V4_PRO)
         self.assertIs(profile_for("deepseek-v4-flash"), DEEPSEEK_V4_FLASH)
+        self.assertIs(profile_for("deepseek-v4.1-flash"), DEEPSEEK_V4_1_FLASH)
 
     def test_unknown_names_say_what_is_available(self):
         with self.assertRaises(KeyError) as caught:

--- a/gen9-cluster/tests/test_planner.py
+++ b/gen9-cluster/tests/test_planner.py
@@ -4,7 +4,8 @@ import dataclasses
 import unittest
 
 from gen9_cluster.hardware import GB, ConsoleUnit, Downbin, Runtime
-from gen9_cluster.model import DEEPSEEK_TINY, DEEPSEEK_V4_PRO
+from gen9_cluster.model import (DEEPSEEK_TINY, DEEPSEEK_V4_1_FLASH,
+                                DEEPSEEK_V4_PRO)
 from gen9_cluster.planner import PlanningError, describe_plan, plan_split
 
 #: A hypothetical unpublished model, for the paths that have to keep warning
@@ -126,6 +127,38 @@ class TestPlacement(unittest.TestCase):
             self.assertEqual(sorted(host.hot_layers + host.dense_layers),
                              sorted(stage.layers))
             self.assertGreater(host.kv_bytes, 0)
+
+    def test_engram_tables_sit_on_their_stage_host_nvme(self):
+        """CSA2's conditional-memory tables are NVMe residents by design, and
+        they belong to the shelf whose host runs their layer — a lookup must
+        not cross a shelf boundary ahead of the layer that needs it."""
+        plan = plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(60))
+        host_by_layer = {}
+        for stage in plan.stages:
+            for layer in stage.layers:
+                host_by_layer[layer] = stage.host_unit
+        for layer in DEEPSEEK_V4_1_FLASH.engram.layer_ids:
+            host = plan.units[host_by_layer[layer]]
+            self.assertIn(f"engram-{layer}@ssd", host.io_pieces)
+
+    def test_decoder_stage_hosts_hold_little_growing_cache(self):
+        """Only the source layers' hosts see a cache that grows with context —
+        a host of pure Reuse layers is almost cache-free, which is the CED
+        split's whole residency consequence."""
+        plan = plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(60),
+                          context_tokens=1_000_000)
+        attention = DEEPSEEK_V4_1_FLASH.attention
+        sources = (set(attention.kv_source_layers)
+                   | set(attention.index_source_layers))
+        source_hosts = {stage.host_unit for stage in plan.stages
+                        if any(layer in sources for layer in stage.layers)}
+        for stage in plan.stages:
+            host = plan.units[stage.host_unit]
+            if stage.host_unit in source_hosts:
+                # ~36 B/token for a decoder index stream, ~144 B for a main one
+                self.assertGreater(host.kv_bytes, 50 * 1024 * 1024)
+            else:
+                self.assertLess(host.kv_bytes, 10 * 1024 * 1024)
 
     def test_a_devmode_xbox_is_not_asked_to_hold_more_than_its_sandbox(self):
         fleet = ps5_fleet(3) + [ConsoleUnit("xsx-dev", "xbox-series-x",

--- a/gen9-cluster/tests/test_planner.py
+++ b/gen9-cluster/tests/test_planner.py
@@ -143,12 +143,25 @@ class TestPlacement(unittest.TestCase):
             # ...while the every-token fusion projection sits in its RAM
             self.assertIn(f"engram-{layer}-fuse", host.io_pieces)
 
-    def test_a_no_ssd_plan_cannot_hold_v41(self):
-        """--no-ssd is a storage constraint, not a preference: V4.1's Engram
-        row stores are NVMe residents, so a RAM-only plan is infeasible no
-        matter how large the fleet."""
+    def test_a_no_ssd_plan_shards_engram_across_ram(self):
+        """With no drive to use, a hash-addressed table can still live in the
+        fleet's RAM — split across units exactly like routed experts are."""
+        plan = plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(160),
+                          allow_ssd_tier=False)
+        engram = DEEPSEEK_V4_1_FLASH.engram
+        quant = DEEPSEEK_V4_1_FLASH.weights
+        for table, layer in enumerate(engram.layer_ids):
+            want = engram.table_row_bytes(table, quant)
+            held = sum(u.engram_rows.get(layer, 0) for u in plan.units.values())
+            self.assertEqual(held, want)
+            self.assertFalse(any(f"engram-{layer}@ssd" in u.io_pieces
+                                 for u in plan.units.values()))
+
+    def test_a_tiny_no_ssd_fleet_still_cannot_hold_v41(self):
+        """Sharding needs RAM to shard into — a fleet without the ~183 GiB of
+        headroom the tables need refuses rather than drop rows."""
         with self.assertRaises(PlanningError):
-            plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(160),
+            plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(30),
                        allow_ssd_tier=False)
 
     def test_the_vision_tower_sits_where_images_enter(self):

--- a/gen9-cluster/tests/test_planner.py
+++ b/gen9-cluster/tests/test_planner.py
@@ -140,6 +140,34 @@ class TestPlacement(unittest.TestCase):
         for layer in DEEPSEEK_V4_1_FLASH.engram.layer_ids:
             host = plan.units[host_by_layer[layer]]
             self.assertIn(f"engram-{layer}@ssd", host.io_pieces)
+            # ...while the every-token fusion projection sits in its RAM
+            self.assertIn(f"engram-{layer}-fuse", host.io_pieces)
+
+    def test_a_no_ssd_plan_cannot_hold_v41(self):
+        """--no-ssd is a storage constraint, not a preference: V4.1's Engram
+        row stores are NVMe residents, so a RAM-only plan is infeasible no
+        matter how large the fleet."""
+        with self.assertRaises(PlanningError):
+            plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(160),
+                       allow_ssd_tier=False)
+
+    def test_the_vision_tower_sits_where_images_enter(self):
+        """The vision encoder produces embeddings consumed at the front of the
+        pipeline, so it rides the first stage's host, not wherever headroom
+        happens to be."""
+        plan = plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(60))
+        first_host = plan.units[plan.stages[0].host_unit]
+        self.assertIn("vision-encoder", first_host.io_pieces)
+
+    def test_engram_reads_are_priced_into_decode(self):
+        """A plan that carries the tables is slower than the same fleet
+        without them: row lookups off NVMe plus the fusion read are part of
+        every token's cost, not free."""
+        with_tables = plan_split(DEEPSEEK_V4_1_FLASH, ps5_fleet(60))
+        without = plan_split(dataclasses.replace(DEEPSEEK_V4_1_FLASH,
+                                                 engram=None), ps5_fleet(60))
+        self.assertGreater(with_tables.seconds_per_token,
+                           without.seconds_per_token)
 
     def test_decoder_stage_hosts_hold_little_growing_cache(self):
         """Only the source layers' hosts see a cache that grows with context —


### PR DESCRIPTION
## Summary

Adds a `DEEPSEEK_V4_1_FLASH` profile to the gen9 (PS5/Xbox fleet) planner. V4.1 is a different architecture from V4, not a variant, so this introduces three new config types rather than reusing `HybridAttentionConfig`:

- `CSA2Config` — causal-encoder/decoder attention: 20 encoder layers + 20 decoder layers driven by the published 43-entry `compress_ratios` schedule. Decoder layers don't own KV; a shared 4-source-layer main pool (`kv_source_layer_ids`) and an 8-source indexer pool (`index_source_layer_ids`) feed them. Layer modes Full/Reindex/Reuse/SWA are derived from the schedule + source lists; `candidate_source_layer` gates when decoder Reindex scans get bounded by the 2048-block candidate pool. All verbatim from `config.json`.
- `EngramConfig` — the conditional-memory tables (~196B params across two tables at layers 1 and 14), modeled on deepseek-ai/Engram as modified per the model card. Each table splits into `table_row_bytes` (cold store) and `fusion_bytes` (stage-host RAM).
- `VisionConfig` — the 32-layer SigLIP-style tower, priced as an io piece.
- DSpark drafting: `draft_moe` (own 128-expert top-3 MoE) + `draft_markov_rank` fields on `ModelProfile`; `moe_for_block`, `expert_bytes`, `cold_bytes_per_moe_layer`, `router_bytes` are now block-aware so draft experts size independently.
- Two quant specs: `FP8_UE8M0_32` (ue8m0 scales per 32×32 block) for weights, `FP4_E4M3_16` for expert weights and KV.

## Coffer-split decisions

- Growing cache concentrates on the shelf hosts that own the source layers — a host of pure Reuse layers carries ~37 KB/layer of sliding-window state and nothing that scales with context. Reindex hosts hold the 36 B/token index stream.
- Engram splits in two: the hash-addressed **row store** goes to the stage host's NVMe by design (`engram-{layer}@ssd`), while the small **fusion projection** is read every token and sits in stage-host RAM (`engram-{layer}-fuse`). `_estimate_decode` prices the row lookup plus a cross-shelf hop when it spills off-stage.
- `_assign_io` now honors `allow_ssd_tier`: under `--no-ssd`, Engram rows shard across fleet RAM instead (shelf first, then roomiest members — deterministic addressing makes any slice placeable anywhere), while RAM-overflowing io pieces count toward the shortfall. The old silent-spill path had also been understating the other profiles' RAM-only floors (V4-Pro 73→83, V4-Flash 20→22).
- `vision-encoder` rides the first stage's host, where the embeddings it produces are consumed.
- `deployment_config` reports `engram_ram_bytes` per node so a `--no-ssd` deployment shows how much of each unit's residency is Engram rows — a plain diff of two configs answers "what changed".

## Modeled figures vs. the model card

| | card | modeled |
|---|---|---|
| backbone params | 552B | 551.6B (565.9B w/ drafts) |
| activated decode | 16B | 15.8B |
| KV per token | ~890B | 864B (~3% under — documented in test) |
| Engram | ~196B | 196.6B |

The weight-term decomposition in `CSA2Config.weight_params` is this repo's reading of the card (checked against totals), not published per-term.

Results: on-disk total 468 GiB; floor is **43 PS5s RAM-only** (Engram rows sharded) or **24 with NVMe**; 60×PS5 ≈ 23.1 tok/s.

## Verification

232 tests pass (`python3 -m unittest discover -s tests -t .`), flake8 clean, mypy clean, `kernels/make test` passes. New tests pin the published figures (`TestV41FlashAgainstPublishedFigures`), the layer-mode schedule + candidate-pool gating (`TestCSA2LayerModes`), draft/aux accounting (`TestV41DraftAndAuxiliary`), and the planner invariants: Engram rows on stage-host NVMe with fusion in its RAM, `--no-ssd` shards them across fleet RAM (and the deployment config accounts for the rows), non-source hosts hold no growing cache, and Engram reads are priced into decode.

## Docs

- `README.md`: profile-table row, V4.1 bullets (CED/shared KV, Engram placement, DSpark drafts), quick-start example, honest floor figures.
- `GEN9_SPLITTING.md`: new "What V4.1 changes" section covering cache concentration, the Engram rows/fusion split + RAM-shard fallback, draft MoE, and the floor trade.
- `REFERENCES.md`: V4.1-Flash card, deepseek-ai/Engram, deepseek-ai/DeepSelect (indexer top-k reference; CUDA, so cited for semantics rather than ported).

Link to Devin session: https://app.devin.ai/sessions/0fa07c8795cb4dfaa811e63898535920
Requested by: @erkinalp